### PR TITLE
docs: add calico/kubeovn upgrade from ipv4 to dual-stack guides

### DIFF
--- a/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
+++ b/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
@@ -38,7 +38,7 @@ During the upgrade, application pods must be restarted to obtain dual-stack IP a
 
 `kube-apiserver` runs as a static pod. The configuration file path is:
 
-```
+```text
 /etc/kubernetes/manifests/kube-apiserver.yaml
 ```
 
@@ -52,7 +52,7 @@ Update `--service-cluster-ip-range` to dual-stack format:
 
 The configuration file path is:
 
-```
+```text
 /etc/kubernetes/manifests/kube-controller-manager.yaml
 ```
 

--- a/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
+++ b/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
@@ -4,7 +4,7 @@ kind:
 products:
   - Alauda Container Platform
 ProductsVersion:
-  - '4.2.5,4.3.1,4.4.0'
+  - '4.2,4.3'
 ---
 
 # Upgrade a Calico Cluster from IPv4 to Dual Stack (IPv4/IPv6)
@@ -22,7 +22,7 @@ This document describes how to upgrade a Kubernetes cluster that uses Calico as 
 
 | Item | Requirement |
 |------|------|
-| ACP version | ≥ 4.2.5, or ≥ 4.3.1, or ≥ 4.4.0 |
+| ACP version | 4.2, 4.3 |
 | CNI plugin | Calico |
 | Node kernel | IPv6 is enabled (`net.ipv6.conf.all.disable_ipv6 = 0`) and forwarding is enabled (`net.ipv6.conf.all.forwarding = 1`) |
 | Node NIC | A real IPv6 address is configured (GUA, for example `2004::/64`) |
@@ -32,6 +32,7 @@ This document describes how to upgrade a Kubernetes cluster that uses Calico as 
 
 :::warning
 During the upgrade, all pods that use container networking must be restarted to obtain dual-stack IP addresses again. Plan a maintenance window in advance and notify the relevant application teams.
+At the same time, the parameter changes to components such as `calico-node` in this document create `resourcePatch` entries. These `resourcePatch` entries may be removed during a cluster upgrade, which can cause the dual-stack arguments configured here to be lost. Pay special attention to this during upgrades, and re-check and re-apply the relevant arguments after the upgrade if needed.
 :::
 
 ### Step 1: Update the kube-apiserver configuration on all master nodes
@@ -63,64 +64,94 @@ Update the following two parameters to dual-stack format:
 - --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
 ```
 
-### Step 3: Update the Calico moduleInfo configuration
+### Step 3: Update the `calico-config` ConfigMap
 
-#### 3.1 Find the target cluster moduleInfo
-
-Run the following command on the Global cluster node to find the Calico moduleInfo for the target cluster:
+Run:
 
 ```bash
-kubectl get moduleInfo -A | grep {cluster-name} | grep calico
+kubectl edit configmap calico-config -n kube-system
 ```
 
-Example output:
+Set the `assign_ipv6` parameter to `true`.
 
-```text
-calico-ccc75e628c532d4f3ecd341c27ee1ae4       region1      calico                 calico                 Running      v4.2.17   v4.2.17   v4.2.17
-```
+### Step 4: Update the `calico-node` DaemonSet configuration
 
-In this output, the first `NAME` column is the value to use for `{moduleInfo-name}`.
-
-#### 3.2 Edit moduleInfo and update the dual-stack parameters
+Run:
 
 ```bash
-kubectl edit moduleInfo {moduleInfo-name} -n {namespace}
+kubectl edit daemonset calico-node -n kube-system
 ```
 
-Update the following parameters for dual-stack:
+Add the following environment variables under `env`:
 
 ```yaml
-spec:
-  config:
-    components:
-      networking:
-        NET_STACK: dual
-      dual_stack:
-        v4PodCIDR: 10.3.0.0/16
-        v6PodCIDR: fd00:10:3::/112
+- name: IP6
+  value: "autodetect"
+- name: CALICO_IPV6POOL_CIDR
+  value: "fd00:10:3::/112"
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"
+- name: FELIX_IPV6SUPPORT
+  value: "true"
 ```
 
-### Step 4: Wait for the Calico core components to restart
+The value of `CALICO_IPV6POOL_CIDR` defines the CIDR range from which IPv6 addresses are allocated.
 
-Wait until all Calico core components restart successfully:
+### Step 5: Confirm that Calico automatically creates the default IPv6 IPPool
 
-- `calico-node`
-- `calico-kube-controllers`
+After the above changes are applied, Calico automatically creates a default IPv6 IPPool using the CIDR range configured in `CALICO_IPV6POOL_CIDR`.
 
-### Step 5: Verify dual-stack functionality
-
-After the components are in `Running` state, restart all pods that use container networking so that they can obtain dual-stack IP addresses again, and then run the following command:
+Run:
 
 ```bash
-# Check whether the pod has dual-stack IPs assigned
-kubectl get pod <pod-name> -o jsonpath='{.status.podIPs}'
+kubectl get ippool -A
 ```
 
-Expected output example:
+Expected output is similar to:
 
-```json
-[{"ip":"10.3.x.x"},{"ip":"fd00:10:3::x"}]
+```text
+NAME                  AGE
+default-ipv4-ippool   5d4h
+default-ipv6-ippool   2m34s
 ```
+
+Confirm that `default-ipv6-ippool` has been created.
+
+### Step 6: Update the default subnet to a dual-stack subnet
+
+After the cluster is upgraded to dual stack, the existing default subnet `default-ipv4-ippool` remains single stack and does not yet map to the dual-stack IPPool. This does not affect the new IPv6 IPPool itself, but it affects correct querying of the custom resources `Subnet` and `IPs`.
+
+If you want to update the default subnet, run:
+
+```bash
+kubectl edit subnet default-ipv4-ippool
+```
+
+Update the subnet configuration to dual-stack format, for example:
+
+```yaml
+cidrBlock: 10.3.0.0/16,fd00:10:3::/112
+protocol: Dual
+```
+
+### Step 7: Delete the pods that require CNI-assigned addresses
+
+Run the following script to delete all pods that use container networking and have `restartPolicy=Always`:
+
+```bash
+#!/usr/bin/env bash
+for ns in $(kubectl get ns --no-headers -o custom-columns=NAME:.metadata.name); do
+  for pod in $(kubectl get pod --no-headers -n "$ns" --field-selector spec.restartPolicy=Always -o custom-columns=NAME:.metadata.name,HOST:spec.hostNetwork | awk '{if ($2!="true") print $1}'); do
+    kubectl delete pod "$pod" -n "$ns" --ignore-not-found --wait=false
+  done
+done
+```
+
+After the pods restart, they will be assigned both IPv4 and IPv6 addresses.
+
+Run `kubectl get ips -A` and confirm that the newly created IP entries contain both IPv4 and IPv6 addresses.
+
+To further verify IPv6 connectivity, select two IPv6 addresses of pods that use container networking in the same cluster from the `kubectl get ips -A` output, and run `ping6` between them.
 
 ## Additional Information
 

--- a/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
+++ b/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
@@ -92,14 +92,6 @@ spec:
         v6PodCIDR: fd00:10:3::/112
 ```
 
-:::tip
-Calico dual-stack parameters differ from Kube-OVN:
-
-- `NET_STACK` must be set to `dual` instead of `dual_stack`
-- Pod CIDR is configured with separate `v4PodCIDR` and `v6PodCIDR` fields
-- `JOIN_CIDR` and `SVC_CIDR` do not need to be configured separately
-:::
-
 ### Step 4: Wait for the Calico core components to restart
 
 Wait until all Calico core components restart successfully:

--- a/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
+++ b/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
@@ -31,7 +31,7 @@ This document describes how to upgrade a Kubernetes cluster that uses Calico as 
 ## Resolution
 
 :::warning
-During the upgrade, application pods must be restarted to obtain dual-stack IP addresses again. Plan a maintenance window in advance and notify the relevant application teams.
+During the upgrade, all pods that use container networking must be restarted to obtain dual-stack IP addresses again. Plan a maintenance window in advance and notify the relevant application teams.
 :::
 
 ### Step 1: Update the kube-apiserver configuration on all master nodes
@@ -73,6 +73,14 @@ Run the following command on the Global cluster node to find the Calico moduleIn
 kubectl get moduleInfo -A | grep {cluster-name} | grep calico
 ```
 
