### PR TITLE
[networking] Kubelet CSR Stuck at Approved When the Signing Controller Is Not Issuing

### DIFF
--- a/docs/en/solutions/Expired_Node_Certificates_Cause_CSR_Backlog_and_CNI_Pod_Crashes.md
+++ b/docs/en/solutions/Expired_Node_Certificates_Cause_CSR_Backlog_and_CNI_Pod_Crashes.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Expired Node Certificates Cause CSR Backlog and CNI Pod Crashes
 ## Issue
 
 Node certificates expire and the automatic renewal process stalls, causing a cascade of failures:

--- a/docs/en/solutions/Expired_Node_Certificates_Cause_CSR_Backlog_and_CNI_Pod_Crashes.md
+++ b/docs/en/solutions/Expired_Node_Certificates_Cause_CSR_Backlog_and_CNI_Pod_Crashes.md
@@ -32,53 +32,110 @@ The kube-controller-manager's certificate signing controller stops issuing certi
 
 ## Resolution
 
-Recover each affected node by removing the stale kubelet PKI and forcing certificate reissuance.
+Recover each affected node by restoring a bootstrap path so kubelet can request a fresh client certificate, then approving the CSR it emits.
 
-### Step 1: Delete Stale Kubelet PKI
+> **Important on modern kubeadm clusters:** `/etc/kubernetes/kubelet.conf` references `/var/lib/kubelet/pki/kubelet-client-current.pem` as a **file** — not an inline-embedded cert. When that file is missing and `/etc/kubernetes/bootstrap-kubelet.conf` has already been removed (the standard post-join state), kubelet has no valid identity, cannot submit a CSR, and will crash-loop with `failed to run Kubelet: unable to load bootstrap kubeconfig`. Simply `rm`-ing the PKI dir and restarting kubelet is **not enough** — you must also hand kubelet a fresh bootstrap kubeconfig first.
 
-SSH into the affected node and remove the PKI directory:
+### Step 1: Create a Bootstrap Token
+
+On a control-plane node (or anywhere with cluster-admin kubectl), mint a bootstrap token the affected node can use to authenticate:
+
+```bash
+kubeadm token create --print-join-command
+```
+
+If `kubeadm` is not on the workstation, create the token Secret directly:
+
+```bash
+TOKEN_ID=$(head -c 3 /dev/urandom | xxd -p)
+TOKEN_SECRET=$(head -c 8 /dev/urandom | xxd -p)
+EXP=$(date -u -d '+1 hour' +%Y-%m-%dT%H:%M:%SZ)
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bootstrap-token-${TOKEN_ID}
+  namespace: kube-system
+type: bootstrap.kubernetes.io/token
+stringData:
+  token-id: ${TOKEN_ID}
+  token-secret: ${TOKEN_SECRET}
+  usage-bootstrap-authentication: "true"
+  usage-bootstrap-signing: "true"
+  auth-extra-groups: system:bootstrappers:kubeadm:default-node-token
+  expiration: "${EXP}"
+EOF
+echo "token: ${TOKEN_ID}.${TOKEN_SECRET}"
+```
+
+### Step 2: Write Bootstrap Kubeconfig on the Node
+
+On the affected node, rebuild `/etc/kubernetes/bootstrap-kubelet.conf`. Reuse the CA data that's already embedded in `/etc/kubernetes/kubelet.conf`:
 
 ```bash
 ssh <node-address>
-sudo rm -rf /var/lib/kubelet/pki
+CA_DATA=$(sudo grep certificate-authority-data /etc/kubernetes/kubelet.conf | awk '{print $2}')
+API_SERVER=$(sudo grep "server:" /etc/kubernetes/kubelet.conf | awk '{print $2}')
+sudo tee /etc/kubernetes/bootstrap-kubelet.conf >/dev/null <<EOF
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ${CA_DATA}
+    server: ${API_SERVER}
+  name: default-cluster
+contexts:
+- context:
+    cluster: default-cluster
+    user: kubelet-bootstrap
+  name: default-context
+current-context: default-context
+kind: Config
+users:
+- name: kubelet-bootstrap
+  user:
+    token: <TOKEN_FROM_STEP_1>
+EOF
+sudo chmod 600 /etc/kubernetes/bootstrap-kubelet.conf
 ```
 
