### PR TITLE
[virtualization] KubeVirt live storage migration aborts when target PV is smaller than source PV

### DIFF
--- a/docs/en/solutions/KubeVirt_live_storage_migration_aborts_when_target_PV_is_smaller_than_source_PV.md
+++ b/docs/en/solutions/KubeVirt_live_storage_migration_aborts_when_target_PV_is_smaller_than_source_PV.md
@@ -1,0 +1,79 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# KubeVirt live storage migration aborts when target PV is smaller than source PV
+
+## Issue
+
+On Alauda Container Platform (Kubernetes `v1.34.5-1`, KubeVirt HyperConverged `kubevirt-kubevirt-hyperconverged` Phase `Deployed` in namespace `kubevirt`, `kubevirt-migration-controller` Running), a live storage migration of a virtual-machine disk fails inside the `virt-launcher` pod's QEMU process even though the source and target `PersistentVolumeClaim` requested identical storage capacity. The QEMU `-blockdev` initialization aborts with a message of the form:
+
+```text
+-blockdev {"driver":"raw","file":"libvirt-1-storage","offset":0,"size":<source-bytes>,...}:
+The sum of offset (0) and size (0) has to be smaller or equal to the actual size of the
+containing file (<target-bytes>)
+```
+
+The two byte values disagree by a fraction of a percent — for example, source `17,482,664,378,368` bytes vs. target `17,482,235,510,784` bytes (~409 MiB short) — despite the two PVCs sharing the same `.spec.resources.requests.storage` value.
+
+## Root Cause
+
+A dynamic storage provisioner must honour at least the requested PVC size, but is permitted to provision a `PersistentVolume` larger than the request. When the PVC uses `volumeMode: Block`, the bound `PersistentVolume` is mapped to the `virt-launcher` pod as a raw block device, and QEMU sees the **actual provisioned capacity of the PV**, not the requested PVC size. Live storage migration creates a fresh destination PVC (via the `VirtualMachineStorageMigrationPlan` CR's `targetMigrationPVCs[].destinationPVC`, where `volumeMode` is a first-class enum accepting `Block`). If the source PV was over-provisioned past the request by its provisioner while the destination PV was allocated more tightly, the destination's raw block device ends up smaller than the source's address space. QEMU detects this precondition violation before any data is copied and aborts the migration with the `offset (0) and size (0) has to be smaller or equal to the actual size of the containing file` error.
+
+The over-provisioning is real on ACP's default storage. On a lab cluster the default `StorageClass` `topolvm-hdd` (provisioner `topolvm.cybozu.com`, LVM-backed, 4 MiB physical extents) was issued a `Block` PVC requesting `1610612737` bytes; the bound `PersistentVolume` reported `.spec.capacity.storage = 1540Mi = 1614807040` bytes, i.e. `+4194303` bytes (one full LVM extent) over the request. A second `Block` PVC issued against the same `StorageClass` with a request only two bytes smaller (`1610612735`) bound to a PV reporting `1536Mi = 1610612736` bytes — a `4 MiB` divergence in actual provisioned capacity between two PVs whose `.spec.resources.requests.storage` values are byte-for-byte identical at the `Quantity` level. The same mechanism scales up to the ~409 MiB gap seen in the field when source and target use differently-tuned provisioners.
+
+## Diagnostic Steps
+
+The discrepancy is invisible at the PVC layer. Both the source and the destination PVC will report identical `.spec.resources.requests.storage`, and a `kubectl describe pvc` comparison will look healthy. The actual provisioned capacity surfaces on the bound `PersistentVolume`, not on the PVC, so the comparison must be done at the PV layer.
+
+Confirm the two PVCs requested the same storage:
+
+```bash
+kubectl -n <vm-namespace> get pvc <source-pvc> <target-pvc> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.spec.resources.requests.storage}{"\n"}{end}'
+```
+
+Then compare the actual capacity of the two bound PVs — this is where the mismatch becomes visible:
+
+```bash
+kubectl get pv \
+  -o jsonpath='{range .items[*]}{.metadata.name}{" capacity="}{.spec.capacity.storage}{" claim="}{.spec.claimRef.namespace}/{.spec.claimRef.name}{"\n"}{end}' \
+  | grep -E '<source-pvc>|<target-pvc>'
+```
+
+For `topolvm` specifically, the per-volume `LogicalVolume` CR exposes the underlying realized size and confirms how the request was rounded:
+
+```bash
+kubectl get logicalvolumes.topolvm.cybozu.com \
+  -o jsonpath='{range .items[*]}{.metadata.name}{": spec.size="}{.spec.size}{" status.currentSize="}{.status.currentSize}{"\n"}{end}'
+```
+
+If the source PV's `.spec.capacity.storage` is greater than the destination PV's, the live storage migration will hit the QEMU precondition every time it is retried until the destination is grown past the source.
+
+## Resolution
+
+Expand the destination PVC's storage request to a value greater than or equal to the actual byte count of the source PV (not the source PVC's request). The destination `StorageClass` must have `allowVolumeExpansion: true`; the default `topolvm-hdd` on ACP satisfies this:
+
+```bash
+kubectl get sc topolvm-hdd -o jsonpath='{.allowVolumeExpansion}{"\n"}'
+```
+
+```text
+true
+```
+
+Patch the destination PVC's `.spec.resources.requests.storage` to the source PV's actual byte count:
+
+```bash
+kubectl -n <vm-namespace> patch pvc <target-pvc> --type=merge \
+  -p '{"spec":{"resources":{"requests":{"storage":"<source-PV-actual-bytes>"}}}}'
+```
+
+The provisioner expands the bound block device in place; this was confirmed on `topolvm-hdd`, where patching a PVC's request from `1610612735` to `1610612740` bytes grew the bound PV's `.spec.capacity.storage` from `1536Mi` to `1540Mi` without recreating the PVC. Once the destination PV's `.spec.capacity.storage` is at least the source PV's `.spec.capacity.storage`, retrying the live storage migration lets QEMU's `-blockdev` precondition pass and the migration proceeds.
+
+Use the byte count taken from the source PV's `.spec.capacity.storage`, or from the QEMU error message itself (the `size` value in the failing `-blockdev` line) — not the value from the source PVC's request, which is what produced the mismatch in the first place.