+Example output:
+
+```text
+calico-ccc75e628c532d4f3ecd341c27ee1ae4       region1      calico                 calico                 Running      v4.2.17   v4.2.17   v4.2.17
+```
+
+In this output, the first `NAME` column is the value to use for `{moduleInfo-name}`.
+
 #### 3.2 Edit moduleInfo and update the dual-stack parameters
 
 ```bash
@@ -101,7 +109,7 @@ Wait until all Calico core components restart successfully:
 
 ### Step 5: Verify dual-stack functionality
 
-After the components are in `Running` state, restart all container network pods so that they can obtain dual-stack IP addresses again, and then run the following command:
+After the components are in `Running` state, restart all pods that use container networking so that they can obtain dual-stack IP addresses again, and then run the following command:
 
 ```bash
 # Check whether the pod has dual-stack IPs assigned

--- a/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
+++ b/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
@@ -1,0 +1,132 @@
+---
+kind:
+  - How To
+products:
+  - Alauda Container Platform
+ProductsVersion:
+  - '4.2.5,4.3.1,4.4.0'
+---
+
+# Upgrade a Calico Cluster from IPv4 to Dual Stack (IPv4/IPv6)
+
+## Issue
+
+This document describes how to upgrade a Kubernetes cluster that uses Calico as the CNI plugin from IPv4-only mode to dual-stack IPv4/IPv6 mode.
+
+## Environment
+
+- Alauda Container Platform cluster using Calico as the CNI plugin.
+- Special requirement for Calico dual-stack: unlike Kube-OVN, Calico requires real IPv6 addresses on the node NICs and IPv6 routing to be reachable between nodes before dual-stack networking can work correctly.
+
+## Prerequisites
+
+| Item | Requirement |
+|------|------|
+| ACP version | ≥ 4.2.5, or ≥ 4.3.1, or ≥ 4.4.0 |
+| CNI plugin | Calico |
+| Node kernel | IPv6 is enabled (`net.ipv6.conf.all.disable_ipv6 = 0`) and forwarding is enabled (`net.ipv6.conf.all.forwarding = 1`) |
+| Node NIC | A real IPv6 address is configured (GUA, for example `2004::/64`) |
+| Inter-node network | IPv6 routing is reachable between nodes and nodes can ping each other over IPv6 |
+
+## Resolution
+
+:::warning
+During the upgrade, application pods must be restarted to obtain dual-stack IP addresses again. Plan a maintenance window in advance and notify the relevant application teams.
+:::
+
+### Step 1: Update the kube-apiserver configuration on all master nodes
+
+`kube-apiserver` runs as a static pod. The configuration file path is:
+
+```
+/etc/kubernetes/manifests/kube-apiserver.yaml
+```
+
+Update `--service-cluster-ip-range` to dual-stack format:
+
+```yaml
+- --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
+```
+
+### Step 2: Update the kube-controller-manager configuration on all master nodes
+
+The configuration file path is:
+
+```
+/etc/kubernetes/manifests/kube-controller-manager.yaml
+```
+
+Update the following two parameters to dual-stack format:
+
+```yaml
+- --cluster-cidr=10.3.0.0/16,fd00:10:3::/112
+- --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
+```
+
+### Step 3: Update the Calico moduleInfo configuration
+
+#### 3.1 Find the target cluster moduleInfo
+
+Run the following command on the Global cluster node to find the Calico moduleInfo for the target cluster:
+
+```bash
+kubectl get moduleInfo -A | grep {cluster-name} | grep calico
+```
+
+#### 3.2 Edit moduleInfo and update the dual-stack parameters
+
+```bash
+kubectl edit moduleInfo {moduleInfo-name} -n {namespace}
+```
+
+Update the following parameters for dual-stack:
+
+```yaml
+spec:
+  config:
+    components:
+      networking:
+        NET_STACK: dual
+      dual_stack:
+        v4PodCIDR: 10.3.0.0/16
+        v6PodCIDR: fd00:10:3::/112
+```
+
+:::tip
+Calico dual-stack parameters differ from Kube-OVN:
+
+- `NET_STACK` must be set to `dual` instead of `dual_stack`
+- Pod CIDR is configured with separate `v4PodCIDR` and `v6PodCIDR` fields
+- `JOIN_CIDR` and `SVC_CIDR` do not need to be configured separately
+:::
+
+### Step 4: Wait for the Calico core components to restart
+
+Wait until all Calico core components restart successfully:
+
+- `calico-node`
+- `calico-kube-controllers`
+
+### Step 5: Verify dual-stack functionality
+
+After the components are in `Running` state, restart all container network pods so that they can obtain dual-stack IP addresses again, and then run the following command:
+
+```bash
+# Check whether the pod has dual-stack IPs assigned
+kubectl get pod <pod-name> -o jsonpath='{.status.podIPs}'
+```
+
+Expected output example:
+
+```json
+[{"ip":"10.3.x.x"},{"ip":"fd00:10:3::x"}]
+```
+
+## Additional Information
+
+### CIDR planning reference
+
+| Purpose | IPv4 | IPv6 |
+|------|------|------|
+| Pod CIDR | `10.3.0.0/16` | `fd00:10:3::/112` |
+| Service CIDR | `10.4.0.0/16` | `fd00:10:4::/112` |

--- a/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
+++ b/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
@@ -165,8 +165,11 @@ ip -6 r
 You should see an IPv6 route similar to:
 
 ```text
+fd00:10:3::/112 dev ovn0 proto static src 2004::192:168:134:191 metric 1024 pref medium
 fd00:100:64::/112 dev ovn0 proto kernel metric 256 pref medium
 ```
+
+One route is for the Pod CIDR, and the other is for the Join CIDR.
 
 ### Step 8: Restart all pods that use container networking
 

--- a/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
+++ b/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
@@ -31,7 +31,7 @@ This document describes how to upgrade a Kubernetes cluster that uses Kube-OVN a
 ## Resolution
 
 :::warning
-During the upgrade, all container network pods must be restarted to obtain dual-stack IP addresses again. Plan a maintenance window in advance and notify the relevant application teams.
+During the upgrade, all pods that use container networking must be restarted to obtain dual-stack IP addresses again. Plan a maintenance window in advance and notify the relevant application teams.
 :::
 
 ### Step 1: Update the kube-apiserver configuration on all master nodes
@@ -120,9 +120,11 @@ kubectl get moduleInfo -A | grep {cluster-name} | grep kube-ovn
 
 Example output:
 
+```text
+kube-ovn-2bcc878187dd9f0bb1c2b144032eae99   region1   kube-ovn   kube-ovn   Processing   v4.2.17   v4.2.17   v4.2.17
 ```
-business-1-2bcc878187dd9f0bb1c2b144032eae99   business-1   kube-ovn   kube-ovn   Processing   v4.2.28   ...
-```
+
+In this output, the first `NAME` column is the value to use for `{moduleInfo-name}`.
 
 #### 4.2 Edit moduleInfo and update the dual-stack parameters
 
@@ -160,7 +162,7 @@ Wait until all Kube-OVN core components in the member cluster restart successful
 
 ### Step 6: Verify dual-stack functionality
 
-After the components are in `Running` state, restart all container network pods so that they can obtain dual-stack IP addresses again, and then run the following commands:
+After the components are in `Running` state, restart all pods that use container networking so that they can obtain dual-stack IP addresses again, and then run the following commands:
 
 ```bash
 # Check whether the node reports both IPv4 and IPv6 InternalIP addresses
