### PR TITLE
[virtualization] KubeVirt live migration fails between nodes with different CPU models on ACP

### DIFF
--- a/docs/en/solutions/KubeVirt_live_migration_fails_between_nodes_with_different_CPU_models_on_ACP.md
+++ b/docs/en/solutions/KubeVirt_live_migration_fails_between_nodes_with_different_CPU_models_on_ACP.md
@@ -1,0 +1,54 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# KubeVirt live migration fails between nodes with different CPU models on ACP
+
+## Issue
+
+On Alauda Container Platform Virtualization for KubeVirt (plugin `kubevirt-hyperconverged-operator.v4.3.5`, KubeVirt `v1.7.0-alauda.1`, HCO installed in the `kubevirt` namespace), a cluster whose nodes carry different physical CPU types cannot reliably live-migrate every VM between arbitrary nodes. A VirtualMachine whose `spec.template.spec.domain.cpu.model` is left at the `host-model` default takes on the exact CPU model of the node it was scheduled onto, so it is only able to migrate to a node that also supports that same model. When the nodes do not share a common model, a VM pinned to a model that exists on only one node has no compatible migration target.
+
+## Root Cause
+
+The KubeVirt node-labeller records, per node, which CPU models that node natively supports for VM scheduling using `cpu-model.node.kubevirt.io/<model>` labels. It separately records which CPU models a node can accept as a live-migration target using `cpu-model-migration.node.kubevirt.io/<model>` labels. On a heterogeneous cluster these label families do not advertise the same models on every node — the scheduling label sets differ from node to node, reflecting the differing physical CPUs.
+
+The migration label set on a node is a strict superset of, and can differ from, that node's scheduling label set. A node can therefore advertise a model under `cpu-model-migration.node.kubevirt.io/<model>` (it can host that model as a migration target) while not advertising the same model under `cpu-model.node.kubevirt.io/<model>` (it would not schedule a new VM onto that model). Because a `host-model` VM pins to the exact model of its scheduling node, the combination of pinned model and divergent per-node label sets is what leaves a VM without a usable migration target.
+
+## Resolution
+
+Set a cluster-wide default CPU model that is common to all nodes, choosing the latest CPU model present in the scheduling labels of every node. The `HyperConverged` CR (`hco.kubevirt.io/v1beta1`) exposes `spec.defaultCPUModel`, which is empty by default; while it is unset and a VM leaves its CPU model unset, the VM falls back to `host-model` and pins to its scheduling node. Setting `defaultCPUModel` to a model that every node advertises for scheduling gives all VMs a portable model so they can migrate across the heterogeneous nodes.
+
+Apply the value to the singleton `HyperConverged` CR in the `kubevirt` namespace:
+
+```bash
+kubectl patch hyperconverged -n kubevirt kubevirt-hyperconverged \
+  --type merge \
+  -p '{"spec":{"defaultCPUModel":"<model-common-to-all-nodes>"}}'
+```
+
+Choose the model carefully: a model that appears only in the `cpu-model-migration.node.kubevirt.io` labels but not in any `cpu-model.node.kubevirt.io` scheduling label has no scheduling label for the scheduler to match, so setting it as `defaultCPUModel` may leave a VM unable to start or schedule. Restrict the chosen value to models that are present in the scheduling label set of every node.
+
+## Diagnostic Steps
+
+Enumerate the CPU models each node advertises for scheduling by reading the `cpu-model.node.kubevirt.io` labels across the nodes; the leading count from `uniq -c` is the number of nodes advertising that model, and a model whose count is below the total node count is not common to all nodes:
+
+```bash
+kubectl get nodes -l kubernetes.io/os=linux -o yaml \
+  | grep 'cpu-model.node.kubevirt.io' \
+  | sort | uniq -c
+```
+
+To choose a safe `defaultCPUModel`, compare the scheduling labels against the migration labels on the same node. A model that shows up only under `cpu-model-migration.node.kubevirt.io` is a migration-target-only model and must not be selected as the default:
+
+```bash
+kubectl get node <node> -o yaml \
+  | grep -E 'cpu-model(-migration)?\.node\.kubevirt\.io' \
+  | sort
+```
+
+A model that is present under `cpu-model.node.kubevirt.io` on every node is a valid common scheduling model and is a safe candidate for `defaultCPUModel`.

