### PR TITLE
docs: 添加 OVN Underlay 首包延迟优化文档（S2 跳过 Conntrack 方案）

### DIFF
--- a/docs/en/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
+++ b/docs/en/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
@@ -29,7 +29,7 @@ The `skip-conntrack-dst-cidrs` feature allows administrators to specify destinat
 
 > **Warning**: Once conntrack is skipped for a destination CIDR, the following OVN features will **no longer take effect** for traffic to that CIDR:
 > - **NetworkPolicy** — NetworkPolicy rules will not be able to control Pod traffic for the CIDR
-> - **Service Access** — Services within the CIDR cannot be accessed via ClusterIP, NodePort, or LoadBalancer
+> - **Service Access** — When the backend Pods of a Service are in the CIDR, the Service cannot be accessed via ClusterIP, NodePort, or LoadBalancer
 >
 > Ensure that the target CIDRs are **directly accessed Pod-to-Pod traffic** that does not rely on NetworkPolicy or Service routing.
 

--- a/docs/en/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
+++ b/docs/en/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
@@ -28,8 +28,8 @@ The `skip-conntrack-dst-cidrs` feature allows administrators to specify destinat
 ## Configuration Steps
 
 > **Warning**: Once conntrack is skipped for a destination CIDR, the following OVN features will **no longer take effect** for traffic to that CIDR:
-> - **NetworkPolicy** — OVN ACL rules that depend on conntrack state will not match
-> - **Service Load Balancing** — OVN LB rules for ClusterIP/NodePort services will be bypassed
+> - **NetworkPolicy** — NetworkPolicy rules will not be able to control Pod traffic for the CIDR
+> - **Service Access** — Services within the CIDR cannot be accessed via ClusterIP, NodePort, or LoadBalancer
 >
 > Ensure that the target CIDRs are **directly accessed Pod-to-Pod traffic** that does not rely on NetworkPolicy or Service routing.
 

--- a/docs/en/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
+++ b/docs/en/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
@@ -1,0 +1,54 @@
+---
+id: KB202604070001
+products:
+  - Alauda Container Platform
+kind:
+  - Solution
+sourceSHA: pending
+---
+
+# Optimize OVN Underlay First Packet Latency with Skip Conntrack (S2 Solution)
+
+This document describes how to configure the `skip-conntrack-dst-cidrs` parameter in Kube-OVN to skip conntrack processing for specified destination IP CIDRs, reducing first packet latency in OVN underlay networks.
+
+## Overview
+
+In OVN underlay network mode, all cross-subnet traffic goes through conntrack (connection tracking) processing by default, which increases first packet latency. For latency-sensitive scenarios, the `skip-conntrack-dst-cidrs` feature can be used to bypass conntrack processing and reduce first packet latency.
+
+The `skip-conntrack-dst-cidrs` feature allows administrators to specify destination IP CIDRs that should bypass conntrack processing entirely. It works by inserting priority 105 flows in the OVN `ls_in_pre_lb` logical flow table, which take precedence over the default priority 100 conntrack flow.
+
+## Prerequisites
+
+| Item | Requirement |
+|------|------|
+| ACP Version | 4.3+ |
+| Network Mode | OVN Underlay |
+| Kube-OVN Version | v1.15+ (with skip-conntrack-dst-cidrs support) |
+
+## Configuration Steps
+
+> **Warning**: Once conntrack is skipped for a destination CIDR, the following OVN features will **no longer take effect** for traffic to that CIDR:
+> - **NetworkPolicy** — OVN ACL rules that depend on conntrack state will not match
+> - **Service Load Balancing** — OVN LB rules for ClusterIP/NodePort services will be bypassed
+>
+> Ensure that the target CIDRs are **directly accessed Pod-to-Pod traffic** that does not rely on NetworkPolicy or Service routing.
+
+### Step 1: Configure Kube-OVN Controller
+
+Add the `--skip-conntrack-dst-cidrs` startup parameter to the kube-ovn-controller Deployment:
+
+```bash
+kubectl edit deploy kube-ovn-controller -n kube-system
+```
+
+Find the container args section and add the parameter:
+
+```yaml
+containers:
+  - name: kube-ovn-controller
+    args:
+      # ... existing args ...
+      - --skip-conntrack-dst-cidrs=10.0.0.0/24,192.168.1.0/24    # Replace with actual target CIDRs
+```
+
+After saving, the configuration takes effect automatically. To remove, delete the `--skip-conntrack-dst-cidrs` line and save.

--- a/docs/zh/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
+++ b/docs/zh/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
@@ -28,12 +28,12 @@ sourceSHA: pending
 ## 配置步骤
 
 > **警告**：一旦对某个目标 CIDR 跳过 conntrack，以下 OVN 功能对该 CIDR 的流量将**不再生效**：
-> - **NetworkPolicy** — 依赖 conntrack 状态的 OVN ACL 规则将无法匹配
-> - **Service 负载均衡** — ClusterIP/NodePort 服务的 OVN LB 规则将被绕过
+> - **NetworkPolicy** — 即使配置了 NetworkPolicy，也无法控制该 CIDR 的 Pod 流量
+> - **Service 访问** — 无法通过 ClusterIP、NodePort 或 LoadBalancer 访问该 CIDR 内的 Service
 >
 > 请确保目标 CIDR 是**直接 Pod 到 Pod 的通信**，不依赖 NetworkPolicy 或 Service 路由。
 
-### Step 1: 配置 Kube-OVN Controller
+### 步骤 1: 配置 Kube-OVN Controller
 
 在 kube-ovn-controller 的 Deployment 中添加 `--skip-conntrack-dst-cidrs` 启动参数：
 