@@ -169,6 +171,8 @@ kubectl get node <node-name> -o yaml
 # Check whether the pod has dual-stack IPs assigned
 kubectl get pod <pod-name> -o jsonpath='{.status.podIPs}'
 ```
+
+Confirm that both IPv4 and IPv6 `InternalIP` entries are present in `status.addresses`.
 
 Expected output example:
 

--- a/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
+++ b/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
@@ -4,7 +4,7 @@ kind:
 products:
   - Alauda Container Platform
 ProductsVersion:
-  - '4.2.5,4.3.1,4.4.0'
+  - '4.2,4.3'
 ---
 
 # Upgrade a Kube-OVN Cluster from IPv4 to Dual Stack (IPv4/IPv6)
@@ -23,7 +23,7 @@ This document describes how to upgrade a Kubernetes cluster that uses Kube-OVN a
 
 | Item | Requirement |
 |------|------|
-| ACP version | ≥ 4.2.5, or ≥ 4.3.1, or ≥ 4.4.0 |
+| ACP version | 4.2, 4.3 |
 | CNI plugin | Kube-OVN |
 | Node kernel | IPv6 is enabled (`net.ipv6.conf.all.disable_ipv6 = 0`) and forwarding is enabled (`net.ipv6.conf.all.forwarding = 1`) |
 | Node NIC | A real IPv6 address is configured (GUA, for example `2004::/64`) and a default route is configured |
@@ -32,6 +32,7 @@ This document describes how to upgrade a Kubernetes cluster that uses Kube-OVN a
 
 :::warning
 During the upgrade, all pods that use container networking must be restarted to obtain dual-stack IP addresses again. Plan a maintenance window in advance and notify the relevant application teams.
+At the same time, the parameter changes to components such as `kube-ovn-controller` and `kube-ovn-cni` in this document create `resourcePatch` entries. These `resourcePatch` entries may be removed during a cluster upgrade, which can cause the dual-stack arguments configured here to be lost. Pay special attention to this during upgrades, and re-check and re-apply the relevant arguments after the upgrade if needed.
 :::
 
 ### Step 1: Update the kube-apiserver configuration on all master nodes
@@ -108,76 +109,104 @@ For self-managed clusters, upgrading kubelet usually does not overwrite the exis
 For MicroOS clusters, this configuration is lost after a cluster upgrade. Do not treat this file change as a persistent configuration method.
 :::
 
-### Step 4: Update the Kube-OVN moduleInfo configuration
+### Step 4: Update the `kube-system/kube-ovn-controller` arguments
 
-#### 4.1 Find the target cluster moduleInfo
-
-Run the following command on the Global cluster node to find the Kube-OVN moduleInfo for the target cluster:
+Edit the Deployment:
 
 ```bash
-kubectl get moduleInfo -A | grep {cluster-name} | grep kube-ovn
+kubectl edit deploy kube-ovn-controller -n kube-system
 ```
 
-Example output:
-
-```text
-kube-ovn-2bcc878187dd9f0bb1c2b144032eae99   region1   kube-ovn   kube-ovn   Processing   v4.2.17   v4.2.17   v4.2.17
-```
-
-In this output, the first `NAME` column is the value to use for `{moduleInfo-name}`.
-
-#### 4.2 Edit moduleInfo and update the dual-stack parameters
-
-```bash
-kubectl edit moduleInfo {moduleInfo-name}
-```
-
-Update the following five parameters for dual-stack:
+Update the following arguments to dual-stack format:
 
 ```yaml
-spec:
-  config:
-    components:
-      dual_stack:
-        JOIN_CIDR: 100.64.0.0/16,fd00:100:64::/112
-        POD_CIDR: 10.3.0.0/16,fd00:10:3::/112
-        POD_GATEWAY: ""
-        SVC_CIDR: 10.4.0.0/16,fd00:10:4::/112
-      networking:
-        NET_STACK: dual_stack
+- --node-switch-cidr=100.64.0.0/16,fd00:100:64::/112
+- --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
+- --default-cidr=10.3.0.0/16,fd00:10:3::/112
 ```
 
-:::tip
-Set `POD_GATEWAY` to an empty string in dual-stack mode. Kube-OVN allocates the gateway automatically.
-:::
+### Step 5: Verify that the node annotations have been updated to dual stack
 
-### Step 5: Wait for the Kube-OVN core components to restart
-
-Wait until all Kube-OVN core components in the member cluster restart successfully:
-
-- `kube-ovn-controller`
-- `kube-ovn-cni`
-- `ovn-central`
-- `ovs-ovn`
-
-### Step 6: Verify dual-stack functionality
-
-After the components are in `Running` state, restart all pods that use container networking so that they can obtain dual-stack IP addresses again, and then run the following commands:
+Run:
 
 ```bash
-# Check whether the node reports both IPv4 and IPv6 InternalIP addresses
 kubectl get node <node-name> -o yaml
-
-# Check whether the pod has dual-stack IPs assigned
-kubectl get pod <pod-name> -o jsonpath='{.status.podIPs}'
 ```
 
-Confirm that both IPv4 and IPv6 `InternalIP` entries are present in `status.addresses`.
+Confirm that the following annotations are updated to dual-stack format:
 
-Expected output example:
+```yaml
+ovn.kubernetes.io/cidr: 100.64.0.0/16,fd00:100:64::/112
+ovn.kubernetes.io/gateway: 100.64.0.1,fd00:100:64::1
+```
 
-```json
-[{"ip":"10.3.x.x"},{"ip":"fd00:10:3::x"}]
+### Step 6: Update the `kube-system/kube-ovn-cni` arguments
+
+Edit the DaemonSet:
+
+```bash
+kubectl edit ds kube-ovn-cni -n kube-system
+```
+
+Update the following argument to dual-stack format:
+
+```yaml
+- --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
+```
+
+### Step 7: Verify the node IPv6 route
+
+Run the following command on the node:
+
+```bash
+ip -6 r
+```
+
+You should see an IPv6 route similar to:
+
+```text
+fd00:100:64::/112 dev ovn0 proto kernel metric 256 pref medium
+```
+
+### Step 8: Restart all pods that use container networking
+
+Run the following script to delete all pods that use container networking and have `restartPolicy=Always`:
+
+```bash
+#!/usr/bin/env bash
+for ns in $(kubectl get ns --no-headers -o custom-columns=NAME:.metadata.name); do
+  for pod in $(kubectl get pod --no-headers -n "$ns" --field-selector spec.restartPolicy=Always -o custom-columns=NAME:.metadata.name,HOST:spec.hostNetwork | awk '{if ($2!="true") print $1}'); do
+    kubectl delete pod "$pod" -n "$ns" --ignore-not-found --wait=false
+  done
+done
+```
+
+### Step 9: Verify that dual-stack IPs have been allocated
+
+Run:
+
+```bash
+kubectl get ips
+```
+
+You should see both IPv4 and IPv6 addresses allocated to the pod, for example:
+
+```text
+kube-ovn-pinger-vq896.kube-system   10.3.0.16   fd00:10:3::10   9a:3f:b1:71:58:5f   192.168.141.125   ovn-default
+```
+
+To further verify IPv6 connectivity, you can use `kube-ovn-pinger` to run `ping6` to the IPv6 address of a pod that uses container networking in the same cluster, for example:
+
+```bash
+kubectl exec -it -n kube-system kube-ovn-pinger-6fbx6 -- ping6 fd00:10:3::17
+```
+
+Expected output is similar to:
+
+```text
+Defaulted container "pinger" out of: pinger, hostpath-init (init)
+PING fd00:10:3::17 (fd00:10:3::17): 56 data bytes
+64 bytes from fd00:10:3::17: icmp_seq=0 ttl=64 time=2.989 ms
 ```
 
 ## Additional Information

