### PR TITLE
[virtualization] Live-migrated virt-launcher pods stay in Completed and block RWO PVC deletion

### DIFF
--- a/docs/en/solutions/Live_migrated_virt_launcher_pods_stay_in_Completed_and_block_RWO_PVC_deletion.md
+++ b/docs/en/solutions/Live_migrated_virt_launcher_pods_stay_in_Completed_and_block_RWO_PVC_deletion.md
@@ -1,0 +1,108 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Live-migrated virt-launcher pods stay in Completed and block RWO PVC deletion
+
+## Issue
+
+On Alauda Container Platform (Kubernetes `v1.34.5-1`, KubeVirt ModulePlugin `v1.7.0-alauda.2`, HCO operator `1.17.0`, virt-launcher image `registry.alauda.cn:60080/3rdparty/kubevirt/virt-launcher:v1.7.0-alauda.2`), after every successful live migration of a VirtualMachineInstance the source-node `virt-launcher-<vmi>-<suffix>` Pod is left in `STATUS=Completed` (Pod phase `Succeeded`) instead of being deleted; a fresh Pod on the migration target node takes over and runs the VMI. Repeated migrations of the same VMI therefore accumulate N Completed Pods alongside exactly one Running Pod in the VM's namespace, all sharing the same `virt-launcher-<vmi>-` prefix. The diagnostic pattern matches `kubectl get pods` showing many rows with `STATUS=Completed` and `READY=0/3` plus one row with `STATUS=Running` and `READY=3/3` (the `0/3` and `3/3` reflect that virt-launcher `v1.7.0-alauda.2` runs three containers per Pod — `compute`, `volumecontainerdisk`, and a sidecar; the relevant signal is "many Succeeded, one Running").
+
+A secondary symptom appears for any VM that mounts a `ReadWriteOnce` PersistentVolumeClaim — most commonly the auto-provisioned vTPM backing PVC, but the behavior is generic: a PVC referenced by one of those leftover Completed Pods stays `STATUS=Terminating` after `kubectl delete pvc`, because the standard `kubernetes.io/pvc-protection` finalizer remains on `metadata.finalizers` until every Pod that mounts the PVC is gone.
+
+## Root Cause
+
+VirtualMachineInstanceMigration (`virtualmachineinstancemigrations.kubevirt.io/v1`, abbreviated VMIM in the UI; the upstream kind name is `VirtualMachineInstanceMigration`, not `VirtualMachineMigrationInstance`) is a per-migration object that tracks one VMI's move from a source host to a target host. The migration's progress is mirrored on `virtualmachineinstance.status.migrationState`, which carries `sourceNode`, `sourcePod`, `targetNode`, `targetPod`, `migrationUid`, and `completed` fields — the controller therefore distinguishes the source-side Pod from the target-side Pod throughout the migration. When migration completes successfully, libvirt is torn down on the source virt-launcher Pod and its `compute` / `volumecontainerdisk` containers exit cleanly with `exitCode=0` `reason=Completed`; KubeVirt does not delete the Pod object.
+
+The VMIM objects themselves are garbage-collected: virt-controller retains only the most recent five Succeeded/Failed VMIMs per VMI. On a verification run that executed nine sequential `VirtualMachineInstanceMigration` resources against the same VMI, exactly five VMIM objects survived (the five most recent by `creationTimestamp`); the first four were deleted automatically. This retention threshold is hard-coded in the upstream virt-controller — `spec.configuration.migrations` on the cluster's `kubevirt` resource exposes `allowAutoConverge`, `allowPostCopy`, `completionTimeoutPerGiB`, `parallelMigrationsPerCluster`, `progressTimeout`, and `parallelOutboundMigrationsPerNode`, but no retention or completed-Pod-GC field, so the threshold is not tunable from the HyperConverged CR. The same is true for the launcher-Pod cleanup itself: `virt-controller`'s container args expose `--launcher-image`, `--exporter-image`, `--port`, and `-v`, with no `--completed-pod-gc` or equivalent flag.
+
+The Completed Pods are tied to the VMI's lifecycle, not the VMIM's. Stopping the VM (which triggers VMI deletion, either via `virtctl stop` or via `kubectl patch vm <name> --type=merge -p '{"spec":{"runStrategy":"Halted"}}'`) cascades into deletion of every `virt-launcher-<vmi>-<suffix>` Pod: in the same verification run, the namespace went from ten Pods (nine Completed + one Running) to zero immediately after the VMI was removed, and the five surviving VMIMs were also cleaned up by owner-reference cascade.
+
+The Terminating-PVC symptom is core Kubernetes behavior, not KubeVirt-specific. `pvc.metadata.finalizers` is declared as "must be empty before the object is deleted from the registry" — `kubectl explain pvc.metadata.finalizers` confirms the shape — and the `kubernetes.io/pvc-protection` finalizer is added automatically by `kube-controller-manager` to any PVC referenced by a Pod. Reproducing the mechanism with an ordinary `topolvm-hdd` RWO PVC mounted by a long-running Pod yielded `STATUS=Terminating` immediately after `kubectl delete pvc --wait=false`, with `metadata.deletionTimestamp` set and `metadata.finalizers=["kubernetes.io/pvc-protection"]` still present until the holding Pod was removed. The vTPM case in the original report is just the most visible instance of this rule: a vTPM-enabled VM auto-provisions an RWO PVC, and the leftover Completed launcher Pods still reference it, so the PVC waits on `pvc-protection` exactly like any other RWO PVC with a live referrer.
+
+## Resolution
+
+The accumulated Completed `virt-launcher-<vmi>-<suffix>` Pods are inert — their containers have already exited with `exitCode=0` and consume no CPU or memory beyond the Pod object's apiserver/etcd footprint — so leaving them in place until the VM is next stopped is a valid operating posture; the cleanest deletion path is to let the VMI teardown handle them in one shot.
+
+When a faster reclaim is desired (most often to unblock a Terminating RWO PVC referenced by one of the Completed launcher Pods), delete the Completed Pods directly. The remaining Running virt-launcher Pod is unaffected and the VM keeps running; a verification deletion of one Completed launcher Pod left the VMI's currently-running launcher Pod `Running 3/3` throughout. Scope the delete to the Pods that are not running the VMI by selecting on `status.phase=Succeeded` so the Running launcher is never matched:
+
+```bash
+# list Completed virt-launcher Pods for one VM
+kubectl get pods -n <vm-namespace> \
+  --field-selector=status.phase=Succeeded \
+  -l kubevirt.io/vm=<vm-name>
+
+# delete them
+kubectl delete pods -n <vm-namespace> \
+  --field-selector=status.phase=Succeeded \
+  -l kubevirt.io/vm=<vm-name>
+```
+
+For ongoing housekeeping, schedule the same delete as a Kubernetes `CronJob` (`batch/v1`, registered on this platform) running in the VM's namespace. The Pod field selector `status.phase=Succeeded` is the same primitive Kubernetes uses for any "finished pod" cleanup and is honored by the apiserver here (server-side dry-run of such a CronJob is accepted, and the field selector returns the expected list of Succeeded Pods cluster-wide). The job's ServiceAccount needs `get` / `list` / `delete` on `pods` in its namespace:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cleanup-completed-virt-launcher
+  namespace: <vm-namespace>
+spec:
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: launcher-cleanup
+          restartPolicy: OnFailure
+          containers:
+            - name: kubectl
+              image: <registry>/kubectl:<tag>
+              command:
+                - /bin/sh
+                - -c
+                - >
+                  kubectl get pods -n <vm-namespace>
+                  --field-selector=status.phase=Succeeded
+                  -l kubevirt.io/vm
+                  -o name | xargs -r kubectl delete -n <vm-namespace>
+```
+
+Use the `-l kubevirt.io/vm` label selector (every virt-launcher Pod carries it, stamped on by virt-controller) to restrict deletion to KubeVirt-owned Pods and avoid sweeping up unrelated Succeeded Pods such as one-shot Jobs.
+
+For a Terminating RWO PVC that is held only by a Completed virt-launcher Pod, deleting that launcher Pod removes the last referrer, `kube-controller-manager` strips the `kubernetes.io/pvc-protection` finalizer, and the PVC's deletion completes without further intervention.
+
+## Diagnostic Steps
+
+Confirm the symptom against one VM. The expected shape is many Completed Pods (`READY=0/3`) plus exactly one Running Pod (`READY=3/3`), all prefixed `virt-launcher-<vmi>-`:
+
+```bash
+kubectl get pods -n <vm-namespace> -l kubevirt.io/vm=<vm-name> -o wide
+```
+
+Cross-reference Completed Pods against the migration history. On this build, `virtualmachineinstancemigrations.kubevirt.io` retains only the last five VMIMs per VMI, so the count of Completed virt-launcher Pods will typically exceed the count of surviving VMIMs after the sixth migration onward; this is expected, not a leak:
+
+```bash
+kubectl get virtualmachineinstancemigration -n <vm-namespace> \
+  --sort-by=.metadata.creationTimestamp
+kubectl get vmi <vm-name> -n <vm-namespace> \
+  -o jsonpath="{.status.migrationState}{'\n'}"
+```
+
+The `migrationState` field is the structural marker for the source/target split — its `sourcePod` and `targetPod` names map directly to the Completed and Running Pods listed above.
+
+For the Terminating-PVC case, list the Pods currently mounting the PVC; any Pod (Running or Completed) still referencing it will hold the `kubernetes.io/pvc-protection` finalizer in place:
+
+```bash
+kubectl get pvc <pvc-name> -n <vm-namespace> \
+  -o jsonpath="{.metadata.deletionTimestamp} finalizers={.metadata.finalizers}{'\n'}"
+
+kubectl get pods -n <vm-namespace> \
+  -o jsonpath='{range .items[?(@.spec.volumes[*].persistentVolumeClaim.claimName=="<pvc-name>")]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}'
+```
+
+Once the referrer Pods are deleted (manually or via the CronJob above), the PVC's `metadata.finalizers` array empties and the apiserver removes the object.

--- a/docs/en/solutions/virt_launcher_Pods_Remain_in_Completed_State_After_Live_Migration.md
+++ b/docs/en/solutions/virt_launcher_Pods_Remain_in_Completed_State_After_Live_Migration.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# virt-launcher Pods Remain in Completed State After Live Migration
 ## Overview
 
 After several successive live migrations of a VirtualMachine, the cluster accumulates multiple `virt-launcher-<vm>-<hash>` pods in `Completed` state alongside the single `Running` pod that currently hosts the VM:

--- a/docs/en/solutions/virt_launcher_Pods_Remain_in_Completed_State_After_Live_Migration.md
+++ b/docs/en/solutions/virt_launcher_Pods_Remain_in_Completed_State_After_Live_Migration.md
@@ -1,0 +1,122 @@
+---
+kind:
+   - Information
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Overview
+
+After several successive live migrations of a VirtualMachine, the cluster accumulates multiple `virt-launcher-<vm>-<hash>` pods in `Completed` state alongside the single `Running` pod that currently hosts the VM:
+
+```text
+virt-launcher-fedora-skilled-bonobo-dljkv   0/1  Completed  0  12m
+virt-launcher-fedora-skilled-bonobo-k6t92   1/1  Running    0  11s
+virt-launcher-fedora-skilled-bonobo-lx2th   0/1  Completed  0  54s
+virt-launcher-fedora-skilled-bonobo-qdkmk   0/1  Completed  0  84s
+virt-launcher-fedora-skilled-bonobo-qk5qt   0/1  Completed  0  33s
+```
+
+This is the expected behaviour of the current KubeVirt implementation — not a failure mode — but it can look alarming on a busy VM page and has one real operational consequence around vTPM PVCs.
+
+## Root Cause
+
+Each live migration spins up a **target** `virt-launcher` pod before the source hands off the running VM. Once the handoff completes, the source pod terminates gracefully and enters `Completed`. KubeVirt intentionally does **not** garbage-collect the source pod: operators may need the source's logs to diagnose a migration that later turns out to have degraded the workload, and the Completed pod holds a reference to any PVCs the source had mounted.
+
+KubeVirt does garbage-collect the `VirtualMachineInstanceMigration` objects (keeping only the most recent few), and the Completed pods are all torn down automatically when the VMI itself is deleted (VM stop). A VM that migrates N times during its lifetime will therefore retain N-1 Completed pods until it is stopped.
+
+The one side-effect worth acting on is **vTPM**. A vTPM persistent-state PVC is declared `ReadWriteOnce` because the vTPM state must be owned by a single live QEMU process at a time. While a Completed source pod still exists, it still holds a `VolumeAttachment` reference, and the PVC cannot finalise a `Terminating` state. This is visible as a PVC that appears stuck deleting.
+
+## Resolution
+
+Decide between leaving the pods alone (recommended for steady-state clusters) and automating a cleanup.
+
+1. **Leave them be for short-lived VMs.** A VM that is destined to be stopped anyway will cleanse itself when stopped; no action is needed.
+
+2. **Schedule a cleanup CronJob for long-lived VMs** that migrate frequently (HPA-driven workloads, GPU partners with heavy NUMA rebalancing). Keep the Job RBAC narrow — only the verbs needed to delete pods in the VM namespaces:
+
+   ```yaml
+   apiVersion: batch/v1
+   kind: CronJob
+   metadata:
+     name: virt-launcher-completed-gc
+     namespace: virt-launcher-gc
+   spec:
+     schedule: "17 */6 * * *"     # every 6 hours at :17
+     concurrencyPolicy: Forbid
+     successfulJobsHistoryLimit: 1
+     jobTemplate:
+       spec:
+         backoffLimit: 0
+         ttlSecondsAfterFinished: 600
+         template:
+           spec:
+             serviceAccountName: virt-launcher-gc
+             restartPolicy: Never
+             containers:
+               - name: gc
+                 image: bitnami/kubectl:1.33
+                 command:
+                   - /bin/sh
+                   - -ec
+                   - |
+                     kubectl get pod -A \
+                       -l kubevirt.io=virt-launcher \
+                       --field-selector status.phase=Succeeded \
+                       -o json \
+                     | jq -r '.items[]
+                         | select((now - ((.status.containerStatuses[]?.state.terminated.finishedAt // .metadata.creationTimestamp) | fromdateiso8601)) > 3600)
+                         | "\(.metadata.namespace) \(.metadata.name)"' \
+                     | while read ns name; do
+                         echo "deleting $ns/$name"
+                         kubectl -n "$ns" delete pod "$name" --ignore-not-found
+                       done
+   ```
+
+   The filter above only deletes pods that have been in `Succeeded` for more than an hour, which leaves a grace window for investigating a recently-migrated VM.
+
+3. **Unstick a Terminating vTPM PVC** by deleting the Completed source pod that still references it. Confirm the running pod is healthy first:
+
+   ```bash
+   NS=<vm-ns>; VM=<vm-name>
+   kubectl -n "$NS" get pod -l kubevirt.io=virt-launcher,vm.kubevirt.io/name="$VM" -o wide
+   kubectl -n "$NS" get pvc | grep -i tpm
+   kubectl -n "$NS" delete pod <stale-completed-pod>
+   ```
+
+   If the PVC still refuses to finalise, inspect `kubectl -n <ns> get volumeattachment` for stale attachments and follow up on the CSI driver side.
+
+4. **Scope the cleanup carefully.** The filter must match *only* Completed `virt-launcher` pods. A broader `--field-selector status.phase=Succeeded` applied across all namespaces will also delete Job pods and other Succeeded workloads that the cluster is still using as audit references.
+
+## Diagnostic Steps
+
+Count Completed virt-launcher pods per VM:
+
+```bash
+kubectl get pod -A -l kubevirt.io=virt-launcher \
+  --field-selector status.phase=Succeeded \
+  -o json \
+| jq -r '.items[] | "\(.metadata.namespace)/\(.metadata.labels["vm.kubevirt.io/name"])"' \
+| sort | uniq -c | sort -rn | head
+```
+
+Identify Completed pods older than an hour (cleanup candidates):
+
+```bash
+kubectl get pod -A -l kubevirt.io=virt-launcher \
+  --field-selector status.phase=Succeeded \
+  -o json \
+| jq -r '.items[]
+    | select((now - (.metadata.creationTimestamp | fromdateiso8601)) > 3600)
+    | "\(.metadata.namespace)\t\(.metadata.name)"'
+```
+
+Confirm a stuck PVC is being held by a Completed source pod, not by the Running one:
+
+```bash
+NS=<vm-ns>; PVC=<pvc>
+kubectl -n "$NS" describe pvc "$PVC" | grep -i used-by -A5
+```
+
+If the `Used By` line lists more than one pod, the extras are the Completed source pods; remove them in order from oldest to newest. If `Used By` lists only the currently-Running pod and the PVC still fails to finalise, the issue is not the Completed-pod behaviour described here — investigate the CSI driver's detach path.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