--- a/docs/zh/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
+++ b/docs/zh/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
@@ -29,7 +29,7 @@ sourceSHA: pending
 
 > **警告**：一旦对某个目标 CIDR 跳过 conntrack，以下 OVN 功能对该 CIDR 的流量将**不再生效**：
 > - **NetworkPolicy** — 即使配置了 NetworkPolicy，也无法控制该 CIDR 的 Pod 流量
-> - **Service 访问** — 无法通过 ClusterIP、NodePort 或 LoadBalancer 访问该 CIDR 内的 Service
+> - **Service 访问** — 当 Service 的后端 Pod 位于该 CIDR 时，无法通过 ClusterIP、NodePort 或 LoadBalancer 访问该 Service
 >
 > 请确保目标 CIDR 是**直接 Pod 到 Pod 的通信**，不依赖 NetworkPolicy 或 Service 路由。
 

--- a/docs/zh/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
+++ b/docs/zh/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
@@ -1,0 +1,52 @@
+---
+id: KB202604070001
+products:
+  - Alauda Container Platform
+kind:
+  - Solution
+sourceSHA: pending
+---
+
+# OVN Underlay 网络首包延迟优化 - 跳过 Conntrack 方案（S2 方案）
+
+本文档介绍如何在 Kube-OVN 中配置 `skip-conntrack-dst-cidrs` 参数，使指定目标 IP CIDR 的流量跳过 conntrack 处理，从而降低 OVN Underlay 网络的首包延迟和 conntrack 表压力。
+
+## 概述
+
+在 OVN Underlay 网络模式下，所有跨子网流量默认都会经过 conntrack（连接跟踪）处理，这会导致首包延迟增加。对于对延迟敏感的场景，可通过 `skip-conntrack-dst-cidrs` 功能跳过 conntrack 处理来降低首包延迟。
+
+`skip-conntrack-dst-cidrs` 功能允许管理员指定需要跳过 conntrack 处理的目标 IP CIDR。它在 OVN `ls_in_pre_lb` 逻辑流表中插入优先级为 105 的流表项，优先级高于默认的优先级 100 的 conntrack 流表。
+
+## 先决条件
+
+| 项目 | 要求 |
+|------|------|
+| ACP 版本 | 4.3+ |
+| 网络模式 | OVN Underlay |
+| Kube-OVN 版本 | v1.15+（支持 skip-conntrack-dst-cidrs） |
+
+## 配置步骤
+
+> **警告**：一旦对某个目标 CIDR 跳过 conntrack，以下 OVN 功能对该 CIDR 的流量将**不再生效**：
+> - **NetworkPolicy** — 依赖 conntrack 状态的 OVN ACL 规则将无法匹配
+> - **Service 负载均衡** — ClusterIP/NodePort 服务的 OVN LB 规则将被绕过
+>
+> 请确保目标 CIDR 是**直接 Pod 到 Pod 的通信**，不依赖 NetworkPolicy 或 Service 路由。
+
+### Step 1: 配置 Kube-OVN Controller
+
+在 kube-ovn-controller 的 Deployment 中添加 `--skip-conntrack-dst-cidrs` 启动参数：
+
+```bash
+kubectl edit deploy kube-ovn-controller -n kube-system
+```
+
+找到容器启动参数部分，添加该参数：
+
+```yaml
+    args:
+      # ... 已有参数 ...
+      - --skip-conntrack-dst-cidrs=10.0.0.0/24,192.168.1.0/24    # 替换为实际的目标 CIDR
+```
+
+保存后自动生效。如需删除配置，删除该行并保存即可。

--- a/docs/zh/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
+++ b/docs/zh/solutions/How_to_Optimize_OVN_Underlay_First_Packet_Latency_with_Skip_Conntrack.md
@@ -9,7 +9,7 @@ sourceSHA: pending
 
 # OVN Underlay 网络首包延迟优化 - 跳过 Conntrack 方案（S2 方案）
 
-本文档介绍如何在 Kube-OVN 中配置 `skip-conntrack-dst-cidrs` 参数，使指定目标 IP CIDR 的流量跳过 conntrack 处理，从而降低 OVN Underlay 网络的首包延迟和 conntrack 表压力。
+本文档介绍如何在 Kube-OVN 中配置 `skip-conntrack-dst-cidrs` 参数，使指定目标 IP CIDR 的流量跳过 conntrack 处理，从而降低 OVN Underlay 网络的首包延迟。
 
 ## 概述
 
@@ -44,6 +44,8 @@ kubectl edit deploy kube-ovn-controller -n kube-system
 找到容器启动参数部分，添加该参数：
 
 ```yaml
+containers:
+  - name: kube-ovn-controller
     args:
       # ... 已有参数 ...
       - --skip-conntrack-dst-cidrs=10.0.0.0/24,192.168.1.0/24    # 替换为实际的目标 CIDR


### PR DESCRIPTION
## Summary

- 添加 OVN Underlay 网络首包延迟优化方案文档（中英文）
- 介绍 `skip-conntrack-dst-cidrs` 参数的配置方法和使用注意事项
- 关联 Jira: ACP-51629

## Test plan

- [x] 文档格式符合项目规范（frontmatter、标题术语、代码块）
- [x] 中英文内容一致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added English and Chinese guides on reducing OVN Underlay first‑packet latency by enabling skip-conntrack for selected destination CIDRs. Covers prerequisites, step‑by‑step controller argument configuration, expected behavior (bypasses conntrack for specified CIDRs), CIDR formatting, and a warning that NetworkPolicy and Service access/LoadBalancer behavior will not apply to skipped CIDRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->