-### Step 2: Restart the Kubelet
+### Step 3: Remove Stale PKI and Restart Kubelet
+
+With the bootstrap kubeconfig in place, kubelet has a way to authenticate when the file-backed client cert is missing:
 
 ```bash
+sudo rm -rf /var/lib/kubelet/pki
 sudo systemctl restart kubelet
 ```
 
-The kubelet generates a new private key and submits a fresh CSR to the API server upon startup.
+Kubelet now boots in bootstrap mode, generates a fresh private key, and submits a CSR signed with the bootstrap token.
 
-### Step 3: Approve Pending CSRs
+### Step 4: Approve the Pending CSR
 
-From a control-plane node or workstation with cluster admin access, approve the new CSR:
+From the workstation with cluster-admin access:
 
 ```bash
 kubectl get csr
 kubectl certificate approve <csr-name>
 ```
 
-If multiple nodes are affected, approve all pending CSRs at once:
+For multiple affected nodes at once:
 
 ```bash
 kubectl get csr -o name | xargs -I{} kubectl certificate approve {}
 ```
 
-### Step 4: Verify Recovery
+The built-in CSR approver may also approve it automatically (via group `system:bootstrappers:kubeadm:default-node-token`), so this step is sometimes a no-op.
 
-Confirm the node returns to `Ready` status:
+### Step 5: Verify Recovery
+
+Confirm the node returns to `Ready` and the CNI pods there are running:
 
 ```bash
 kubectl get nodes
-```
-
-Check that CNI pods on the recovered node are running:
-
-```bash
 kubectl get pods -n kube-system --field-selector spec.nodeName=<node-name>
 ```
+
+After the node stabilizes, `/etc/kubernetes/bootstrap-kubelet.conf` is no longer needed — you can delete it to prevent a stale token from lingering on disk.
 
 ## Diagnostic Steps
 

--- a/docs/en/solutions/Expired_Node_Certificates_Cause_CSR_Backlog_and_CNI_Pod_Crashes.md
+++ b/docs/en/solutions/Expired_Node_Certificates_Cause_CSR_Backlog_and_CNI_Pod_Crashes.md
@@ -1,0 +1,113 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+Node certificates expire and the automatic renewal process stalls, causing a cascade of failures:
+
+- The API server rejects kubelet requests with x509 certificate errors:
+
+```
+Unable to authenticate the request" err="[x509: certificate has expired or is not yet valid:
+current time xxxx-xx-xxxx is after xxxx-xx-xxxx
+```
+
+- CNI agent pods on affected nodes enter `CrashLoopBackOff`:
+
+```
+certificate signing request csr-xxxxx is approved, waiting to be issued
+failed to start the node certificate manager: certificate was not signed: context deadline exceeded
+```
+
+- Multiple Certificate Signing Requests (CSRs) remain in `Approved` state but are never issued.
+
+## Root Cause
+
+The kube-controller-manager's certificate signing controller stops issuing certificates even though CSRs have been approved. This creates a backlog of pending CSRs. Without valid certificates, the kubelet on affected nodes cannot authenticate to the API server, and CNI components that depend on node certificates fail to initialize.
+
+## Resolution
+
+Recover each affected node by removing the stale kubelet PKI and forcing certificate reissuance.
+
+### Step 1: Delete Stale Kubelet PKI
+
+SSH into the affected node and remove the PKI directory:
+
+```bash
+ssh <node-address>
+sudo rm -rf /var/lib/kubelet/pki
+```
+
+### Step 2: Restart the Kubelet
+
+```bash
+sudo systemctl restart kubelet
+```
+
+The kubelet generates a new private key and submits a fresh CSR to the API server upon startup.
+
+### Step 3: Approve Pending CSRs
+
+From a control-plane node or workstation with cluster admin access, approve the new CSR:
+
+```bash
+kubectl get csr
+kubectl certificate approve <csr-name>
+```
+
+If multiple nodes are affected, approve all pending CSRs at once:
+
+```bash
+kubectl get csr -o name | xargs -I{} kubectl certificate approve {}
+```
+
+### Step 4: Verify Recovery
+
+Confirm the node returns to `Ready` status:
+
+```bash
+kubectl get nodes
+```
+
+Check that CNI pods on the recovered node are running:
+
+```bash
+kubectl get pods -n kube-system --field-selector spec.nodeName=<node-name>
+```
+
+## Diagnostic Steps
+
+### Inspect API Server Certificate Errors
+
+```bash
+kubectl logs -n kube-system kube-apiserver-<node-name> --tail=200 | \
+  grep "certificate has expired"
+```
+
+### List CSRs and Their Status
+
+```bash
+kubectl get csr
+```
+
+Look for CSRs stuck in `Approved` without progressing to `Issued`.
+
+### Verify kube-controller-manager Health
+
+```bash
+kubectl get pods -n kube-system | grep kube-controller-manager
+kubectl logs -n kube-system kube-controller-manager-<node-name> --tail=100
+```
+
+If the kube-controller-manager is unhealthy or showing certificate-related errors itself, troubleshoot the control-plane certificates first.
+
+### Check CNI Pod Logs
+
+```bash
+kubectl logs -n kube-system <cni-pod-name> --tail=50 | grep -i "certificate\|csr\|x509"
+```