--- a/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
+++ b/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
@@ -106,7 +106,7 @@ systemctl restart kubelet
 :::warning
 For self-managed clusters, upgrading kubelet usually does not overwrite the existing `--node-ip` configuration in `/var/lib/kubelet/kubeadm-flags.env`.
 
-For MicroOS clusters, this configuration is lost after a cluster upgrade. Do not treat this file change as a persistent configuration method.
+For MicroOS clusters, this configuration is lost after a cluster upgrade, so do not treat this file change as a persistent configuration method. Do not rely on `/var/lib/kubelet/kubeadm-flags.env` remaining unchanged after upgrades. After the upgrade, re-check whether kubelet still uses `--node-ip=<IPv4>,<IPv6>` and whether `Node.status.addresses` is still dual-stack. If the configuration is missing, re-apply it and restart kubelet.
 :::
 
 ### Step 4: Update the `kube-system/kube-ovn-controller` arguments

--- a/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
+++ b/docs/en/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
@@ -1,0 +1,187 @@
+---
+kind:
+  - How To
+products:
+  - Alauda Container Platform
+ProductsVersion:
+  - '4.2.5,4.3.1,4.4.0'
+---
+
+# Upgrade a Kube-OVN Cluster from IPv4 to Dual Stack (IPv4/IPv6)
+
+## Issue
+
+This document describes how to upgrade a Kubernetes cluster that uses Kube-OVN as the CNI plugin from IPv4-only mode to dual-stack IPv4/IPv6 mode.
+
+## Environment
+
+- Alauda Container Platform cluster using Kube-OVN as the CNI plugin.
+- IPv6 is supported on the cluster node operating system and is not disabled in the kernel.
+- The cluster node NICs are configured with real IPv6 addresses, and IPv6 routing is reachable between nodes.
+
+## Prerequisites
+
+| Item | Requirement |
+|------|------|
+| ACP version | ≥ 4.2.5, or ≥ 4.3.1, or ≥ 4.4.0 |
+| CNI plugin | Kube-OVN |
+| Node kernel | IPv6 is enabled (`net.ipv6.conf.all.disable_ipv6 = 0`) and forwarding is enabled (`net.ipv6.conf.all.forwarding = 1`) |
+| Node NIC | A real IPv6 address is configured (GUA, for example `2004::/64`) and a default route is configured |
+
+## Resolution
+
+:::warning
+During the upgrade, all container network pods must be restarted to obtain dual-stack IP addresses again. Plan a maintenance window in advance and notify the relevant application teams.
+:::
+
+### Step 1: Update the kube-apiserver configuration on all master nodes
+
+`kube-apiserver` runs as a static pod. The configuration file path is:
+
+```
+/etc/kubernetes/manifests/kube-apiserver.yaml
+```
+
+Update `--service-cluster-ip-range` to dual-stack format:
+
+```yaml
+- --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
+```
+
+### Step 2: Update the kube-controller-manager configuration on all master nodes
+
+The configuration file path is:
+
+```
+/etc/kubernetes/manifests/kube-controller-manager.yaml
+```
+
+Update the following two parameters to dual-stack format:
+
+```yaml
+- --cluster-cidr=10.3.0.0/16,fd00:10:3::/112
+- --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
+```
+
+### Step 3: Update the kubelet `--node-ip` parameter on all nodes
+
+In bare-metal dual-stack environments, kubelet must be explicitly configured with dual-stack node addresses. Otherwise, `Node.status.addresses` usually reports only the IPv4 `InternalIP`, which can affect Kube-OVN routing behavior that depends on node addresses.
+
+A common configuration file path is:
+
+```bash
+/var/lib/kubelet/kubeadm-flags.env
+```
+
+Change the single-stack configuration:
+
+```bash
+--node-ip=<IPv4>
+```
+
+To dual-stack:
+
+```bash
+--node-ip=<IPv4>,<IPv6>
+```
+
+Example:
+
+```bash
+--node-ip=192.168.134.191,2001:db8::191
+```
+
+:::warning
+`<IPv6>` must use the IPv6 address already configured on the node NIC as described in the prerequisites. Do not use an address from the Kube-OVN `join` network.
+:::
+
+After the change, restart kubelet:
+
+```bash
+systemctl daemon-reload
+systemctl restart kubelet
+```
+
+:::warning
+For self-managed clusters, upgrading kubelet usually does not overwrite the existing `--node-ip` configuration in `/var/lib/kubelet/kubeadm-flags.env`.
+
+For MicroOS clusters, this configuration is lost after a cluster upgrade. Do not treat this file change as a persistent configuration method.
+:::
+
+### Step 4: Update the Kube-OVN moduleInfo configuration
+
+#### 4.1 Find the target cluster moduleInfo
+
+Run the following command on the Global cluster node to find the Kube-OVN moduleInfo for the target cluster:
+
+```bash
+kubectl get moduleInfo -A | grep {cluster-name} | grep kube-ovn
+```
+
+Example output:
+
+```
+business-1-2bcc878187dd9f0bb1c2b144032eae99   business-1   kube-ovn   kube-ovn   Processing   v4.2.28   ...
+```
+
+#### 4.2 Edit moduleInfo and update the dual-stack parameters
+
+```bash
+kubectl edit moduleInfo {moduleInfo-name}
+```
+
+Update the following five parameters for dual-stack:
+
+```yaml
+spec:
+  config:
+    components:
+      dual_stack:
+        JOIN_CIDR: 100.64.0.0/16,fd00:100:64::/112
+        POD_CIDR: 10.3.0.0/16,fd00:10:3::/112
+        POD_GATEWAY: ""
+        SVC_CIDR: 10.4.0.0/16,fd00:10:4::/112
+      networking:
+        NET_STACK: dual_stack
+```
+
+:::tip
+Set `POD_GATEWAY` to an empty string in dual-stack mode. Kube-OVN allocates the gateway automatically.
+:::
+
+### Step 5: Wait for the Kube-OVN core components to restart
+
+Wait until all Kube-OVN core components in the member cluster restart successfully:
+
+- `kube-ovn-controller`
+- `kube-ovn-cni`
+- `ovn-central`
+- `ovs-ovn`
+
+### Step 6: Verify dual-stack functionality
+
+After the components are in `Running` state, restart all container network pods so that they can obtain dual-stack IP addresses again, and then run the following commands:
+
+```bash
+# Check whether the node reports both IPv4 and IPv6 InternalIP addresses
+kubectl get node <node-name> -o yaml
+
+# Check whether the pod has dual-stack IPs assigned
+kubectl get pod <pod-name> -o jsonpath='{.status.podIPs}'
+```
+
+Expected output example:
+
+```json
+[{"ip":"10.3.x.x"},{"ip":"fd00:10:3::x"}]
+```
+
+## Additional Information
+
+### CIDR planning reference
+
+| Purpose | IPv4 | IPv6 |
+|------|------|------|
+| Pod CIDR | `10.3.0.0/16` | `fd00:10:3::/112` |
+| Service CIDR | `10.4.0.0/16` | `fd00:10:4::/112` |
+| Join CIDR | `100.64.0.0/16` | `fd00:100:64::/112` |

--- a/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
+++ b/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
@@ -4,7 +4,7 @@ kind:
 products:
   - Alauda Container Platform
 ProductsVersion:
-  - '4.2.5,4.3.1,4.4.0'
+  - '4.2,4.3'
 ---
 
 # 如何将 Calico 集群从 IPv4 升级为双栈（IPv4/IPv6）
@@ -16,13 +16,12 @@ ProductsVersion:
 ## 环境
 
 - 使用 Calico 作为 CNI 插件的 Alauda Container Platform 集群。
