### PR TITLE
[observability] How kubectl top calculates container memory as the cgroup working set on ACP

### DIFF
--- a/docs/en/solutions/How_kubectl_top_Calculates_Memory_and_the_Meaning_of_Working_Set.md
+++ b/docs/en/solutions/How_kubectl_top_Calculates_Memory_and_the_Meaning_of_Working_Set.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# How kubectl top Calculates Memory and the Meaning of Working Set
 ## Overview
 
 Operators routinely look at three different memory numbers for the same container and find that none of them agree:

--- a/docs/en/solutions/How_kubectl_top_Calculates_Memory_and_the_Meaning_of_Working_Set.md
+++ b/docs/en/solutions/How_kubectl_top_Calculates_Memory_and_the_Meaning_of_Working_Set.md
@@ -1,0 +1,103 @@
+---
+kind:
+   - Information
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Overview
+
+Operators routinely look at three different memory numbers for the same container and find that none of them agree:
+
+- `kubectl top pod` shows one figure;
+- `free` (or `cat /proc/meminfo`) inside the container shows a much larger one;
+- a Prometheus dashboard plotting `container_memory_usage_bytes` shows yet a third value.
+
+None of these tools is wrong. They are answering different questions against different cgroup counters. This article walks through the counters that the kubelet, cAdvisor, and the platform monitoring stack expose, so that "memory usage" can be reasoned about precisely.
+
+## Resolution
+
+### What `kubectl top` reports
+
+`kubectl top pod` and `kubectl top node` consume metrics from the metrics-server, which in turn reads from the kubelet's `/metrics/resource` endpoint. The kubelet derives those numbers from cAdvisor, which reads cgroup files for each container. The specific value reported as "memory" is the **working set**:
+
+```text
+working_set = memory.usage_in_bytes - memory.stat.inactive_file
+```
+
+The intent of the working set is to approximate "memory that the kernel cannot trivially reclaim under pressure". Page-cache pages on the inactive list are cheap to evict, so they are subtracted off; everything else (anonymous RSS, dirty cache, kernel-pinned cache) is counted in.
+
+### How the underlying cgroup counters compose
+
+For a container's cgroup, `/sys/fs/cgroup/memory/memory.usage_in_bytes` is the *sum of all charged pages*, including page cache. Decomposing it through `memory.stat`:
+
+```text
+memory.usage_in_bytes  ≈  memory.stat.rss        # anonymous + swapped-in
+                       +  memory.stat.cache      # page cache (active + inactive)
+                       +  memory.stat.kernel     # slabs, etc.
+```
+
+The working set carves the page cache in half along the kernel's active/inactive LRU split, keeping the active half in the number and discarding the inactive half. That is why the working set tracks closer to "what the OOM killer would have to evict" than the raw `usage_in_bytes` does.
+
+The same numbers can be inspected directly on a node via the cgroup files (cgroup v1 layout shown; v2 collapses these into `memory.current` and `memory.stat`):
+
+```bash
+NODE=<node-name>
+kubectl debug node/$NODE -it \
+  --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+  -- chroot /host sh -c '
+     cat /sys/fs/cgroup/memory/memory.usage_in_bytes
+     cat /sys/fs/cgroup/memory/memory.stat
+   '
+```
+
+### Mapping to the Prometheus / cAdvisor names
+
+The platform monitoring stack scrapes cAdvisor and exposes both flavours. The names map directly onto the cgroup counters above:
+
+| Prometheus metric | cgroup expression | What it tells the operator |
+|---|---|---|
+| `container_memory_working_set_bytes` | `usage_in_bytes - inactive_file` | Same number `kubectl top` reports; closest to "non-reclaimable memory". The OOM-killer's input. |
+| `container_memory_usage_bytes` | `memory.usage_in_bytes` | Total charged pages including reclaimable cache. Will appear larger than the working set. |
+| `container_memory_rss` | `memory.stat.rss` | Anonymous-only (no cache). Useful for spotting genuine application growth. |
+| `container_memory_cache` | `memory.stat.cache` | Page cache. A high value here that drops under pressure is normal. |
+
+For dashboards and alerts that approximate "is this container close to OOM", **`container_memory_working_set_bytes` is the right choice** — it is what the kubelet evictor and the OOM killer effectively use as the evictable cut-off, and it lines up with `kubectl top`.
+
+### Why `free` and other host-level views diverge
+
+`free`, `top`, and `docker stats` (or `crictl stats`) each compute "memory used" from a different combination of `/proc/meminfo`, the cgroup tree, and the container runtime's own bookkeeping. None of them subtract `inactive_file`, and `free` reports memory at the host level (so cache shared across many containers is attributed to "buffers/cache"). Comparing `free` inside a container with `kubectl top` is rarely useful; the two answer different questions and should not be expected to match.
+
+### Why working set climbs to ~95 % and stays there
+
+This is a regular source of false-alarm tickets. Linux holds onto page cache as long as there is no pressure — there is no virtue in unused memory — so the working set will rise to fill whatever budget the cgroup has and remain there. When real pressure arrives, `inactive_file` is reclaimed first, then `active_file` is demoted to inactive and reclaimed, and the working set drops. A flat-line at 95 % under no pressure is **healthy steady state**, not a leak. A working set that crosses the cgroup limit and stays there *is* a problem and will end with an OOM kill — alert on sustained-high working set with no slack, not on the absolute percentage.
+
+## Diagnostic Steps
+
+To confirm what `kubectl top` is reading for a pod, compare its number against the live cgroup files:
+
+```bash
+POD=<pod>; NS=<namespace>
+kubectl top pod -n "$NS" "$POD"
+
+# Inside the container (or a debug container with /sys mounted):
+kubectl exec -n "$NS" "$POD" -- sh -c '
+  cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2>/dev/null \
+      || cat /sys/fs/cgroup/memory.current
+  echo "---"
+  cat /sys/fs/cgroup/memory/memory.stat 2>/dev/null \
+      || cat /sys/fs/cgroup/memory.stat
+'
+```
+
+The reported figure should equal `usage_in_bytes - inactive_file` (cgroup v1) or the equivalent computed from `memory.stat` (cgroup v2). Discrepancies of a few hundred KB are expected (the metrics pipeline samples on an interval); discrepancies of many MB suggest the kubelet has not refreshed its cAdvisor view yet — restart the kubelet only as a last resort.
+
+To compare across the metrics surface:
+
+```bash
+kubectl get --raw "/api/v1/nodes/<node>/proxy/metrics/resource" \
+  | grep -E '^container_memory_(working_set|rss)_bytes'
+```
+
+If the working set on a node is consistently above the eviction threshold, expect pods to be evicted in the order their `memory.usage` exceeds their `requests.memory`. Right-sizing requests and (where appropriate) limits is the durable fix; lifting the eviction threshold without addressing the underlying request budget only delays the same outcome.

