### PR TITLE
[configure] Configure Kubelet Log Level Verbosity

### DIFF
--- a/docs/en/solutions/Configure_Kubelet_Log_Level_Verbosity.md
+++ b/docs/en/solutions/Configure_Kubelet_Log_Level_Verbosity.md
@@ -26,21 +26,34 @@ The kubelet supports configurable log verbosity levels ranging from `0` (least v
 | 5–8 | Trace-level output, verbose internal state dumps |
 | 9–10 | Maximum verbosity, rarely needed |
 
-### Persistent Configuration (Mutable Host OS)
+### Persistent Configuration — KubeletConfiguration (preferred on kubeadm clusters)
 
-On mutable host OSes (standard Linux distributions with a writable `/etc`), set the kubelet log level persistently by adding or modifying the `--v` flag via a systemd drop-in file:
+On kubeadm-provisioned clusters the kubelet is configured through `/var/lib/kubelet/config.yaml`. Set the `verbosity` field there and restart kubelet:
+
+```bash
+# On the target node
+sudo sed -i 's/^\s*verbosity:.*/verbosity: 4/; t; $a\verbosity: 4' /var/lib/kubelet/config.yaml
+sudo systemctl restart kubelet
+```
+
+This works regardless of how the systemd unit passes arguments to kubelet, and kubeadm-based automation will preserve it across upgrades.
+
+### Persistent Configuration — systemd drop-in (fallback)
+
+If you cannot edit `config.yaml` (some operator-managed setups lock the file), override the kubelet `ExecStart` via a drop-in that **inlines the `--v` flag directly**. Setting a bare environment variable like `KUBELET_LOG_LEVEL=4` does **not** raise verbosity — the stock kubeadm systemd unit only expands the three specific variables `$KUBELET_KUBECONFIG_ARGS`, `$KUBELET_CONFIG_ARGS`, and `$KUBELET_KUBEADM_ARGS`; any other name (including `KUBELET_LOG_LEVEL` or `KUBELET_EXTRA_ARGS`) is silently ignored.
 
 ```bash
 sudo mkdir -p /etc/systemd/system/kubelet.service.d/
-sudo tee /etc/systemd/system/kubelet.service.d/10-log-level.conf <<EOF
+sudo tee /etc/systemd/system/kubelet.service.d/10-log-level.conf <<'EOF'
 [Service]
-Environment="KUBELET_LOG_LEVEL=4"
 ExecStart=
-ExecStart=/usr/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_LOG_LEVEL
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS --v=4
 EOF
 sudo systemctl daemon-reload
 sudo systemctl restart kubelet
 ```
+
+The `ExecStart=` (empty) line clears the parent unit's ExecStart; the second line rebuilds it with `--v=4` appended.
 
 ### Persistent Configuration (Immutable OS Nodes)
 
@@ -56,17 +69,18 @@ If the cluster spans both mutable and immutable nodes, scope the change to a nod
 
 ### One-Time Change (Single Node)
 
-For temporary debugging on a single mutable-OS node without touching the persistent configuration, override the kubelet arguments directly on that node:
+For temporary debugging on a single mutable-OS node, use the same drop-in pattern shown above via `systemctl edit`:
 
 ```bash
 sudo systemctl edit kubelet
 ```
 
-Add the following to raise verbosity to level 4:
+Enter the override block — again, the flag must be inlined into `ExecStart`, not placed into a bare environment variable:
 
 ```ini
 [Service]
-Environment="KUBELET_EXTRA_ARGS=--v=4"
+ExecStart=
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS --v=4
 ```
 
 Then reload and restart:
@@ -82,10 +96,14 @@ On immutable-OS nodes, prefer the Immutable Infrastructure flow above even for s
 
 ## Diagnostic Steps
 
-Verify the current kubelet log level by inspecting the running process:
+Verify the current kubelet log level. On kubeadm-provisioned clusters kubelet typically does **not** carry `--v` on its command line — verbosity comes from `config.yaml` — so `ps` on its own reports nothing even when verbosity is set. Check both locations:
 
 ```bash
-ps aux | grep kubelet | grep -o '\-\-v=[0-9]*'
+# The KubeletConfiguration path (primary on kubeadm clusters)
+sudo grep -E '^\s*verbosity:' /var/lib/kubelet/config.yaml || echo "verbosity: (default 2)"
+
+# The command-line path (only populated if you added --v via a drop-in)
+ps aux | grep kubelet | grep -oE '\-\-v=[0-9]+' || echo "(no --v on cmdline)"
 ```
 
 Gather kubelet logs from a specific node:

--- a/docs/en/solutions/Configure_Kubelet_Log_Level_Verbosity.md
+++ b/docs/en/solutions/Configure_Kubelet_Log_Level_Verbosity.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Configure Kubelet Log Level Verbosity
 ## Issue
 
 When troubleshooting node-level problems, increasing the kubelet log verbosity helps identify the root cause. The default log level (`2`) may not provide enough detail for complex issues such as pod scheduling failures, volume mount errors, or container runtime communication problems.

--- a/docs/en/solutions/Configure_Kubelet_Log_Level_Verbosity.md
+++ b/docs/en/solutions/Configure_Kubelet_Log_Level_Verbosity.md
@@ -1,0 +1,111 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+When troubleshooting node-level problems, increasing the kubelet log verbosity helps identify the root cause. The default log level (`2`) may not provide enough detail for complex issues such as pod scheduling failures, volume mount errors, or container runtime communication problems.
+
+## Root Cause
+
+The kubelet supports configurable log verbosity levels ranging from `0` (least verbose) to `10` (most verbose). The default level is `2`, which provides basic operational information. Higher levels expose progressively more diagnostic data, but consume additional CPU, disk I/O, and memory on the node.
+
+## Resolution
+
+### Log Level Reference
+
+| Level Range | Purpose |
+|---|---|
+| 0 | Critical errors only |
+| 1–2 | Default operational output |
+| 3–4 | Debug-level information, suitable for most troubleshooting |
+| 5–8 | Trace-level output, verbose internal state dumps |
+| 9–10 | Maximum verbosity, rarely needed |
+
+### Persistent Configuration (Mutable Host OS)
+
+On mutable host OSes (standard Linux distributions with a writable `/etc`), set the kubelet log level persistently by adding or modifying the `--v` flag via a systemd drop-in file:
+
+```bash
+sudo mkdir -p /etc/systemd/system/kubelet.service.d/
+sudo tee /etc/systemd/system/kubelet.service.d/10-log-level.conf <<EOF
+[Service]
+Environment="KUBELET_LOG_LEVEL=4"
+ExecStart=
+ExecStart=/usr/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_LOG_LEVEL
+EOF
+sudo systemctl daemon-reload
+sudo systemctl restart kubelet
+```
+
+### Persistent Configuration (Immutable OS Nodes)
+
+On immutable-OS nodes — MicroOS, or any setup where `/etc` is backed by a read-mostly overlay that is reset on node upgrades or rollbacks — direct file edits under `/etc/systemd/system/kubelet.service.d/` **will not survive the next node update**. You may see the desired verbosity right after the change, then lose it silently when the node image is replaced.
+
+Persist the change through ACP's Immutable Infrastructure mechanism instead:
+
+- Define the drop-in file as part of the node configuration managed by ACP (under `configure/clusters/nodes`). The platform renders and re-applies it every time a node boots, so the override survives OS upgrades and rollbacks.
+- Trigger a rolling apply on the target node pool. ACP will cordon/drain, restart the kubelet with the new verbosity, and resume scheduling.
+- Revert the same way — update the node configuration to remove the override; do not `rm` the file directly on the node, because the mutation will be lost at the next reconcile.
+
+If the cluster spans both mutable and immutable nodes, scope the change to a node group / pool so that only the intended nodes carry the higher verbosity.
+
+### One-Time Change (Single Node)
+
+For temporary debugging on a single mutable-OS node without touching the persistent configuration, override the kubelet arguments directly on that node:
+
+```bash
+sudo systemctl edit kubelet
+```
+
+Add the following to raise verbosity to level 4:
+
+```ini
+[Service]
+Environment="KUBELET_EXTRA_ARGS=--v=4"
+```
+
+Then reload and restart:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart kubelet
+```
+
+On immutable-OS nodes, prefer the Immutable Infrastructure flow above even for short investigations: running `systemctl edit` on a single node works until that node is re-imaged, at which point the change is gone without warning.
+
+> **Important:** Revert the log level back to the default (`2`) after collecting the necessary logs. Extended operation at high verbosity places significant load on node resources.
+
+## Diagnostic Steps
+
+Verify the current kubelet log level by inspecting the running process:
+
+```bash
+ps aux | grep kubelet | grep -o '\-\-v=[0-9]*'
+```
+
+Gather kubelet logs from a specific node:
+
+```bash
+kubectl get nodes
+kubectl debug node/<node-name> --image=busybox -- cat /host/var/log/kubelet.log
+```
+
+Alternatively, SSH into the node and use journalctl:
+
+```bash
+ssh <node-address>
+sudo journalctl -b -f -u kubelet.service
+```
+
+To collect logs from all nodes at once:
+
+```bash
+for n in $(kubectl get nodes --no-headers | awk '{print $1}'); do
+  ssh "$n" "sudo journalctl -u kubelet.service --since '1 hour ago'" > "${n}.kubelet.log"
+done
+```

--- a/docs/en/solutions/Configure_Kubelet_Log_Level_Verbosity.md
+++ b/docs/en/solutions/Configure_Kubelet_Log_Level_Verbosity.md
@@ -1,0 +1,80 @@
+---
+title: Configure Kubelet Log Level Verbosity on Alauda Container Platform
+component: observability
+scenario: how-to
+tags: [kubelet, logging, systemd, troubleshooting]
+date_created: 2026-05-30
+date_updated: 2026-05-30
+---
+
+# Configure Kubelet Log Level Verbosity on Alauda Container Platform
+
+## Issue
+
+When investigating a node-level problem such as a kubelet that is slow to register pods, stuck on container GC, or generating unexpected NotReady events, the default kubelet log volume is often too sparse to show the failing decision path. Kubelet exposes the upstream klog verbosity control as the `logging.verbosity` field in its `KubeletConfiguration` (`/var/lib/kubelet/config.yaml`, `apiVersion: kubelet.config.k8s.io/v1beta1`), and the same value can be raised at the systemd layer by passing `-v=<level>` to the `kubelet` binary [ev:c1_a]. Raising verbosity surfaces additional klog lines so the failing flow is easier to follow.
+
+## Root Cause
+
+On Alauda Container Platform (k8s v1.34.5 on the verified cluster), the kubelet runs as a host systemd unit at `/etc/systemd/system/kubelet.service` with the kubeadm-supplied drop-in `/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf` already in the load path. That drop-in resets `ExecStart=` and re-launches `/usr/bin/kubelet` with three variables — `$KUBELET_KUBECONFIG_ARGS`, `$KUBELET_CONFIG_ARGS`, and `$KUBELET_KUBEADM_ARGS` — which means kubelet's effective command line is assembled from `EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env` plus the `--config` file [ev:c3_a]. There are two places where verbosity can be introduced: the `KubeletConfiguration` file the kubelet reads at startup, or an additional systemd drop-in that injects `-v=<level>` into the `ExecStart` line [ev:c3_b].
+
+## Resolution
+
+There are two equivalent places to raise kubelet verbosity on a node — the `KubeletConfiguration` file or a systemd drop-in — and either change is picked up by restarting the `kubelet.service` unit on that node [ev:c3_b].
+
+**Path A — edit the kubelet configuration file (persistent).** Change `logging.verbosity` in `/var/lib/kubelet/config.yaml` on the node, then restart the unit. The kubelet reads its merged `KubeletConfiguration` from that file at startup, so the new value applies after the next `systemctl restart kubelet` [ev:c1_a]:
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+logging:
+  verbosity: 4
+# ... rest of the existing fields unchanged
+```
+
+Apply it:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart kubelet
+```
+
+**Path B — add a systemd drop-in (per-node one-time override).** Drop-in unit files placed under `/etc/systemd/system/kubelet.service.d/` are merged with the unit fragment and the existing `10-kubeadm.conf` drop-in at load time, so adding a small file there is the lightest-weight way to override `ExecStart=` for a single node [ev:c3_a]. Create `/etc/systemd/system/kubelet.service.d/20-verbose.conf` on the target node; the override resets `ExecStart=` and re-launches the kubelet with the same three variables the kubeadm drop-in already uses, appending `-v=<level>` [ev:c3_a][ev:c3_b]:
+
+```text
+[Service]
+ExecStart=
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS -v=4
+```
+
+Reload systemd and restart kubelet so the new drop-in takes effect [ev:c3_b]:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart kubelet
+```
+
+After the relevant log lines have been collected, revert the change (delete `/etc/systemd/system/kubelet.service.d/20-verbose.conf` or set `logging.verbosity: 0`) and restart kubelet again to return to the baseline log volume [ev:c1_a][ev:c3_b].
+
+## Diagnostic Steps
+
+Confirm the live kubelet configuration via the kubelet's own configz endpoint; the `logging.verbosity` field reflects whatever value the kubelet currently runs with [ev:c1_a]:
+
+```bash
+kubectl get --raw "/api/v1/nodes/<node>/proxy/configz" \
+  | python3 -c 'import sys, json; print(json.dumps(json.load(sys.stdin)["kubeletconfig"]["logging"], indent=2))'
+```
+
+Tail the kubelet's klog stream on the node itself. Kubelet logs to the systemd journal, so `journalctl -u kubelet.service` returns the raw `Ixxxx`/`Exxxx` lines — increase verbosity first, reproduce the symptom, then read the journal back to the moment of the event [ev:c4]:
+
+```bash
+sudo journalctl -b -f -u kubelet.service
+```
+
+Two related forms of the same command are useful when collecting a window of history rather than tailing live:
+
+```bash
+# Lines since the most recent boot, paged
+sudo journalctl -b -u kubelet.service --no-pager
+# A specific time window
+sudo journalctl -u kubelet.service --since "2026-05-30 03:00:00" --until "2026-05-30 03:30:00"
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章，归入 `configure` 区域。

**⏭️ 自动化验证暂缓 — 暂不自动合并** — 集群缺少该文章操作所需的前置条件，跳过不代表未审；请人工确认内容后再合。

## `configure` 区域建议 reviewer

按 `kb/OWNERS.md`（来源：alauda-ai-base operator-list 的产品 owner）该区域候选自动挑选，@ 错了请无视。


没有 GitHub handle 的贡献者（本区域相关请人工 ping）：

- gangwang &lt;gangwang@alauda.io&gt;
- xdzhang &lt;xdzhang@alauda.io&gt;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for configuring Kubelet log level verbosity on Alauda Container Platform, covering configuration file and systemd-based override methods with diagnostic verification steps for node-level issue investigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/knowledge/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->