### PR TITLE
[networking] Localising ingress request latency on ACP with curl timing and an LB-bypass probe

### DIFF
--- a/docs/en/solutions/Localising_Ingress_Latency_Is_It_the_External_Load_Balancer_or_the_Gateway_Pods.md
+++ b/docs/en/solutions/Localising_Ingress_Latency_Is_It_the_External_Load_Balancer_or_the_Gateway_Pods.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Localising Ingress Latency — Is It the External Load Balancer or the Gateway Pods?
 ## Overview
 
 Requests to an application reachable at `*.apps.<cluster>.example.com` intermittently time out or slow down. The path in front of every exposed application typically has three hops:

--- a/docs/en/solutions/Localising_Ingress_Latency_Is_It_the_External_Load_Balancer_or_the_Gateway_Pods.md
+++ b/docs/en/solutions/Localising_Ingress_Latency_Is_It_the_External_Load_Balancer_or_the_Gateway_Pods.md
@@ -1,0 +1,118 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Overview
+
+Requests to an application reachable at `*.apps.<cluster>.example.com` intermittently time out or slow down. The path in front of every exposed application typically has three hops:
+
+```text
+client → external load balancer (hardware or software LB) → ingress gateway pods → service pods
+```
+
+A single latency spike in any of those hops shows up the same way at the client: slow or failed HTTP. To fix it you have to localise it. The technique below spins up two long-running probes that sample the same URL:
+
+- one **through** the external load balancer (the normal path),
+- one **bypassing** the external load balancer, hitting each ingress gateway pod directly via TLS SNI.
+
+If the bypass is fast but the LB-fronted probe is slow, the problem is the LB. If both are slow, the gateway pods (or what they are routing to) are at fault.
+
+## Resolution
+
+The probes run in a dedicated namespace so cleanup is a single `kubectl delete ns`.
+
+1. **Create the workspace.**
+
+   ```bash
+   kubectl create namespace ingress-latency-probe
+   ```
+
+2. **Export the URL you want to probe and the gateway pod IPs.** Pick any reliable health endpoint that the gateway routes to — the cluster authentication `/healthz` is common, but any stable backend path works. For ACP the gateway pods typically live under the `cpaas-system` namespace with a selector like `service=alb-operator`; adjust for your installation.
+
+   ```bash
+   URL=https://auth.apps.example.com/healthz
+
+   GATEWAY_NS=cpaas-system       # ACP ALB namespace; edit for your platform
+   GATEWAY_SELECTOR=service=alb-operator
+
+   GATEWAY_IPS=$(kubectl -n $GATEWAY_NS get pod -l $GATEWAY_SELECTOR \
+                   -o jsonpath='{range .items[*]}{.status.hostIP}{"\n"}{end}' \
+                 | sort -u)
+   echo "$GATEWAY_IPS"
+   ```
+
+3. **Run the LB-fronted probe** — this is what your users see. It records per-request latency and HTTP response code:
+
+   ```bash
+   kubectl -n ingress-latency-probe run curl-lb --restart=Never \
+     --image=curlimages/curl:8.10.1 --command -- sh -ec '
+       while :; do
+         curl -sk --noproxy "*" --connect-timeout 2 \
+           -w "remote_ip=%{remote_ip} code=%{response_code} connect=%{time_connect} total=%{time_total}\n" \
+           -o /dev/null "'$URL'" || true
+         sleep 5
+       done'
+   ```
+
+4. **Run the bypass probe** — same URL, but resolve the hostname to each gateway IP in turn via `curl --resolve`. TLS SNI still matches the certificate because the Host header and SNI host stay the same.
+
+   ```bash
+   kubectl -n ingress-latency-probe run curl-bypass --restart=Never \
+     --image=curlimages/curl:8.10.1 --command -- sh -ec '
+       HOST=$(printf "%s" "'$URL'" | awk -F/ "{print \$3}")
+       while :; do
+         for ip in '"$(echo $GATEWAY_IPS | tr "\n" " ")"'; do
+           curl -sk --noproxy "*" --connect-timeout 2 \
+             --resolve "$HOST:443:$ip" \
+             -w "remote_ip=%{remote_ip} code=%{response_code} connect=%{time_connect} total=%{time_total}\n" \
+             -o /dev/null "'$URL'" || true
+         done
+         sleep 5
+       done'
+   ```
+
+5. **Compare the two.** Tail both logs for a few minutes while the issue is reproducing:
+
+   ```bash
+   kubectl -n ingress-latency-probe logs curl-lb     --tail=50 -f &
+   kubectl -n ingress-latency-probe logs curl-bypass --tail=50 -f
+   ```
+
+6. **Interpret the result.**
+
+   | `curl-lb` | `curl-bypass` | Conclusion |
+   |---|---|---|
+   | fast | fast | Latency originates further upstream of the LB — client network, DNS, or the client itself. |
+   | slow | fast | External LB (or its health checks, SNAT rules, connection reuse) is the bottleneck. Work with the LB owner. |
+   | fast | slow on one pod | That single gateway pod is degraded. Cordon/drain its node or restart the pod. |
+   | slow | slow on every pod | The gateway plane or its downstream is the issue — check gateway pod CPU/memory, backend service latency, or cluster network. |
+
+7. **Clean up** when the investigation is done:
+
+   ```bash
+   kubectl delete namespace ingress-latency-probe
+   ```
+
+## Diagnostic Steps
+
+If both probes show clean runs but users still complain, the problem is almost certainly outside the path this probe covers. Useful next steps:
+
+- Confirm the probe pods resolve the same DNS name the client does:
+
+  ```bash
+  kubectl -n ingress-latency-probe run curl-dns --rm -it \
+    --image=curlimages/curl:8.10.1 --restart=Never \
+    -- sh -c 'getent hosts auth.apps.example.com; nslookup auth.apps.example.com'
+  ```
+
+- Run a client-side trace from outside the cluster (`mtr`, `traceroute`) to rule out an upstream WAN issue.
+
+- For the LB-fronted side, have the LB owner capture packets on its ingress side while the probe is running; a parallel capture on the gateway pod node confirms where the delay is introduced.
+
+- Check the gateway's own metrics: request rate, request duration P99, pod CPU throttling, upstream RTT. A degraded backend looks identical to a slow gateway from the probe's perspective — `--bypass` does not isolate gateway-vs-backend, only LB-vs-gateway.
+
+Treat the probe pods as short-lived. Leaving them running indefinitely is fine operationally but the loop runs forever — delete the namespace when finished to avoid surprise costs on the LB.

