### PR TITLE
[virtualization] Recovering virt-launcher pods stuck Terminating on a NotReady ACP node

### DIFF
--- a/docs/en/solutions/Recovering_virt_launcher_pods_stuck_Terminating_on_a_NotReady_ACP_node.md
+++ b/docs/en/solutions/Recovering_virt_launcher_pods_stuck_Terminating_on_a_NotReady_ACP_node.md
@@ -1,0 +1,54 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Recovering virt-launcher pods stuck Terminating on a NotReady ACP node
+
+## Issue
+
+On Alauda Container Platform running KubeVirt `v1.7.0-alauda.2` with the Hyperconverged Cluster Operator `v1.17.0` (Kubernetes `v1.34.5`), a worker node that loses contact with the control plane stops posting its kubelet heartbeat, and the node-lifecycle controller in `kube-controller-manager` flips the node's `Ready`, `MemoryPressure`, `DiskPressure`, and `PIDPressure` conditions to `Unknown` with reason `NodeStatusUnknown` once the `--node-monitor-grace-period` (50s on this cluster) elapses without a fresh status update.
+
+Any pod bound to the unreachable node remains in the `Terminating` phase, because the API server cannot confirm that the kubelet has actually stopped its containers and released its resources while the node is unreachable. The `virt-launcher-<vmi>` carrier pods that back each running VirtualMachineInstance are no exception: they are ordinary pods created by `virt-controller` and supervised by the `virt-handler` DaemonSet (one pod per node) in the `kubevirt` namespace, and on a NotReady node they are also stuck in `Terminating` for the same reason.
+
+Because the `virt-launcher` carrier pods never finish terminating, their bound VirtualMachineInstances (`virtualmachineinstances.kubevirt.io`) are not torn down and recreated on healthy nodes — VM failover is not triggered automatically on this install.
+
+## Root Cause
+
+This ACP install carries the HCO cluster default `spec.evictionStrategy: None` on the singleton `HyperConverged` CR `kubevirt-hyperconverged` in the `kubevirt` namespace, which means live-migrate-on-drain is off by default and a VMI on a NotReady node will not be auto-evacuated; the `workloadUpdateStrategy.methods=["LiveMigrate"]` setting only governs operator updates, not node-failure evacuation. Stuck `Terminating` virt-launcher pods are therefore the expected steady state after the node-lifecycle grace period expires and until the node object itself is removed or the node returns.
+
+The standard upstream node-lifecycle loop is what drives this. The `kube-controller-manager` on this cluster runs `nodelifecycle` as part of its default `--controllers=*,bootstrapsigner,tokencleaner` set, and once `--node-monitor-grace-period=50s` passes without a kubelet heartbeat the controller flips the node's conditions to `Unknown` with reason `NodeStatusUnknown`; pod cleanup for that node then waits on the API server being able to talk to the kubelet, which by definition it cannot.
+
+## Resolution
+
+Confirm the node is truly unreachable (for example powered off, NIC down, or experiencing hardware failure) before taking any destructive action — deleting a node object that is only transiently disconnected will tear down pods that may still be running on it.
+
+Once the node is confirmed unreachable, delete the node object so the control plane can finalize pod cleanup for everything that was bound to it. The node-lifecycle controller and the API server will then release the stuck `Terminating` pods, including the affected `virt-launcher-<vmi>` carriers, so that the control plane can finally clean them up; recreation of the VirtualMachineInstances on remaining healthy nodes only follows when each VMI has an owner that drives recreation (a `VirtualMachine` with a recreating `RunStrategy`, or a `VirtualMachineInstanceReplicaSet`) — a bare VMI is not relaunched by `virt-controller` on its own:
+
+```bash
+kubectl delete node <node-name>
+```
+
+Once the underlying issue is resolved, power the node back on and let it rejoin the cluster; the kubelet will re-register the node object and resume posting its status to the control plane.
+
+## Diagnostic Steps
+
+Inspect the node's conditions to confirm it has crossed the `NodeStatusUnknown` threshold rather than reporting a transient blip. On an unreachable node, the `Ready`, `MemoryPressure`, `DiskPressure`, and `PIDPressure` conditions all read `status: Unknown` with reason `NodeStatusUnknown`, in contrast to a healthy node where `Ready=True` carries `reason=KubeletReady` and `message=kubelet is posting ready status`:
+
+```bash
+kubectl describe node <node-name>
+```
+
+The condition messages on the unreachable node read `Kubelet stopped posting node status`, which is the kubelet-supplied wording the node-lifecycle controller surfaces once it stops receiving heartbeats.
+
+List `Terminating` pods across all namespaces to surface the stuck virt-launcher carriers and any other workloads pinned to the unreachable node:
+
+```bash
+kubectl get pods -A | grep Terminating
+```
+
+The `STATUS` column here is the printer-synthesized phase the API server returns for pods whose `DeletionTimestamp` is set but whose graceful termination has not completed; on a healthy cluster this command returns nothing, so any hit on a single node is a strong signal to cross-check that node's `Ready` condition before proceeding.