-- **Calico 双栈的特殊要求**：与 Kube-OVN 不同，Calico 要求节点网卡本身已配置 IPv6 地址，且节点间 IPv6 路由互通，才能正常建立双栈网络。
 
 ## 前置条件
 
 | 项目 | 要求 |
 |------|------|
-| ACP 版本 | ≥ 4.2.5，或 ≥ 4.3.1，或 ≥ 4.4.0 |
+| ACP 版本 | 4.2, 4.3 |
 | CNI 插件 | Calico |
 | 节点内核 | 已启用 IPv6（`net.ipv6.conf.all.disable_ipv6 = 0`）且已开启转发（`net.ipv6.conf.all.forwarding = 1`） |
 | 节点网卡 | 已配置真实 IPv6 地址（GUA，如 `2004::/64` 段） |
@@ -33,6 +32,7 @@ ProductsVersion:
 
 :::warning
 升级过程中，所有使用容器网络的 Pod 需要重启，才能重新获取双栈 IP 地址。请提前规划操作窗口，并通知相关业务团队。
+同时，本文中对 `calico-node` 等组件参数的修改会生成 `resourcePatch`。集群升级时这些 `resourcePatch` 可能会被删除，导致这里配置的双栈参数丢失。升级时请重点关注这一点，并在升级后重新检查相关参数，必要时重新设置。
 :::
 
 ### 步骤 1：修改所有 Master 节点的 kube-apiserver 配置
@@ -64,64 +64,94 @@ ProductsVersion:
 - --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
 ```
 
-### 步骤 3：修改 Calico 的 moduleInfo 配置
+### 步骤 3：修改 `calico-config` ConfigMap
 
-#### 3.1 查找目标集群的 moduleInfo
-
-在 Global 集群节点上执行，找到对应集群的 Calico moduleInfo：
+执行以下命令：
 
 ```bash
-kubectl get moduleInfo -A | grep {集群名} | grep calico
+kubectl edit configmap calico-config -n kube-system
 ```
 
-示例输出：
+将 `assign_ipv6` 参数设置为 `true`。
 
-```text
-calico-ccc75e628c532d4f3ecd341c27ee1ae4       region1      calico                 calico                 Running      v4.2.17   v4.2.17   v4.2.17
-```
+### 步骤 4：修改 `calico-node` DaemonSet 配置
 
-其中，第一列 `NAME` 对应 `{moduleInfo名称}`。
-
-#### 3.2 编辑 moduleInfo，修改双栈相关参数
+执行以下命令：
 
 ```bash
-kubectl edit moduleInfo {moduleInfo名称} -n {namespace}
+kubectl edit daemonset calico-node -n kube-system
 ```
 
-将以下参数修改为双栈配置：
+在 `env` 中增加以下环境变量：
 
 ```yaml
-spec:
-  config:
-    components:
-      networking:
-        NET_STACK: dual
-      dual_stack:
-        v4PodCIDR: 10.3.0.0/16
-        v6PodCIDR: fd00:10:3::/112
+- name: IP6
+  value: "autodetect"
+- name: CALICO_IPV6POOL_CIDR
+  value: "fd00:10:3::/112"
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"
+- name: "FELIX_IPV6SUPPORT"
+  value: "true"
 ```
 
-### 步骤 4：等待 Calico 核心组件重启
+其中，`CALICO_IPV6POOL_CIDR` 的取值表示期望分配 IPv6 地址的 CIDR 范围。
 
-等待以下 Calico 核心组件全部重启完成：
+### 步骤 5：确认 Calico 已自动创建默认 IPv6 IPPool
 
-- `calico-node`
-- `calico-kube-controllers`
+以上修改完成后，Calico 会自动生成一个默认的 IPv6 IPPool，其地址范围为 `CALICO_IPV6POOL_CIDR` 所设置的 CIDR 范围。
 
-### 步骤 5：验证双栈功能
-
-全部组件 Running 后，重启所有使用容器网络的 Pod，使其重新获取双栈 IP，然后执行以下命令验证：
+执行以下命令：
 
 ```bash
-# 查看 Pod 是否已分配双栈 IP
-kubectl get pod <pod-name> -o jsonpath='{.status.podIPs}'
+kubectl get ippool -A
 ```
 
-预期输出示例：
+预期输出类似：
 
-```json
-[{"ip":"10.3.x.x"},{"ip":"fd00:10:3::x"}]
+```text
+NAME                  AGE
+default-ipv4-ippool   5d4h
+default-ipv6-ippool   2m34s
 ```
+
+确认 `default-ipv6-ippool` 已创建。
+
+### 步骤 6：修改默认子网为双栈子网
+
+升级成双栈后，原有默认子网 `default-ipv4-ippool` 仍为单栈类型，尚未建立与双栈 IPPool 的对应关系。这不会影响新生成 IPv6 IPPool 的使用，但会影响自定义资源 `Subnet` 和 `IPs` 的正确查询。
+
+如需修改默认子网，可执行以下命令：
+
+```bash
+kubectl edit subnet default-ipv4-ippool
+```
+
+将子网配置修改为双栈格式，例如：
+
+```yaml
+cidrBlock: 10.3.0.0/16,fd00:10:3::/112
+protocol: Dual
+```
+
+### 步骤 7：删除需要 CNI 分配地址的 Pod
+
+执行以下脚本，删除所有使用容器网络且 `restartPolicy=Always` 的 Pod：
+
+```bash
+#!/usr/bin/env bash
+for ns in $(kubectl get ns --no-headers -o custom-columns=NAME:.metadata.name); do
+  for pod in $(kubectl get pod --no-headers -n "$ns" --field-selector spec.restartPolicy=Always -o custom-columns=NAME:.metadata.name,HOST:spec.hostNetwork | awk '{if ($2!="true") print $1}'); do
+    kubectl delete pod "$pod" -n "$ns" --ignore-not-found --wait=false
+  done
+done
+```
+
+Pod 重启后会重新分配 IPv4 和 IPv6 两个地址。
+
+执行 `kubectl get ips -A`，确认新创建的 IP 已同时包含 IPv4 和 IPv6 地址。
+
+如需进一步验证 IPv6 连通性，可从 `kubectl get ips -A` 的输出中选择同一集群内两个使用容器网络的 Pod IPv6 地址，互相执行 `ping6` 测试。
 
 ## 相关信息
 

--- a/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
+++ b/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
@@ -39,7 +39,7 @@ ProductsVersion:
 
 `kube-apiserver` 以静态 Pod 方式运行，配置文件路径：
 
-```
+```text
 /etc/kubernetes/manifests/kube-apiserver.yaml
 ```
 
@@ -53,7 +53,7 @@ ProductsVersion:
 
 配置文件路径：
 
-```
+```text
 /etc/kubernetes/manifests/kube-controller-manager.yaml
 ```
 

--- a/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
+++ b/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
@@ -32,7 +32,7 @@ ProductsVersion:
 ## 解决方案
 
 :::warning
-升级过程中，业务 Pod 需要重启才能重新获取双栈 IP 地址。请提前规划操作窗口，并通知相关业务团队。
+升级过程中，所有使用容器网络的 Pod 需要重启，才能重新获取双栈 IP 地址。请提前规划操作窗口，并通知相关业务团队。
 :::
 
 ### 步骤 1：修改所有 Master 节点的 kube-apiserver 配置
@@ -74,6 +74,14 @@ ProductsVersion:
 kubectl get moduleInfo -A | grep {集群名} | grep calico
 ```
 
+示例输出：
+
+```text
+calico-ccc75e628c532d4f3ecd341c27ee1ae4       region1      calico                 calico                 Running      v4.2.17   v4.2.17   v4.2.17
+```
+
+其中，第一列 `NAME` 对应 `{moduleInfo名称}`。
+
 #### 3.2 编辑 moduleInfo，修改双栈相关参数
 
 ```bash
