### PR TITLE
[configure] Pods Pending with Insufficient Memory While Nodes Show Free Memory

### DIFF
--- a/docs/en/solutions/Pods_Pending_with_Insufficient_Memory_While_Nodes_Show_Free_Memory.md
+++ b/docs/en/solutions/Pods_Pending_with_Insufficient_Memory_While_Nodes_Show_Free_Memory.md
@@ -1,0 +1,89 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A pod stays in `Pending` state with a scheduling error similar to:
+
+```text
+0/6 nodes are available:
+  3 Insufficient memory,
+  3 node(s) had taint {node-role.kubernetes.io/control-plane:}, that the pod didn't tolerate.
+```
+
+`kubectl top node` reports plenty of free memory on the same workers, and the new pod only requests `500Mi`. Yet the scheduler refuses to place it.
+
+## Root Cause
+
+The scheduler does not compare a pod's request to the node's **real-time** memory usage. It compares it to the node's **allocatable** budget minus the **sum of requests** of every pod already admitted. Once that accounting pool is exhausted, the node is full from the scheduler's perspective — even if running pods use far less than they asked for.
+
+This is by design. `.spec.containers[].resources.requests` acts as a reservation: the kubelet guarantees the pod can consume up to that amount without being throttled or OOM-killed relative to lower-priority workloads. Admitting a new pod that would push total requests beyond allocatable would break that guarantee for everyone already on the node.
+
+`kubectl top` reports current utilization through the metrics pipeline. It is the right tool for capacity investigations and the wrong one for reasoning about scheduling — the two numbers are computed from different inputs and will legitimately disagree whenever pods request more than they currently use.
+
+## Resolution
+
+Right-size requests first; add hardware second.
+
+1. **Audit request vs. actual usage** for the high-request pods on the saturated nodes. If a pod reserves `4Gi` but its 7-day P95 working set is `900Mi`, the reservation is wrong — lower it. A modest over-provision factor (typically 1.3× to 1.5× of P95) is a reasonable rule of thumb for stable workloads.
+
+2. **Separate requests from limits intentionally.** Setting `requests == limits` (Guaranteed QoS) consumes the most capacity. Most workloads are better served by `requests` sized for the P95 steady state and `limits` sized for the peak, placing them in Burstable QoS. Only infrastructure components that must never be OOM-killed need the Guaranteed tier.
+
+3. **Use `LimitRange` to catch regressions.** A namespace-level default with reasonable ceilings keeps a single team from accidentally reserving an entire node:
+
+   ```yaml
+   apiVersion: v1
+   kind: LimitRange
+   metadata:
+     name: default-requests
+     namespace: team-a
+   spec:
+     limits:
+       - type: Container
+         default:        { cpu: "500m", memory: "512Mi" }
+         defaultRequest: { cpu: "100m", memory: "128Mi" }
+         max:            { cpu: "4",    memory: "8Gi"   }
+   ```
+
+4. **Scale the cluster only after requests are honest.** Adding worker nodes to cover inflated requests simply relocates the waste. When additional capacity is genuinely required, a HorizontalPodAutoscaler for elastic services and a node autoscaler for the fleet are cheaper than permanently over-provisioning both.
+
+## Diagnostic Steps
+
+Compare allocatable memory to the sum of requests on each node:
+
+```bash
+kubectl describe node <node-name> | sed -n '/Allocated resources/,/Events/p'
+```
+
+The table at the bottom lists requests/limits per resource and the percentage of allocatable already reserved.
+
+Find the top memory reservers on a suspect node:
+
+```bash
+node=<node-name>
+kubectl get pods -A -o json \
+  --field-selector spec.nodeName=$node \
+| jq -r '.items[] | .spec.containers[] as $c
+         | [.metadata.namespace, .metadata.name, $c.name,
+            ($c.resources.requests.memory // "0")] | @tsv' \
+| sort -k4 -h | column -t
+```
+
+Compare those numbers with real usage from the metrics pipeline:
+
+```bash
+kubectl top pod -A --containers | sort -k5 -h | tail -20
+```
+
+Inspect the pending pod's events to confirm the exact predicate that rejected each node:
+
+```bash
+kubectl describe pod <pending-pod> -n <ns>
+```
+
+If the imbalance is across a single deployment, look for a missing anti-affinity rule that is concentrating replicas on the already-saturated node.

--- a/docs/en/solutions/Pods_Pending_with_Insufficient_Memory_While_Nodes_Show_Free_Memory.md
+++ b/docs/en/solutions/Pods_Pending_with_Insufficient_Memory_While_Nodes_Show_Free_Memory.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Pods Pending with Insufficient Memory While Nodes Show Free Memory
 ## Issue
 
 A pod stays in `Pending` state with a scheduling error similar to:

--- a/docs/en/solutions/Pods_Pending_with_Insufficient_Memory_While_Nodes_Show_Free_Memory.md
+++ b/docs/en/solutions/Pods_Pending_with_Insufficient_Memory_While_Nodes_Show_Free_Memory.md
@@ -1,0 +1,65 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x,4.3.x
+---
+
+# Pods stay Pending with Insufficient memory while kubectl top shows free RAM on ACP
+
+## Issue
+
+On Alauda Container Platform running upstream Kubernetes v1.34.5, new Pods can sit in `Pending` with a `FailedScheduling` event reporting `0/N nodes are available: N Insufficient memory`, even though `kubectl top node` shows healthy free RAM on every Node. The scheduling component on ACP is the upstream `kube-scheduler` binary, deployed as a static Pod `kube-scheduler-<node-ip>` in the `kube-system` namespace using image `registry.alauda.cn:60080/tkestack/kube-scheduler:v1.34.5`, so the fit-predicate logic and the `Insufficient <resource>` reason string come straight from upstream kube-scheduler code [ev:c1_a]. The scheduler reaches that verdict by comparing each Pod's `spec.containers[*].resources.requests` against each Node's `status.allocatable` minus the sum of already-scheduled Pods' requests (a residual computed in the scheduler's in-memory cache, not republished on the Node object), and a Pod that cannot fit any Node's remaining headroom stays Pending with the `0/N nodes are available: N Insufficient <resource>` `FailedScheduling` event [ev:c1_b].
+
+## Root Cause
+
+`status.allocatable` is strictly less than `status.capacity` because the kubelet subtracts `kubeReserved`, `systemReserved`, and the hard-eviction threshold from Capacity before publishing Allocatable. On the affected ACP cluster the kubelet config sets `kubeReserved={cpu:100m, memory:902Mi}`, `systemReserved={cpu:100m, memory:902Mi}`, and `evictionHard.memory.available=100Mi` uniformly across the control-plane Node and the three worker Nodes; the resulting Node status shows Capacity memory `16384568Ki` and Allocatable memory `14434872Ki`, a delta of `1904Mi` that matches the reservation arithmetic exactly (`902Mi + 902Mi + 100Mi = 1904Mi`) [ev:c2].
+
+Scheduling is bookkeeping over `requests`, not over actual utilization. Once a Pod is scheduled the full `requests` value is subtracted from the Node's Allocatable for scheduling purposes, even when the Pod is consuming far less RAM at runtime, so the scheduler treats a Node as full when the sum of Pod requests reaches Allocatable [ev:c3]. `kubectl top node` reads from the `metrics.k8s.io/v1beta1` `NodeMetrics` API (served on ACP by `cpaas-monitor-prometheus-adapter`), which reports current instantaneous CPU and memory **utilization** sampled by the metrics pipeline — it does not report scheduled `requests` [ev:c5_a]. Because top measures utilization while the scheduler reasons about requests, a Node can appear to have plenty of free memory in `kubectl top node` while the scheduler still rejects new Pods with `Insufficient memory`; the two surfaces measure different things [ev:c5_b].
+
+## Resolution
+
+The first-line remediation is to right-size each Pod's `resources.requests` to match real application memory usage, so the scheduler's bookkeeping reflects reality and frees Allocatable headroom on existing Nodes [ev:c6_a]. When right-sizing requests is not feasible, the alternative is to add memory to existing workers or add more worker Nodes; both grow the cluster's aggregate Allocatable and give the scheduler more room without changing Pod specs [ev:c6_b].
+
+Edit the workload's Pod template to lower over-stated requests. The mechanism is fixed (the scheduler reads `.spec.containers[*].resources.requests` literally, so lower requests free Allocatable headroom) [ev:c6_a]; the specific Mi / cpu numbers below are illustrative placeholders and should be replaced with values that reflect the workload's measured usage:
+
+```yaml
+spec:
+  containers:
+    - name: app
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          memory: 512Mi
+          cpu: 500m
+```
+
+After the change, the scheduler re-evaluates pending Pods on its next cycle and the `FailedScheduling` event clears once a Node has enough remaining Allocatable to fit the new request [ev:c1_b].
+
+## Diagnostic Steps
+
+Inspect the Node's accounting first. `kubectl describe node <name>` prints an `Allocated resources` block listing per-resource Requests and Limits as percentages of the Node's **Allocatable** (not Capacity); this is the column that matches what the scheduler sees and is the right place to look when a Pod is stuck Pending with `Insufficient memory` while top shows free RAM [ev:c4]. On a Node from the affected ACP cluster the block shows entries shaped like `cpu 6120m (78%) ... memory 7728Mi (54%) ... limits 32928m (422%) / 51174Mi (363%)` — percentages computed against Allocatable, with the Limits column exceeding 100% because limits do not gate scheduling [ev:c3]:
+
+```bash
+kubectl describe node <node-name>
+```
+
+Compare Capacity to Allocatable to confirm the reservation arithmetic [ev:c2]:
+
+```bash
+kubectl get node <node-name> -o jsonpath='{.status.capacity}{"\n"}{.status.allocatable}{"\n"}'
+```
+
+The Capacity-minus-Allocatable delta equals `kubeReserved + systemReserved + evictionHard.memory.available`; on the affected cluster that is `1904Mi` (`902Mi + 902Mi + 100Mi`), consistent across all four Nodes [ev:c2].
+
+Cross-check utilization against scheduled requests. `kubectl top node` reports instantaneous utilization from the `metrics.k8s.io/v1beta1` `NodeMetrics` API and will routinely show a much lower number than the `describe node` Requests column when workloads request more than they actually use [ev:c5_a]:
+
+```bash
+kubectl top node <node-name>
+```
+
+A wide gap between the top reading and the `describe node` Requests percentage is the canonical signature of the utilization-vs-requests confusion behind this symptom; trust the Requests column for scheduling decisions [ev:c5_b].


### PR DESCRIPTION
ACP-native solution, re-verified on a live cluster (Kubernetes v1.34.5). Asserts only runtime-verified claims, with concrete version/namespace anchors and per-paragraph evidence references.