### PR TITLE
[configure] Setting a non-UTC timezone on ACP nodes

### DIFF
--- a/docs/en/solutions/Setting_a_Non_UTC_Timezone_on_Cluster_Nodes.md
+++ b/docs/en/solutions/Setting_a_Non_UTC_Timezone_on_Cluster_Nodes.md
@@ -1,0 +1,126 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+Some operational environments require a node-level timezone other than UTC — typically because legacy log-shipping pipelines, on-call rotation tools, or local compliance reports expect timestamps in regional time. Out of the box, the node OS shipped with ACP is configured for UTC. The question is how to override that for a specific subset of nodes (or for the whole cluster) in a way that survives reboots, image upgrades, and node replacements.
+
+The short answer: it works, it is supported, and it is **not recommended**. Anything that consumes logs from more than one source — the platform's own log pipeline, an external SIEM, an aggregator that stitches together pod logs and node logs — has to rationalise mixed timezones before correlation. Daylight Saving Time transitions add a second class of bugs: applications that log local time silently change their offset twice a year, and any time-window query against historical data has to know which side of the transition it is reading.
+
+If the requirement is real anyway, do it declaratively at the node-pool level so it survives the next node reconcile.
+
+## Root Cause
+
+The node OS keeps timezone state under `/etc/localtime` (a symlink into `/usr/share/zoneinfo/...`) and exposes it via `timedatectl`. The kubelet, the container runtime, and every pod that does **not** mount its own zoneinfo inherit this value through `TZ`-derived defaults.
+
+On ACP, nodes are managed declaratively: any change made by hand on the host (`timedatectl set-timezone`, `ln -sf /usr/share/zoneinfo/...`) is reverted at the next reconcile. The change must therefore be expressed in the node-configuration surface — the same surface used for sysctls, kubelet drop-ins, and other host-level settings — so the platform applies it on every matching node and reapplies it after replacement.
+
+## Resolution
+
+### Preferred: platform-managed node configuration
+
+Use the `configure/clusters/nodes` node-configuration surface (the same one that owns kubelet drop-ins and host-level sysctls; the underlying mechanism is the platform's Immutable Infrastructure capability). Declare a unit that runs `timedatectl set-timezone` once per node and ties to a label selector so only the intended node pool is affected.
+
+A typical declaration, scoped to nodes labelled `node-role/timezone=local`:
+
+```yaml
+nodeSelector:
+  matchLabels:
+    node-role/timezone: local
+files: []
+systemdUnits:
+  - name: custom-timezone.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Set node timezone
+      After=network-online.target
+      ConditionPathExists=!/etc/.timezone-applied
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/bin/timedatectl set-timezone Europe/Madrid
+      ExecStartPost=/usr/bin/touch /etc/.timezone-applied
+      [Install]
+      WantedBy=multi-user.target
+```
+
+Substitute the desired IANA timezone (`Europe/Madrid`, `Asia/Shanghai`, etc.) — `timedatectl list-timezones` on any node enumerates the valid values. The `ConditionPathExists=!` plus `ExecStartPost=touch` idiom keeps the unit a true one-shot: subsequent reboots see the marker and do not re-run, which keeps the unit out of "failed but harmless" status reporting.
+
+The platform applies the change by draining each matching node, restarting the relevant unit, and reconciling. Each affected node reboots (or, where the underlying mechanism is a kubelet drop-in only, restarts the kubelet) — schedule the rollout off-peak and stage it pool-by-pool.
+
+To target a subset rather than the whole cluster, label the relevant nodes first:
+
+```bash
+kubectl label node <worker-01> <worker-02> node-role/timezone=local
+```
+
+Removing the label (`kubectl label node <name> node-role/timezone-`) does **not** undo the change; the symlink that `timedatectl` writes survives. To revert, declare a second node-configuration entry that pins the timezone back to `UTC` and let it land on the originally-modified pool.
+
+### Fallback: per-pod TZ environment
+
+When the requirement is "this one application logs in regional time" rather than "the node logs in regional time", do not touch the host. Set `TZ` on the pod and (where the application's runtime needs it) mount the zoneinfo file into the container:
+
+```yaml
+spec:
+  containers:
+    - name: app
+      image: example.io/app:1.0
+      env:
+        - name: TZ
+          value: "Europe/Madrid"
+      volumeMounts:
+        - name: zoneinfo
+          mountPath: /etc/localtime
+          readOnly: true
+  volumes:
+    - name: zoneinfo
+      hostPath:
+        path: /usr/share/zoneinfo/Europe/Madrid
+        type: File
+```
+
+The pod-level approach side-steps every operational drawback of changing the host timezone: log aggregation still sees a consistent UTC clock at the platform layer, and there is no DST cliff to coordinate across the fleet.
+
+## Diagnostic Steps
+
+After a node has reconciled, confirm the change actually landed:
+
+```bash
+NODE=<node-name>
+kubectl debug node/$NODE -it \
+  --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+  -- chroot /host sh -c '
+     timedatectl
+     ls -l /etc/localtime
+   '
+```
+
+Expected: `Time zone: Europe/Madrid (CET, +0100)` (or whichever zone was declared) and `/etc/localtime` symlinked into the same path under `/usr/share/zoneinfo`. If the node still shows UTC, either the label is missing on that node (`kubectl get node $NODE --show-labels`) or the platform rollout has not completed yet — check the node-pool status surface.
+
+To compare what the kubelet's containers see versus what the host shows:
+
+```bash
+kubectl debug node/$NODE -it \
+  --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+  -- chroot /host sh -c 'date; TZ=UTC date'
+```
+
+The bare `date` reflects the host's local timezone; the `TZ=UTC date` reflects UTC. A divergence between the two confirms the override is in effect.
+
+To audit timezone consistency across a fleet (looking for nodes that did not pick up a rollout, or that picked up a stale rollout):
+
+```bash
+for n in $(kubectl get node -l node-role/timezone=local -o name); do
+  echo "=== $n"
+  kubectl debug "$n" -it \
+    --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+    -- chroot /host sh -c 'timedatectl | grep "Time zone"'
+done
+```
+
+Any node whose output disagrees with the rest is a candidate for re-reconcile. Inconsistent timezones across a single node pool are almost always an in-flight rollout, not a permanent state — re-check after the platform finishes.

--- a/docs/en/solutions/Setting_a_Non_UTC_Timezone_on_Cluster_Nodes.md
+++ b/docs/en/solutions/Setting_a_Non_UTC_Timezone_on_Cluster_Nodes.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Setting a Non-UTC Timezone on Cluster Nodes
 ## Issue
 
 Some operational environments require a node-level timezone other than UTC — typically because legacy log-shipping pipelines, on-call rotation tools, or local compliance reports expect timestamps in regional time. Out of the box, the node OS shipped with ACP is configured for UTC. The question is how to override that for a specific subset of nodes (or for the whole cluster) in a way that survives reboots, image upgrades, and node replacements.

--- a/docs/en/solutions/Setting_a_non_UTC_timezone_on_ACP_nodes.md
+++ b/docs/en/solutions/Setting_a_non_UTC_timezone_on_ACP_nodes.md
@@ -1,0 +1,60 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Setting a non-UTC timezone on ACP nodes
+
+## Issue
+
+On an Alauda Container Platform cluster running Kubernetes server v1.34.5 with systemd-based Ubuntu 22.04 worker and control-plane nodes, operators occasionally need to switch a node's system timezone away from UTC to match a local-time operational policy or to make a single node's on-host logs read in wall-clock time. The node-level timezone is controlled by the underlying host's systemd toolchain — `timedatectl(1)` reports the current local time, universal time, RTC time, configured time zone, system-clock-synchronized status, and NTP service status, and is the canonical surface for both reading and changing the active zone.
+
+## Root Cause
+
+Cluster orchestration does not own per-node timezone state; the active zone is recorded on each host's filesystem as `/etc/localtime`, a symlink that points into `../usr/share/zoneinfo/<zone>` and identifies the currently-selected timezone (for example, `/etc/localtime -> ../usr/share/zoneinfo/UTC`). The zoneinfo database that the symlink resolves into, and that `timedatectl` reads from, is provided by the `tzdata` package shipped on the node OS. Any change to the node timezone therefore has to be made on the host itself — through the systemd surface that owns these files — and applies only to that host.
+
+Operating a non-UTC timezone at the node level is not generally recommended. Once individual nodes report timestamps in differing local-time strings, cluster-wide log aggregation must apply per-source offset processing to align events on a common timeline, which complicates correlation and incident triage. The same divergence is amplified twice a year by daylight saving time transitions, which routinely cause confusion in logs and break applications that assume monotonic, jump-free local time. UTC on every node sidesteps both classes of problem and is the conventional choice for cluster hosts.
+
+## Resolution
+
+When a non-UTC zone is genuinely required on a specific node, change the node's timezone with `timedatectl set-timezone <zone>`, run on the host itself. On the Ubuntu 22.04 substrate this exercises the systemd 249 `timedatectl` interface; the command updates `/etc/localtime` to point at the requested entry under `/usr/share/zoneinfo/` and notifies systemd of the new active zone in a single step.
+
+Apply the change via the host's normal administration path (for example, a direct host shell, the host provisioning tool that manages the node, or — for ad-hoc administration — a `kubectl debug` session that drops into the host's mount namespace). The on-host command is the same regardless of how the shell is obtained:
+
+```bash
+sudo timedatectl set-timezone Asia/Shanghai
+```
+
+To deliver the change as a unit that survives node re-provisioning, wrap the same call in a systemd oneshot unit whose `ExecStart` invokes `timedatectl set-timezone <zone>`, and install that unit through the host's configuration tooling so it is reapplied on each fresh boot of the node. Apply the unit only to nodes that genuinely require the non-UTC zone, and leave the rest of the cluster on UTC to keep aggregated logs aligned.
+
+## Diagnostic Steps
+
+Verify the live state on the target node by launching a debug pod that mounts the node's root filesystem at `/host` and reading the three systemd-managed surfaces directly from there. The debug pod is the most portable entry point on a cluster of Kubernetes server v1.34.5, and reading through the `/host` mount avoids needing to chroot into the host namespace — `chroot /host` is not admitted on this cluster because the debug pod is created without the `privileged` capability:
+
+```bash
+kubectl debug node/<node-name> -it --image=busybox
+```
+
+The configured zone name is recorded in `/etc/timezone` on the node OS and is the shortest read for the current setting; from inside the debug pod, read it through the `/host` mount:
+
+```bash
+cat /host/etc/timezone
+```
+
+Then inspect the underlying symlink to confirm which zoneinfo entry is active; the link target identifies the selected zone directly. Read it through the `/host` mount as well:
+
+```bash
+ls -l /host/etc/localtime
+```
+
+Finally, confirm that the zoneinfo database backing the symlink and `/etc/timezone` is installed by querying the node's package manager against the host root with `--root=/host` — `tzdata` is the package that provides `/usr/share/zoneinfo/` and the zone definitions both surfaces read from:
+
+```bash
+dpkg --root=/host -l tzdata
+```
+
+If `timedatectl` reports an unexpected zone or `/etc/localtime` points at the wrong entry, re-run `timedatectl set-timezone <zone>` on the host to bring the symlink and the systemd-tracked active zone back into the desired state.


### PR DESCRIPTION
新增一篇 ACP KB 文章。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for configuring non-UTC timezones on Alauda Container Platform nodes, including setup procedures, persistence methods, and diagnostic troubleshooting steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/knowledge/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->