@@ -102,7 +110,7 @@ spec:
 
 ### 步骤 5：验证双栈功能
 
-全部组件 Running 后，重启所有容器网络 Pod 使其重新获取双栈 IP，然后执行以下命令验证：
+全部组件 Running 后，重启所有使用容器网络的 Pod，使其重新获取双栈 IP，然后执行以下命令验证：
 
 ```bash
 # 查看 Pod 是否已分配双栈 IP

--- a/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
+++ b/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Calico.md
@@ -1,0 +1,125 @@
+---
+kind:
+  - How To
+products:
+  - Alauda Container Platform
+ProductsVersion:
+  - '4.2.5,4.3.1,4.4.0'
+---
+
+# 如何将 Calico 集群从 IPv4 升级为双栈（IPv4/IPv6）
+
+## 目的
+
+本文介绍如何将使用 Calico 作为 CNI 插件的 Kubernetes 集群，从纯 IPv4 模式升级为 IPv4/IPv6 双栈模式。
+
+## 环境
+
+- 使用 Calico 作为 CNI 插件的 Alauda Container Platform 集群。
+- **Calico 双栈的特殊要求**：与 Kube-OVN 不同，Calico 要求节点网卡本身已配置 IPv6 地址，且节点间 IPv6 路由互通，才能正常建立双栈网络。
+
+## 前置条件
+
+| 项目 | 要求 |
+|------|------|
+| ACP 版本 | ≥ 4.2.5，或 ≥ 4.3.1，或 ≥ 4.4.0 |
+| CNI 插件 | Calico |
+| 节点内核 | 已启用 IPv6（`net.ipv6.conf.all.disable_ipv6 = 0`）且已开启转发（`net.ipv6.conf.all.forwarding = 1`） |
+| 节点网卡 | 已配置真实 IPv6 地址（GUA，如 `2004::/64` 段） |
+| 节点间网络 | IPv6 路由互通（节点间可 IPv6 ping 通） |
+
+
+## 解决方案
+
+:::warning
+升级过程中，业务 Pod 需要重启才能重新获取双栈 IP 地址。请提前规划操作窗口，并通知相关业务团队。
+:::
+
+### 步骤 1：修改所有 Master 节点的 kube-apiserver 配置
+
+`kube-apiserver` 以静态 Pod 方式运行，配置文件路径：
+
+```
+/etc/kubernetes/manifests/kube-apiserver.yaml
+```
+
+将 `--service-cluster-ip-range` 参数修改为双栈格式：
+
+```yaml
+- --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
+```
+
+### 步骤 2：修改所有 Master 节点的 kube-controller-manager 配置
+
+配置文件路径：
+
+```
+/etc/kubernetes/manifests/kube-controller-manager.yaml
+```
+
+将以下两个参数修改为双栈格式：
+
+```yaml
+- --cluster-cidr=10.3.0.0/16,fd00:10:3::/112
+- --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
+```
+
+### 步骤 3：修改 Calico 的 moduleInfo 配置
+
+#### 3.1 查找目标集群的 moduleInfo
+
+在 Global 集群节点上执行，找到对应集群的 Calico moduleInfo：
+
+```bash
+kubectl get moduleInfo -A | grep {集群名} | grep calico
+```
+
+#### 3.2 编辑 moduleInfo，修改双栈相关参数
+
+```bash
+kubectl edit moduleInfo {moduleInfo名称} -n {namespace}
+```
+
+将以下参数修改为双栈配置：
+
+```yaml
+spec:
+  config:
+    components:
+      networking:
+        NET_STACK: dual
+      dual_stack:
+        v4PodCIDR: 10.3.0.0/16
+        v6PodCIDR: fd00:10:3::/112
+```
+
+### 步骤 4：等待 Calico 核心组件重启
+
+等待以下 Calico 核心组件全部重启完成：
+
+- `calico-node`
+- `calico-kube-controllers`
+
+### 步骤 5：验证双栈功能
+
+全部组件 Running 后，重启所有容器网络 Pod 使其重新获取双栈 IP，然后执行以下命令验证：
+
+```bash
+# 查看 Pod 是否已分配双栈 IP
+kubectl get pod <pod-name> -o jsonpath='{.status.podIPs}'
+```
+
+预期输出示例：
+
+```json
+[{"ip":"10.3.x.x"},{"ip":"fd00:10:3::x"}]
+```
+
+## 相关信息
+
+### CIDR 地址规划参考
+
+| 用途 | IPv4 | IPv6 |
+|------|------|------|
+| Pod CIDR | `10.3.0.0/16` | `fd00:10:3::/112` |
+| Service CIDR | `10.4.0.0/16` | `fd00:10:4::/112` |

--- a/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
+++ b/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
@@ -32,7 +32,7 @@ ProductsVersion:
 ## 解决方案
 
 :::warning
-升级过程中，所有容器网络 Pod 需要重启才能重新获取双栈 IP 地址。请提前规划操作窗口，并通知相关业务团队。
+升级过程中，所有使用容器网络的 Pod 需要重启，才能重新获取双栈 IP 地址。请提前规划操作窗口，并通知相关业务团队。
 :::
 
 ### 步骤 1：修改所有 Master 节点的 kube-apiserver 配置
@@ -121,9 +121,11 @@ kubectl get moduleInfo -A | grep {集群名} | grep kube-ovn
 
 示例输出：
 
+```text
+kube-ovn-2bcc878187dd9f0bb1c2b144032eae99   region1   kube-ovn   kube-ovn   Processing   v4.2.17   v4.2.17   v4.2.17
 ```
-business-1-2bcc878187dd9f0bb1c2b144032eae99   business-1   kube-ovn   kube-ovn   Processing   v4.2.28   ...
-```
+
+其中，第一列 `NAME` 对应 `{moduleInfo名称}`。
 
 #### 4.2 编辑 moduleInfo，修改双栈相关参数
 
@@ -162,7 +164,7 @@ spec:
 
 ### 步骤 6：验证双栈功能
 
-以上组件 Running 后，重启所有容器网络 Pod 使其重新获取双栈 IP，然后执行以下命令验证：
+以上组件 Running 后，重启所有使用容器网络的 Pod，使其重新获取双栈 IP，然后执行以下命令验证：
 
 ```bash
 # 查看节点是否已同时上报 IPv4/IPv6 InternalIP
@@ -171,6 +173,8 @@ kubectl get node <node-name> -o yaml
 # 查看 Pod 是否已分配双栈 IP
 kubectl get pod <pod-name> -o jsonpath='{.status.podIPs}'
 ```
+
+确认 `status.addresses` 中同时存在 IPv4 和 IPv6 的 `InternalIP`。
 
 预期输出示例：
 

--- a/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
+++ b/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
@@ -107,7 +107,7 @@ systemctl restart kubelet
 :::warning
 对于自建集群，升级 kubelet 时通常不会覆盖 `/var/lib/kubelet/kubeadm-flags.env` 中已有的 `--node-ip` 配置。
 
-对于 MicroOS 集群，集群升级后此配置会丢失，因此不建议将其作为持久化修改方式。
+对于 MicroOS 集群，集群升级后此配置会丢失，因此不建议将其作为持久化修改方式。不要依赖 `/var/lib/kubelet/kubeadm-flags.env` 在升级后保持不变。升级完成后，建议重新检查 kubelet 的 `--node-ip=<IPv4>,<IPv6>` 配置以及 `Node.status.addresses` 是否仍为双栈；如配置丢失，需重新设置并重启 kubelet。
 :::
 
 ### 步骤 4：修改 `kube-system/kube-ovn-controller` 的参数

--- a/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
+++ b/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
@@ -166,8 +166,11 @@ ip -6 r
 预期可以看到类似以下 IPv6 路由：
 
 ```text
+fd00:10:3::/112 dev ovn0 proto static src 2004::192:168:134:191 metric 1024 pref medium
 fd00:100:64::/112 dev ovn0 proto kernel metric 256 pref medium
 ```