--- a/docs/en/solutions/virt_launcher_Pods_Stuck_Terminating_When_a_Worker_Node_Goes_Unreachable.md
+++ b/docs/en/solutions/virt_launcher_Pods_Stuck_Terminating_When_a_Worker_Node_Goes_Unreachable.md
@@ -1,0 +1,91 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A worker node drops off the network (power loss, NIC failure, hypervisor panic) and enters `NotReady` with `Kubelet stopped posting node status`. VirtualMachineInstances that were running on that node do **not** fail over to healthy workers:
+
+- Their `virt-launcher` pods stay in `Terminating` indefinitely.
+- The VMI objects are not recreated elsewhere.
+- Any attempt to live-migrate the affected VMs times out (the source agent is no longer reachable).
+
+Applications running inside those VMs are down for as long as the node is `NotReady`, even though other workers have ample capacity.
+
+## Root Cause
+
+Kubernetes is deliberately conservative about declaring a pod dead when its host stops responding. When a node's kubelet goes silent:
+
+1. The control plane marks the node `NotReady` after `node-monitor-grace-period`.
+2. The `taint-manager` applies the `node.kubernetes.io/unreachable:NoExecute` taint after the monitor grace period and evicts pods only after `tolerationSeconds` (default 300s).
+3. Pods on the dead node move to `Terminating`, but their `deletionTimestamp` **cannot be acknowledged** because the kubelet (which would normally finalize termination) is unreachable. They stay in `Terminating` forever until the node object is deleted or the kubelet recovers.
+
+VMIs inherit this behaviour from their `virt-launcher` pods. The VMI controller considers the VM to still be "running on" the old node until the pod is fully terminated; no replacement virt-launcher is created while that is true. This protects against split-brain — recreating the VM on another node while the original host is alive but partitioned would result in two hypervisors writing the same disk — but it means HA is not automatic when the node is genuinely dead.
+
+## Resolution
+
+Once you are certain the node is truly gone (powered off, hardware failed, hypervisor crashed), the remedy is to remove the node from the cluster's view. Removing the node forces the control plane to garbage-collect the stranded pods, which in turn unblocks the VMI controller to schedule replacement `virt-launcher` pods.
+
+1. **Confirm the node is not coming back soon.** The sequence below is destructive to failover ordering; do not run it if there's a chance the node will rejoin in the near term.
+
+   ```bash
+   kubectl get node <node> -o wide
+   kubectl describe node <node> | sed -n '/Conditions/,/Addresses/p'
+   # verify out-of-band: is the host actually powered off?
+   ```
+
+2. **Delete the node.** This causes the controller manager to tear down the stranded pods:
+
+   ```bash
+   kubectl delete node <node>
+   ```
+
+   Within a few seconds the `Terminating` `virt-launcher` pods transition to `Terminated` and are garbage-collected. The VMI controller then notices the VMIs are no longer running and recreates their `virt-launcher` pods on healthy nodes (obeying affinities, tolerations, PDBs, and capacity).
+
+3. **When the node returns, rejoin cleanly.** Once the underlying issue is fixed, power the host back on and let it re-register with the cluster. The rejoin flow is the standard node-join process — nothing extra is needed from the virtualization side.
+
+4. **Protect long-term against repeat incidents.** `kubectl delete node` is a manual-intervention workflow. For clusters that need automatic VM failover:
+
+   - Enable the platform's node-health-check feature (where available) to fence unresponsive nodes and delete the node object after a configurable window. This converts the manual step above into an automated one with safety checks.
+   - Shorten `tolerationSeconds` on unreachable taint for VMI-hosting workloads if your storage can safely take the split-brain risk; raise it for workloads that must never be double-run.
+   - Run stateless front-ends that can absorb the ~10–15 minute failover window behind a Service, so the application-facing impact is soaked by the rest of the topology.
+
+5. **Do not `--force` delete the pods directly.** `kubectl delete pod --force --grace-period=0` removes the pod object but does not wake up the VMI controller's reconciliation cleanly, and if the node ever comes back you'll have two virt-launcher pods competing for the same disk. Delete the node, not the pods.
+
+## Diagnostic Steps
+
+Confirm the node is marked as stopped reporting:
+
+```bash
+kubectl get node <node> -o jsonpath='{.status.conditions[?(@.type=="Ready")]}' | jq
+# {"lastHeartbeatTime":"...","lastTransitionTime":"...","message":"Kubelet stopped posting node status.",
+#  "reason":"NodeStatusUnknown","status":"Unknown","type":"Ready"}
+```
+
+List the stuck pods bound to it:
+
+```bash
+kubectl get pod -A -o wide \
+  --field-selector spec.nodeName=<node>,status.phase=Running | grep -i Terminating
+kubectl get pod -A -o wide \
+  --field-selector spec.nodeName=<node> | grep -i Terminating
+```
+
+Verify the VMIs that were running on the dead node:
+
+```bash
+kubectl get vmi -A -o wide | awk -v n=<node> '$NF==n'
+```
+
+After deleting the node, confirm the VMI controller recreates `virt-launcher` pods within a minute or two:
+
+```bash
+kubectl get vmi -A -o wide --watch
+kubectl get pod -A -l kubevirt.io=virt-launcher --watch
+```
+
+If VMIs do not reschedule even after the node is removed, check for pinned affinities, missing tolerations on the replacement nodes, or PDB-driven blocks: `kubectl get vmi <vmi> -o yaml | grep -A20 -E 'affinity:|tolerations:'` and `kubectl -n <ns> get pdb`.

--- a/docs/en/solutions/virt_launcher_Pods_Stuck_Terminating_When_a_Worker_Node_Goes_Unreachable.md
+++ b/docs/en/solutions/virt_launcher_Pods_Stuck_Terminating_When_a_Worker_Node_Goes_Unreachable.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# virt-launcher Pods Stuck Terminating When a Worker Node Goes Unreachable
 ## Issue
 
 A worker node drops off the network (power loss, NIC failure, hypervisor panic) and enters `NotReady` with `Kubelet stopped posting node status`. VirtualMachineInstances that were running on that node do **not** fail over to healthy workers:


### PR DESCRIPTION
新增一篇 ACP KB 文章。