--- a/docs/en/solutions/Live_Storage_Migration_Fails_When_Target_Block_PV_Is_Smaller_Than_Source.md
+++ b/docs/en/solutions/Live_Storage_Migration_Fails_When_Target_Block_PV_Is_Smaller_Than_Source.md
@@ -1,0 +1,95 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A running VirtualMachine is being migrated between storage classes. Both the source and destination PersistentVolumeClaims request the same capacity, yet the migration fails in QEMU with a size-mismatch error surfaced in the `virt-launcher` pod log:
+
+```text
+-blockdev {"driver":"raw","file":"libvirt-1-storage","offset":0,"size":17482664378368,...}:
+  The sum of offset (0) and size (0) has to be smaller or equal
+  to the actual size of the containing file (17482235510784)
+```
+
+The numbers suggest the target block device is slightly smaller (~400 MiB, in this example) than the source. The PVC objects themselves look identical, so a quick `kubectl describe pvc` does not reveal the discrepancy.
+
+## Root Cause
+
+PVC `resources.requests.storage` is a *floor*, not an exact size. The Kubernetes storage contract lets a provisioner hand back a PV that is at least the requested size but is permitted to be larger. Different storage backends round differently:
+
+- Some backends snap to their allocation unit (e.g. 4 GiB, 1 GiB, 128 MiB) and return the rounded-up size on the PV.
+- Some backends return exactly the requested bytes.
+
+For a VM running with `volumeMode: Block`, the QEMU process sees the **raw block device** — its byte count is the PV's actual size, not the PVC's request. When the source backend provisioned a PV slightly larger than requested (e.g. 16.00 TiB because its allocation unit is 1 GiB) and the target backend provisioned exactly the requested amount (15.999 TiB), the source disk address space extends past the end of the target device. QEMU's safety check in the `raw` block driver refuses to import data into a smaller device and aborts with the `offset + size` error.
+
+In filesystem-mode PVs this problem is hidden by the filesystem layer: the disk image file just ends where the data ends. Block mode has no such buffer.
+
+## Resolution
+
+Align the destination PV's **actual** byte count with the source's actual byte count, not just the PVC request. There are three options, in order of preference.
+
+1. **Request the source's actual size on the target PVC.** Read the source PV's byte capacity and set the target PVC request to at least that many bytes:
+
+   ```bash
+   SRC_PV=$(kubectl get pvc -n <ns> <src-pvc> -o jsonpath='{.spec.volumeName}')
+   kubectl get pv "$SRC_PV" \
+     -o jsonpath='{.spec.capacity.storage}{"\n"}'
+   # -> "16297Gi" (example)
+   ```
+
+   Patch the destination PVC to request the same (or larger):
+
+   ```bash
+   kubectl -n <ns> patch pvc <dst-pvc> --type=merge \
+     -p '{"spec":{"resources":{"requests":{"storage":"17482664378368"}}}}'
+   ```
+
+   If the target StorageClass supports online expansion (most do), the provisioner will grow the PV and the live migration resumes on the next reconcile.
+
+2. **Pick a target StorageClass whose allocation unit matches the source.** If you are doing a bulk migration, this is more predictable than patching every PVC individually. Consult the StorageClass parameters or the driver docs to determine its rounding behaviour, then provision a target whose unit is ≥ the source's.
+
+3. **Convert to filesystem mode for the migration, then back.** Only viable for downtime-tolerant VMs; involves a cold migration through a filesystem-backed intermediate PVC. Use this only when neither of the above is possible.
+
+As a forward-looking prevention: when you know your storage plan in advance, always round the PVC request up to a multiple of the target backend's allocation unit. Asking for `17T` on a backend that allocates in 1 GiB blocks is fine; asking for `17482235510784` bytes on one backend and migrating to another that rounds differently is an accident waiting to happen.
+
+## Diagnostic Steps
+
+Identify the actual byte count on each side:
+
+```bash
+SRC_PVC=<source-pvc>; DST_PVC=<dest-pvc>; NS=<ns>
+SRC_PV=$(kubectl -n $NS get pvc $SRC_PVC -o jsonpath='{.spec.volumeName}')
+DST_PV=$(kubectl -n $NS get pvc $DST_PVC -o jsonpath='{.spec.volumeName}')
+
+kubectl get pv $SRC_PV -o jsonpath='{.spec.capacity.storage}{"\n"}'
+kubectl get pv $DST_PV -o jsonpath='{.spec.capacity.storage}{"\n"}'
+```
+
+For block-mode PVs, confirm the raw device size visible to the virt-launcher pod:
+
+```bash
+LAUNCHER=$(kubectl -n $NS get pod -l kubevirt.io=virt-launcher \
+             -o jsonpath='{.items[0].metadata.name}')
+kubectl -n $NS exec $LAUNCHER -- \
+  sh -c 'for d in /dev/disk; do blockdev --getsize64 "$d" 2>/dev/null || true; done'
+```
+
+Inspect the QEMU error in context:
+
+```bash
+kubectl -n $NS logs $LAUNCHER -c compute | grep -A3 'offset (0) and size (0)'
+```
+
+Confirm the target StorageClass permits expansion (some CSI drivers do not):
+
+```bash
+kubectl get storageclass $(kubectl get pv $DST_PV -o jsonpath='{.spec.storageClassName}') \
+  -o jsonpath='{.allowVolumeExpansion}{"\n"}'
+```
+
+If expansion is not allowed, you must delete and recreate the target PVC at the correct size; in-place expansion will not happen.

--- a/docs/en/solutions/Live_Storage_Migration_Fails_When_Target_Block_PV_Is_Smaller_Than_Source.md
+++ b/docs/en/solutions/Live_Storage_Migration_Fails_When_Target_Block_PV_Is_Smaller_Than_Source.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Live Storage Migration Fails When Target Block PV Is Smaller Than Source
 ## Issue
 
 A running VirtualMachine is being migrated between storage classes. Both the source and destination PersistentVolumeClaims request the same capacity, yet the migration fails in QEMU with a size-mismatch error surfaced in the `virt-launcher` pod log:


### PR DESCRIPTION
新增一篇 ACP KB 文章。