--- a/docs/en/solutions/How_kubectl_top_calculates_container_memory_as_the_cgroup_working_set_on_ACP.md
+++ b/docs/en/solutions/How_kubectl_top_calculates_container_memory_as_the_cgroup_working_set_on_ACP.md
@@ -1,0 +1,55 @@
+---
+kind:
+   - Information
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# How kubectl top calculates container memory as the cgroup working set on ACP
+
+## Issue
+
+On Alauda Container Platform (Kubernetes v1.34.5), the per-pod and per-node memory figure shown by `kubectl top pods` and `kubectl top nodes` is the container *working set*, not the total amount of memory the container has touched. The `metrics.k8s.io/v1beta1` API on ACP is served by `cpaas-monitor-prometheus-adapter` in the `cpaas-system` namespace (helm chart `prometheus-adapter-1.4.2`), with the APIService reporting `Available=True`; the adapter's memory `containerQuery` is a sum of the cAdvisor series `container_memory_working_set_bytes`, so the value reaching the CLI is the working set itself rather than any platform-specific computation. On a measured pod, the kubelet `PodMetrics` value for the `prometheus` container was `memory=530544Ki` and the cAdvisor sample at the same scrape was `container_memory_working_set_bytes=532905984` bytes — the same number within sample skew between the two collection paths.
+
+Because the working set is a smaller, cache-stripped figure, it does not line up with what node-scoped tools like `free` or container-runtime utilities report for the same workload; total cgroup usage on the same container at the same instant was `container_memory_usage_bytes=1895079936` (~1.895 GB) versus a working set of ~533 MB, roughly a 3.5x gap driven entirely by page cache that the working-set view strips out.
+
+## Root Cause
+
+The working set follows the standard cgroup-derived form: it is the container's total memory usage minus the file-backed page cache that is currently inactive (reclaimable). The same shape is observable through the kubelet `/stats/summary` endpoint on every node — a sampled node reported `usageBytes=15259226112`, `workingSetBytes=5915795456`, and `rssBytes=3337379840`, so `usage > workingSet > rss` strictly, with the ~9.3 GB gap between usage and working set attributable to cache that has already been demoted to the inactive list and is therefore not counted. The same `/stats/summary` payload also surfaces per-cgroup PSI (`pressure stall`) full/some `{avg10, avg60, avg300}` fields populated for the node, which requires the unified-hierarchy cgroup stack to be in use, so the kubelet-exposed working-set value on these nodes is the unified-hierarchy form rather than any legacy stat layout.
+
+Total cgroup usage decomposes into resident anonymous memory plus the page cache, and that identity holds on this cluster. For the `prometheus` container, cAdvisor reported `container_memory_rss=530235392` and `container_memory_cache=1352925184`, summing to 1883160576 bytes — within ~12 MB of `container_memory_usage_bytes=1895079936` at the same scrape. The working set sits at ~533 MB and is essentially equal to `rss` for this container, so the ~1.36 GB gap between usage and working set is the cache portion (mostly inactive file pages) that the working-set definition strips out — the same arithmetic reason that `free` and runtime-level tools, which count cache against the workload, report a higher number than `kubectl top`.
+
+## Resolution
+
+Read the working set with the standard memory view. The values returned by these commands are populated by `cpaas-monitor-prometheus-adapter` from `container_memory_working_set_bytes`, so they are the working set by construction rather than a derived approximation:
+
+```bash
+kubectl top pods -n <namespace>
+kubectl top nodes
+```
+
+Treat the reported number as the working set: a smaller, distinct value than total memory usage, with the difference held by reclaimable page cache. The same scrape exposes both the working set and total usage for direct comparison — querying `container_memory_working_set_bytes` and `container_memory_usage_bytes` on the same container will typically show usage well above the working set, and the gap matches the page-cache series within tens of MB.
+
+Do not cross-compare the working set against tools that measure a different scope or in a different way. Total cgroup usage as exposed by `container_memory_usage_bytes` (~1.9 GB in the sample above) includes cache that the working-set view strips, so the same workload looks several times larger in any tool that reports total usage. The container's own usage and working set are the smaller cgroup-scoped values surfaced by `kubectl top` and the metrics API; node-scoped utilities answer a different question and will not match.
+
+## Diagnostic Steps
+
+To inspect the working set in monitoring queries, use the cAdvisor-exported Prometheus series. Both metrics are scraped from `job=kubelet` on port `10250` (cAdvisor is embedded in the kubelet) and are present in the in-cluster Prometheus' `/api/v1/label/__name__/values` listing on this build (image `registry.alauda.cn:60080/3rdparty/prometheus/prometheus:v3.11.3-v4.3.4`). The working set is published as `container_memory_working_set_bytes`, and the total cgroup usage is published as `container_memory_usage_bytes`:
+
+```text
+container_memory_working_set_bytes   # what kubectl top reports
+container_memory_usage_bytes         # total cgroup usage (>= working set)
+container_memory_rss                 # resident anonymous portion
+container_memory_cache               # page cache; the slack between usage and working set
+```
+
+To confirm the working-set identity directly on a node without leaving the Kubernetes API surface, read the kubelet's summary endpoint via `kubectl get --raw`; the same `usageBytes` / `workingSetBytes` / `rssBytes` fields surface there per container and per node and can be cross-checked against the Prometheus series at the same instant:
+
+```bash
+kubectl get --raw "/api/v1/nodes/<node>/proxy/stats/summary" \
+  | grep -E '"(usageBytes|workingSetBytes|rssBytes)"'
+```
+
+A `usage` figure that sits well above `workingSet` on the same container is expected and confirms the cache-stripping shape rather than indicating a leak; the difference matches `container_memory_cache` within scrape jitter on a healthy node.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