--- a/docs/en/solutions/Kubelet_CSR_Stuck_at_Approved_When_the_Signing_Controller_Is_Not_Issuing.md
+++ b/docs/en/solutions/Kubelet_CSR_Stuck_at_Approved_When_the_Signing_Controller_Is_Not_Issuing.md
@@ -1,0 +1,73 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Kubelet CSR Stuck at Approved When the Signing Controller Is Not Issuing
+
+## Issue
+
+When a node's kubelet client certificate expires, the kubelet renews it through the CertificateSigningRequest API, and the resulting requests surface in `kubectl get csr`. On Alauda Container Platform (Kubernetes server `v1.34.5`) the CSR API is the standard upstream `certificates.k8s.io/v1` group: the `csr` resource is cluster-scoped and listable directly with `kubectl get csr`.
+
+In the affected state, one or more of these requests stay in the `Approved` condition and never progress to `Approved,Issued`. Listing the requests surfaces the stuck condition directly:
+
+```bash
+kubectl get csr
+```
+
+```text
+NAME          AGE   SIGNERNAME                      CONDITION
+csr-sqgzp     5m    kubernetes.io/kubelet-serving   Approved
+```
+
+## Root Cause
+
+A CSR's `status.certificate` field is populated by the signer only after an `Approved` condition is present; while the signature has not been emitted, the request continues to show `Approved` in the CONDITION column of `kubectl get csr`. Once the signing controller emits the certificate, the same request shows `Approved,Issued`. A request that is approved but stuck with an empty `status.certificate` therefore indicates the signer has not acted.
+
+The signer is the `csrsigning` controller in the `kube-controller-manager`. The controller-manager runs with `--controllers=*,bootstrapsigner,tokencleaner`, where `*` enables the default `csrapproving` and `csrsigning` controllers, and the signer is wired to a CA through `--cluster-signing-cert-file` and `--cluster-signing-key-file`; issued certificates use the configured `--cluster-signing-duration` lifetime. When approved CSRs are not reaching `Approved,Issued`, the root cause is that this signing controller is not issuing the requested certificates, which leaves a growing backlog of approved-but-unissued requests.
+
+While that backlog persists, downstream workloads that depend on a freshly issued node certificate can fail to start until their request is signed.
+
+## Diagnostic Steps
+
+Confirm whether kubelet renewal requests have reached the apiserver and inspect their condition; in steady state the list is empty, so any request lingering in `Approved` is the signal to investigate:
+
+```bash
+kubectl get csr
+```
+
+Check the health of the signer by listing the controller-manager pod. On Alauda Container Platform the `kube-controller-manager` runs as a static pod in the `kube-system` namespace, and a portable filter surfaces it directly:
+
+```bash
+kubectl get pods -n kube-system | grep controller
+```
+
+```text
+kube-controller-manager-192.168.135.152   1/1   Running
+```
+
+A `Running` controller-manager pod paired with CSRs stuck at `Approved` points at the `csrsigning` controller failing to issue rather than the pod being down.
+
+## Resolution
+
+Identify the pending kubelet request, then approve it so the signing controller is told to issue the certificate:
+
+```bash
+kubectl get csr
+kubectl certificate approve <csr-name>
+```
+
+Approving a request instructs the certificate signing controller to issue the certificate, the same `csrsigning` mechanism examined above; a healthy signer then moves the request from `Approved` to `Approved,Issued` and populates `status.certificate`. Re-running `kubectl get csr` confirms the transition:
+
+```bash
+kubectl get csr
+```
+
+```text
+NAME          AGE   SIGNERNAME                      CONDITION
+csr-sqgzp     7m    kubernetes.io/kubelet-serving   Approved,Issued
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章。
