### PR TITLE
add How_to_add_healthcheck_for_acp_clusters.md

### DIFF
--- a/docs/en/solutions/How_to_add_healthcheck_for_acp_clusters.md
+++ b/docs/en/solutions/How_to_add_healthcheck_for_acp_clusters.md
@@ -1,0 +1,22 @@
+---
+products: 
+   - Alauda Container Platform
+kind:
+   - Solution
+---
+# How to add a health check for ACP clusters
+## Overview
+The ALB health check port, which is pre-installed in each cluster, serves as an endpoint for monitoring cluster health status. If this port becomes inaccessible, it indicates that the cluster is in an unhealthy state.
+## Prerequisites
+When utilizing the ALB health check port for cluster health monitoring in a VIP-based access configuration, it is mandatory to set up port forwarding rules on the Virtual IP (VIP) for the designated health check port. Failure to configure this port forwarding will result in non-functional health checks.
+## Config Vip Health Check
+The following table specifies the required configuration parameters for Virtual IP (VIP) health check implementation:
+
+| Health Check Parameters | Description      |
+| -------- | -------- |
+| Address  | the address of ALB |
+| Port     | 11782 |
+| Protocol | The protocol type of the health check, it is recommended to use TCP. |
+| Response Timeout | The time required to receive the health check response, it is recommended to configure it to 2 seconds. |
+| Check Interval | The time interval for the health check, it is recommended to configure it to 5 seconds. |
+| Unhealthy Threshold | The number of consecutive failures after which the health check status of the backend server is determined to be failed, it is recommended to configure it to 3 times. |    


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a solution guide for configuring ALB/VIP-based health checks for ACP clusters.
  * Details VIP prerequisites (including port forwarding) and recommended settings: ALB address, Port 11782 (global) or 1936 (business), Protocol TCP, Response Timeout 2s, Check Interval 5s, Unhealthy Threshold 3.
  * Includes a configuration table for quick setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->