--- a/docs/en/solutions/Live_Migration_Fails_When_Worker_Nodes_Have_Different_CPU_Models.md
+++ b/docs/en/solutions/Live_Migration_Fails_When_Worker_Nodes_Have_Different_CPU_Models.md
@@ -1,0 +1,107 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A VirtualMachine live migration stops with:
+
+```text
+Migration cannot proceed since no node is suitable to run the required CPU model
+```
+
+The source node is healthy, the candidate target nodes are not cordoned, and the VM runs fine. The error appears only during migration, typically in clusters whose worker pool is not CPU-homogeneous (e.g. a first wave of Skylake hosts plus a newer wave of Sapphire Rapids).
+
+## Root Cause
+
+KubeVirt schedules VMs based on two separate sets of node labels that describe CPU capabilities:
+
+- `cpu-model.node.kubevirt.io/<model>=true` — CPU models the node can **run** natively. Used when scheduling a VM for the first time.
+- `cpu-model-migration.node.kubevirt.io/<model>=true` — CPU models the node can accept as a **live-migration target**. A subset of, or sometimes larger than, the run list.
+
+A VM whose `spec.template.spec.domain.cpu.model` is `host-model` (the common default) is pinned to the CPU generation of the node it originally landed on. During live migration, KubeVirt looks for a target that carries a compatible `cpu-model-migration.node.kubevirt.io/<model>` label. If every candidate target runs on a different generation — or the candidate is newer but migration compatibility was not labelled — the scheduler returns the error above and the migration fails.
+
+This is a hypervisor-level constraint, not a KubeVirt bug: migrating a guest expecting AVX-512 onto a host without AVX-512 would SIGILL the guest at the next vectorised instruction.
+
+## Resolution
+
+Pick a stable lowest-common-denominator CPU model across the worker fleet and pin every VM to it explicitly. The label-based approach scales across heterogeneous clusters.
+
+1. **Survey the available CPU models.** Intersect `cpu-model-migration.node.kubevirt.io/*` labels across workers. The lowest model that every worker supports is the one to standardise on:
+
+   ```bash
+   kubectl get node -l node-role.kubernetes.io/worker= -o yaml \
+     | grep 'cpu-model-migration.node.kubevirt.io' \
+     | sort | uniq -c | sort -rn \
+     | awk -v workers="$(kubectl get node -l node-role.kubernetes.io/worker= --no-headers | wc -l)" \
+           '$1 == workers {print $2}'
+   ```
+
+   The list returned is the set of models every worker supports for migration — any entry here is a safe choice.
+
+2. **Set the cluster-wide default.** Configure the KubeVirt/HyperConverged default CPU model so new VMs inherit a compatible setting. Use a value from the survey above, leaning toward the newest common model to avoid giving up features needlessly:
+
+   ```yaml
+   apiVersion: kubevirt.io/v1
+   kind: KubeVirt
+   metadata:
+     name: kubevirt
+     namespace: kubevirt
+   spec:
+     configuration:
+       cpuModel: Cascadelake-Server-v5   # example; substitute the intersection result
+   ```
+
+   Changing the default only affects VMs created afterwards. Existing VMs keep whatever `cpu.model` they were created with — including `host-model`, which is the thing causing the migration failure.
+
+3. **Convert existing VMs away from `host-model`.** For each VM that needs to live-migrate, pin it to the common model:
+
+   ```yaml
+   spec:
+     template:
+       spec:
+         domain:
+           cpu:
+             model: Cascadelake-Server-v5  # use the common model you picked
+   ```
+
+   Apply the change and schedule a graceful reboot of the VM (`virtctl restart`). Live migration will not succeed while the VM is still running against `host-model` — the existing libvirt process has already committed to the source's CPU generation.
+
+4. **Avoid configuring `defaultCPUModel` to something only present in the migration labels.** If the chosen model is in `cpu-model-migration.node.kubevirt.io/<model>` but absent from `cpu-model.node.kubevirt.io/<model>` on every worker, new VMs will fail to schedule initially — the migration-compatibility set is *larger* than the native-run set on some QEMU versions.
+
+5. **Plan the fleet upgrade path.** Adding a new generation of workers is a planning moment: pre-label them with the migration compatibility labels before scheduling VMs onto them. Otherwise the first drain of the old generation will find no migration target.
+
+## Diagnostic Steps
+
+Check the current CPU model of the failing VM:
+
+```bash
+kubectl -n <ns> get vm <vm> -o jsonpath='{.spec.template.spec.domain.cpu}{"\n"}'
+# likely prints: {"cores":4,"model":"host-model"}
+```
+
+Look at each worker's migration labels for the model the VM demands:
+
+```bash
+MODEL=$(kubectl -n <ns> get vmi <vm> \
+          -o jsonpath='{.status.currentCPUModel}')
+echo "VM wants: $MODEL"
+
+kubectl get node -l node-role.kubernetes.io/worker= \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.cpu-model-migration\.node\.kubevirt\.io/'"$MODEL"'}{"\n"}{end}'
+```
+
+Nodes that return `true` are valid targets; nodes that return an empty string are not. If no node returns `true`, the migration cannot succeed until the fleet is either labelled or the VM is repinned.
+
+If all workers appear to have the label but migration still fails, check whether the target is under other constraints — taints, resource pressure, PDBs, or affinity rules that exclude it from this VM's candidate set:
+
+```bash
+kubectl get vmim -n <ns> <migration-object> -o yaml
+kubectl describe vmi -n <ns> <vm>
+```
+
+Events on the VMI describe the scheduler's refusal more specifically than the generic "no node suitable" message.

--- a/docs/en/solutions/Live_Migration_Fails_When_Worker_Nodes_Have_Different_CPU_Models.md
+++ b/docs/en/solutions/Live_Migration_Fails_When_Worker_Nodes_Have_Different_CPU_Models.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Live Migration Fails When Worker Nodes Have Different CPU Models
 ## Issue
 
 A VirtualMachine live migration stops with:


### PR DESCRIPTION
新增一篇 ACP KB 文章。