+
+其中，一条是 Pod CIDR 路由，另一条是 Join CIDR 路由。
 
 ### 步骤 8：重启所有使用容器网络的 Pod
 

--- a/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
+++ b/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
@@ -39,7 +39,7 @@ ProductsVersion:
 
 `kube-apiserver` 以静态 Pod 方式运行，配置文件路径：
 
-```
+```text
 /etc/kubernetes/manifests/kube-apiserver.yaml
 ```
 
@@ -53,7 +53,7 @@ ProductsVersion:
 
 配置文件路径：
 
-```
+```text
 /etc/kubernetes/manifests/kube-controller-manager.yaml
 ```
 

--- a/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
+++ b/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
@@ -1,0 +1,189 @@
+---
+kind:
+  - How To
+products:
+  - Alauda Container Platform
+ProductsVersion:
+  - '4.2.5,4.3.1,4.4.0'
+---
+
+# 如何将 Kube-OVN 集群从 IPv4 升级为双栈（IPv4/IPv6）
+
+## 目的
+
+本文介绍如何将使用 Kube-OVN 作为 CNI 插件的 Kubernetes 集群，从纯 IPv4 模式升级为 IPv4/IPv6 双栈模式。
+
+## 环境
+
+- 使用 Kube-OVN 作为 CNI 插件的 Alauda Container Platform 集群。
+- 集群节点操作系统已支持 IPv6（内核未禁用 IPv6）。
+- 集群节点网卡已配置真实 IPv6 地址，节点间 IPv6 路由互通。
+
+## 前置条件
+
+| 项目 | 要求 |
+|------|------|
+| ACP 版本 | ≥ 4.2.5，或 ≥ 4.3.1，或 ≥ 4.4.0 |
+| CNI 插件 | Kube-OVN |
+| 节点内核 | 已启用 IPv6（`net.ipv6.conf.all.disable_ipv6 = 0`）且已开启转发（`net.ipv6.conf.all.forwarding = 1`） |
+| 节点网卡 | 已配置真实 IPv6 地址（GUA，如 `2004::/64` 段）并配置默认路由 |
+
+
+## 解决方案
+
+:::warning
+升级过程中，所有容器网络 Pod 需要重启才能重新获取双栈 IP 地址。请提前规划操作窗口，并通知相关业务团队。
+:::
+
+### 步骤 1：修改所有 Master 节点的 kube-apiserver 配置
+
+`kube-apiserver` 以静态 Pod 方式运行，配置文件路径：
+
+```
+/etc/kubernetes/manifests/kube-apiserver.yaml
+```
+
+将 `--service-cluster-ip-range` 参数修改为双栈格式：
+
+```yaml
+- --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
+```
+
+### 步骤 2：修改所有 Master 节点的 kube-controller-manager 配置
+
+配置文件路径：
+
+```
+/etc/kubernetes/manifests/kube-controller-manager.yaml
+```
+
+将以下两个参数修改为双栈格式：
+
+```yaml
+- --cluster-cidr=10.3.0.0/16,fd00:10:3::/112
+- --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
+```
+
+### 步骤 3：修改所有节点的 kubelet `--node-ip` 参数
+
+在裸机双栈场景下，kubelet 需要显式配置双栈节点地址，否则 `Node.status.addresses` 中通常只会上报 IPv4 `InternalIP`，并可能影响依赖节点地址的 Kube-OVN 路由能力。
+
+常见配置文件路径：
+
+```bash
+/var/lib/kubelet/kubeadm-flags.env
+```
+
+将单栈配置：
+
+```bash
+--node-ip=<IPv4>
+```
+
+修改为双栈配置：
+
+```bash
+--node-ip=<IPv4>,<IPv6>
+```
+
+示例：
+
+```bash
+--node-ip=192.168.134.191,2001:db8::191
+```
+
+:::warning
+`<IPv6>` 必须使用前置条件中节点网卡已配置的 IPv6 地址，不能使用 Kube-OVN `join` 网段地址。
+:::
+
+修改完成后，重启 kubelet：
+
+```bash
+systemctl daemon-reload
+systemctl restart kubelet
+```
+
+:::warning
+对于自建集群，升级 kubelet 时通常不会覆盖 `/var/lib/kubelet/kubeadm-flags.env` 中已有的 `--node-ip` 配置。
+
+对于 MicroOS 集群，集群升级后此配置会丢失，因此不建议将其作为持久化修改方式。
+:::
+
+### 步骤 4：修改 Kube-OVN 的 moduleInfo 配置
+
+#### 4.1 查找目标集群的 moduleInfo
+
+在 Global 集群节点上执行，找到对应集群的 Kube-OVN moduleInfo：
+
+```bash
+kubectl get moduleInfo -A | grep {集群名} | grep kube-ovn
+```
+
+示例输出：
+
+```
+business-1-2bcc878187dd9f0bb1c2b144032eae99   business-1   kube-ovn   kube-ovn   Processing   v4.2.28   ...
+```
+
+#### 4.2 编辑 moduleInfo，修改双栈相关参数
+
+```bash
+kubectl edit moduleInfo {moduleInfo名称}
+```
+
+将以下 5 个参数修改为双栈配置：
+
+```yaml
+spec:
+  config:
+    components:
+      dual_stack:
+        JOIN_CIDR: 100.64.0.0/16,fd00:100:64::/112
+        POD_CIDR: 10.3.0.0/16,fd00:10:3::/112
+        POD_GATEWAY: ""
+        SVC_CIDR: 10.4.0.0/16,fd00:10:4::/112
+      networking:
+        NET_STACK: dual_stack
+```
+
+:::tip
+`POD_GATEWAY` 在双栈模式下置空，由 Kube-OVN 自动分配网关。
+:::
+
+### 步骤 5：等待 Kube-OVN 核心组件重启
+
+等待业务集群 Kube-OVN 核心组件全部重启完成：
+
+- `kube-ovn-controller`
+- `kube-ovn-cni`
+- `ovn-central`
+- `ovs-ovn`
+
+
+### 步骤 6：验证双栈功能
+
+以上组件 Running 后，重启所有容器网络 Pod 使其重新获取双栈 IP，然后执行以下命令验证：
+
+```bash
+# 查看节点是否已同时上报 IPv4/IPv6 InternalIP
+kubectl get node <node-name> -o yaml
+
+# 查看 Pod 是否已分配双栈 IP
+kubectl get pod <pod-name> -o jsonpath='{.status.podIPs}'
+```
+
+预期输出示例：
+
+```json
+[{"ip":"10.3.x.x"},{"ip":"fd00:10:3::x"}]
+```
+
+## 相关信息
+
+### CIDR 地址规划参考
+
+| 用途 | IPv4 | IPv6 |
+|------|------|------|
+| Pod CIDR | `10.3.0.0/16` | `fd00:10:3::/112` |
+| Service CIDR | `10.4.0.0/16` | `fd00:10:4::/112` |
+| Join CIDR | `100.64.0.0/16` | `fd00:100:64::/112` |

--- a/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
+++ b/docs/zh/solutions/How_to_Enable_DualStack_IPv4_IPv6_with_Kube-OVN.md
@@ -4,7 +4,7 @@ kind:
 products:
   - Alauda Container Platform
 ProductsVersion:
-  - '4.2.5,4.3.1,4.4.0'
+  - '4.2,4.3'
 ---
 
 # 如何将 Kube-OVN 集群从 IPv4 升级为双栈（IPv4/IPv6）
@@ -23,7 +23,7 @@ ProductsVersion:
 
 | 项目 | 要求 |
 |------|------|