--- a/docs/en/solutions/Localising_Ingress_Latency_Is_It_the_External_Load_Balancer_or_the_Gateway_Pods.md
+++ b/docs/en/solutions/Localising_Ingress_Latency_Is_It_the_External_Load_Balancer_or_the_Gateway_Pods.md
@@ -31,13 +31,13 @@ The probes run in a dedicated namespace so cleanup is a single `kubectl delete n
    kubectl create namespace ingress-latency-probe
    ```
 
-2. **Export the URL you want to probe and the gateway pod IPs.** Pick any reliable health endpoint that the gateway routes to — the cluster authentication `/healthz` is common, but any stable backend path works. For ACP the gateway pods typically live under the `cpaas-system` namespace with a selector like `service=alb-operator`; adjust for your installation.
+2. **Export the URL you want to probe and the gateway pod IPs.** Pick any reliable health endpoint that the gateway routes to — the cluster authentication `/healthz` is common, but any stable backend path works. For ACP the gateway pods live under the `cpaas-system` namespace; the dataplane pods (`global-alb2-*`) carry the label `alb2.cpaas.io/pod_type=alb`. The `alb-operator-ctl-*` pod is the controller and is not on the data path — do not point the bypass probe at it.
 
    ```bash
    URL=https://auth.apps.example.com/healthz
 
    GATEWAY_NS=cpaas-system       # ACP ALB namespace; edit for your platform
-   GATEWAY_SELECTOR=service=alb-operator
+   GATEWAY_SELECTOR=alb2.cpaas.io/pod_type=alb
 
    GATEWAY_IPS=$(kubectl -n $GATEWAY_NS get pod -l $GATEWAY_SELECTOR \
                    -o jsonpath='{range .items[*]}{.status.hostIP}{"\n"}{end}' \

--- a/docs/en/solutions/Localising_ingress_request_latency_on_ACP_with_curl_timing_and_an_LB_bypass_probe.md
+++ b/docs/en/solutions/Localising_ingress_request_latency_on_ACP_with_curl_timing_and_an_LB_bypass_probe.md
@@ -1,0 +1,61 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Localising ingress request latency on ACP with curl timing and an LB-bypass probe
+
+## Issue
+
+Slow or intermittently slow HTTPS requests that arrive over the ingress wildcard domain can have their delay introduced at one of several distinct hops on the path between client and backend: the external load balancer that sits in front of the cluster, the ingress data-plane pods that terminate the request, or the backend application itself. On Alauda Container Platform the in-cluster ingress data plane is the ALB front of class `global-alb2` (controller `cpaas.io/alb2`), reachable on its node host address (the `ADDRESS` shown for Ingress objects on that class), with the HTTPS listener served by the ALB frontend `global-alb2-00443` on port 443; the external load balancer, by contrast, is not a cluster object and can only be observed indirectly through the timing comparison below.
+
+## Root Cause
+
+Because the external load balancer is outside the cluster and the ingress data plane is inside it, a single end-to-end timing measurement cannot, on its own, say which hop is responsible for elevated latency. Where the latency originates is localised by sending the same HTTP probe two ways — once through the external load balancer along the normal client path, and once bypassing it so the request lands directly on the ingress data-plane pod — and reading which of the two paths carries the elevated timing.
+
+## Resolution
+
+Use `curl` with `--write-out` to expose per-request timing for each path. The fields `%{time_connect}` and `%{time_total}` give the TCP-connect time and the total request time, and `%{remote_ip}`, `%{local_ip}` and `%{response_code}` confirm which endpoint actually answered; this instrumentation is libcurl-generic and works in any image that ships `curl`, with no platform-specific dependency. A typical probe form is:
+
+```bash
+curl -sS -o /dev/null \
+  -w 'connect=%{time_connect} total=%{time_total} remote=%{remote_ip} local=%{local_ip} code=%{response_code}\n' \
+  https://<ingress-host>/
+```
+
+The through-the-load-balancer probe resolves the endpoint hostname normally via DNS, so the request traverses the external load balancer before reaching the ingress data plane. A standing platform Ingress published on the `global-alb2` class (its host answers on the ingress address, port 443) makes a convenient always-present target for this leg, since it is reachable on the same wildcard ingress path that application traffic uses.
+
+The bypass probe pins the same hostname to a chosen ingress data-plane pod IP with `curl --resolve <host>:443:<ingress_pod_ip>`, so the identical request is sent straight to that pod and skips the external load balancer entirely. The pod IPs to pin against are the node host addresses of the ALB data-plane pods, which on ACP are enumerated directly with `kubectl`, reading the host IP from the data-plane pods (label `service_name=alb2-global-alb2`) in the `cpaas-system` namespace:
+
+```bash
+kubectl get pod -n cpaas-system -l service_name=alb2-global-alb2 \
+  -o jsonpath='{range .items[*]}{.status.hostIP}{"\n"}{end}'
+```
+
+```bash
+curl -sS -o /dev/null \
+  --resolve <ingress-host>:443:<ingress_pod_ip> \
+  -w 'connect=%{time_connect} total=%{time_total} remote=%{remote_ip} local=%{local_ip} code=%{response_code}\n' \
+  https://<ingress-host>/
+```
+
+Comparing the two outputs localises the hop: if the through-LB probe shows high `time_connect`/`time_total` while the bypass probe to the ingress data-plane pods stays fast, the latency is attributable to the external load balancer rather than to the ingress pods or the backend.
+
+## Diagnostic Steps
+
+To capture intermittent latency rather than a single sample, run the comparison continuously from a pod that loops the `curl` command and logs each result. The pod shape is a plain `kubectl run` driving a `while` loop around the timing `curl`; reading the pod logs with timestamps then builds a latency timeline that exposes when the slow path appears. This pod shape is a valid Pod on Kubernetes v1.34.5 and carries no platform-specific dependency, since the timing is pure libcurl `--write-out`. The ALB data-plane container image on this platform is `registry.alauda.cn:60080/acp/alb-nginx:v4.3.1`.
+
+```bash
+kubectl run ingress-latency-probe --image=<image-with-curl> --restart=Never -- \
+  sh -c 'while true; do \
+    curl -sS -o /dev/null \
+      -w "%(date)T connect=%{time_connect} total=%{time_total} code=%{response_code}\n" \
+      https://<ingress-host>/; \
+    sleep 5; done'
+```
+
+For a quick one-shot check without deploying anything, the same comparison can be run by `kubectl exec` into an existing pod that already ships `curl`, issuing the through-LB request and the `--resolve` bypass request back-to-back and comparing their reported timings.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