-| ACP 版本 | ≥ 4.2.5，或 ≥ 4.3.1，或 ≥ 4.4.0 |
+| ACP 版本 | 4.2, 4.3 |
 | CNI 插件 | Kube-OVN |
 | 节点内核 | 已启用 IPv6（`net.ipv6.conf.all.disable_ipv6 = 0`）且已开启转发（`net.ipv6.conf.all.forwarding = 1`） |
 | 节点网卡 | 已配置真实 IPv6 地址（GUA，如 `2004::/64` 段）并配置默认路由 |
@@ -33,6 +33,7 @@ ProductsVersion:
 
 :::warning
 升级过程中，所有使用容器网络的 Pod 需要重启，才能重新获取双栈 IP 地址。请提前规划操作窗口，并通知相关业务团队。
+同时，本文中对 `kube-ovn-controller`、`kube-ovn-cni` 等组件参数的修改会生成 `resourcePatch`。集群升级时这些 `resourcePatch` 可能会被删除，导致这里配置的双栈参数丢失。升级时请重点关注这一点，并在升级后重新检查相关参数，必要时重新设置。
 :::
 
 ### 步骤 1：修改所有 Master 节点的 kube-apiserver 配置
@@ -109,77 +110,104 @@ systemctl restart kubelet
 对于 MicroOS 集群，集群升级后此配置会丢失，因此不建议将其作为持久化修改方式。
 :::
 
-### 步骤 4：修改 Kube-OVN 的 moduleInfo 配置
+### 步骤 4：修改 `kube-system/kube-ovn-controller` 的参数
 
-#### 4.1 查找目标集群的 moduleInfo
-
-在 Global 集群节点上执行，找到对应集群的 Kube-OVN moduleInfo：
+编辑 Deployment：
 
 ```bash
-kubectl get moduleInfo -A | grep {集群名} | grep kube-ovn
+kubectl edit deploy kube-ovn-controller -n kube-system
 ```
 
-示例输出：
-
-```text
-kube-ovn-2bcc878187dd9f0bb1c2b144032eae99   region1   kube-ovn   kube-ovn   Processing   v4.2.17   v4.2.17   v4.2.17
-```
-
-其中，第一列 `NAME` 对应 `{moduleInfo名称}`。
-
-#### 4.2 编辑 moduleInfo，修改双栈相关参数
-
-```bash
-kubectl edit moduleInfo {moduleInfo名称}
-```
-
-将以下 5 个参数修改为双栈配置：
+将以下参数修改为双栈格式：
 
 ```yaml
-spec:
-  config:
-    components:
-      dual_stack:
-        JOIN_CIDR: 100.64.0.0/16,fd00:100:64::/112
-        POD_CIDR: 10.3.0.0/16,fd00:10:3::/112
-        POD_GATEWAY: ""
-        SVC_CIDR: 10.4.0.0/16,fd00:10:4::/112
-      networking:
-        NET_STACK: dual_stack
+- --node-switch-cidr=100.64.0.0/16,fd00:100:64::/112
+- --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
+- --default-cidr=10.3.0.0/16,fd00:10:3::/112
 ```
 
-:::tip
-`POD_GATEWAY` 在双栈模式下置空，由 Kube-OVN 自动分配网关。
-:::
+### 步骤 5：验证节点注解是否已更新为双栈
 
-### 步骤 5：等待 Kube-OVN 核心组件重启
-
-等待业务集群 Kube-OVN 核心组件全部重启完成：
-
-- `kube-ovn-controller`
-- `kube-ovn-cni`
-- `ovn-central`
-- `ovs-ovn`
-
-
-### 步骤 6：验证双栈功能
-
-以上组件 Running 后，重启所有使用容器网络的 Pod，使其重新获取双栈 IP，然后执行以下命令验证：
+执行以下命令：
 
 ```bash
-# 查看节点是否已同时上报 IPv4/IPv6 InternalIP
 kubectl get node <node-name> -o yaml
-
-# 查看 Pod 是否已分配双栈 IP
-kubectl get pod <pod-name> -o jsonpath='{.status.podIPs}'
 ```
 
-确认 `status.addresses` 中同时存在 IPv4 和 IPv6 的 `InternalIP`。
+确认以下注解已经更新为双栈格式：
 
-预期输出示例：
+```yaml
+ovn.kubernetes.io/cidr: 100.64.0.0/16,fd00:100:64::/112
+ovn.kubernetes.io/gateway: 100.64.0.1,fd00:100:64::1
+```
 
-```json
-[{"ip":"10.3.x.x"},{"ip":"fd00:10:3::x"}]
+### 步骤 6：修改 `kube-system/kube-ovn-cni` 的参数
+
+编辑 DaemonSet：
+
+```bash
+kubectl edit ds kube-ovn-cni -n kube-system
+```
+
+将以下参数修改为双栈格式：
+
+```yaml
+- --service-cluster-ip-range=10.4.0.0/16,fd00:10:4::/112
+```
+
+### 步骤 7：验证节点 IPv6 路由
+
+在节点上执行：
+
+```bash
+ip -6 r
+```
+
+预期可以看到类似以下 IPv6 路由：
+
+```text
+fd00:100:64::/112 dev ovn0 proto kernel metric 256 pref medium
+```
+
+### 步骤 8：重启所有使用容器网络的 Pod
+
+执行以下脚本，删除所有使用容器网络且 `restartPolicy=Always` 的 Pod：
+
+```bash
+#!/usr/bin/env bash
+for ns in $(kubectl get ns --no-headers -o custom-columns=NAME:.metadata.name); do
+  for pod in $(kubectl get pod --no-headers -n "$ns" --field-selector spec.restartPolicy=Always -o custom-columns=NAME:.metadata.name,HOST:spec.hostNetwork | awk '{if ($2!="true") print $1}'); do
+    kubectl delete pod "$pod" -n "$ns" --ignore-not-found --wait=false
+  done
+done
+```
+
+### 步骤 9：验证双栈 IP 是否已生成
+
+执行以下命令：
+
+```bash
+kubectl get ips
+```
+
+预期可以看到 Pod 已同时分配 IPv4 和 IPv6 地址，例如：
+
+```text
+kube-ovn-pinger-vq896.kube-system   10.3.0.16   fd00:10:3::10   9a:3f:b1:71:58:5f   192.168.141.125   ovn-default
+```
+
+如需进一步验证 IPv6 连通性，可以使用 `kube-ovn-pinger` 对同一集群内使用容器网络的 Pod IPv6 地址执行 `ping6`，例如：
+
+```bash
+kubectl exec -it -n kube-system kube-ovn-pinger-6fbx6 -- ping6 fd00:10:3::17
+```
+
+预期输出类似：
+
+```text
+Defaulted container "pinger" out of: pinger, hostpath-init (init)
+PING fd00:10:3::17 (fd00:10:3::17): 56 data bytes
+64 bytes from fd00:10:3::17: icmp_seq=0 ttl=64 time=2.989 ms
 ```
 
 ## 相关信息


### PR DESCRIPTION
## Background
This PR adds dual-stack upgrade guides for ACP 4.2 and 4.3, covering both Kube-OVN and Calico scenarios.

For these ACP versions, the implementation path differs from later versions, so the documents focus on the actual component-level changes and post-change verification steps required in ACP 4.2 and 4.3.

## Changes
- add Kube-OVN dual-stack guides in Chinese and English for ACP 4.2 and 4.3
- add Calico dual-stack guides in Chinese and English for ACP 4.2 and 4.3
- document component argument changes, verification steps, and connectivity checks
- add upgrade warnings about `resourcePatch` cleanup risks

## Notes
- for Kube-OVN, the guide includes kubelet `--node-ip`, `kube-ovn-controller`, and `kube-ovn-cni` updates
- for Calico, the guide includes `calico-config`, `calico-node`, IPPool, subnet, and `kubectl get ips -A` verification
- these are documentation-only changes

## Test
- not run (documentation changes only)