### PR TITLE
[configure] Increasing NIC Ring Buffer Size via Declarative Node Tuning

### DIFF
--- a/docs/en/solutions/Increasing_NIC_Ring_Buffer_Size_via_Declarative_Node_Tuning.md
+++ b/docs/en/solutions/Increasing_NIC_Ring_Buffer_Size_via_Declarative_Node_Tuning.md
@@ -1,0 +1,97 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+Workloads on a node intermittently drop network packets and `ethtool -S <iface>` reports growing counters such as `ring full` on the transmit side and `pkts rx OOB` on the receive side:
+
+```text
+Rx Queue#: 2
+  ucast pkts rx: 7903511
+  pkts rx OOB: 632
+Tx Queue#: 0
+  ring full: 88209
+Tx Queue#: 1
+  ring full: 87586
+```
+
+The default NIC ring buffer is too small for the burst rate that the workload presents. Raising it requires a kernel-level `ethtool` call that has to be re-applied across reboots and across new nodes joining the pool — exactly the kind of node-level configuration that should be expressed declaratively rather than scripted by hand.
+
+## Root Cause
+
+Linux NIC drivers expose two queue rings — receive (RX) and transmit (TX) — sized in descriptors. Each descriptor parks one packet between the driver and the host. When traffic arrives in bursts faster than the kernel can drain the ring, descriptors fill up; the next packet is either dropped (`pkts rx OOB`) or the TX path stalls (`ring full`). Increasing the ring size buys time for the host to catch up, at the cost of slightly higher latency and pinned DMA memory.
+
+`ethtool -G <iface> rx N tx N` is the right kernel call, but issuing it imperatively on a node leaves no record of the desired state, gets reverted on reboot if the driver re-initialises, and has to be repeated for every freshly provisioned node. The platform's declarative node-tuning surface (`configure/clusters/nodes`, backed by the **Immutable Infrastructure** extension) is built precisely for this: an admin declares the tunable, the platform converts it into a per-node profile that survives reboots and re-applies to new nodes that match the selector.
+
+## Resolution
+
+1. **Identify the interface and confirm a higher ring size is supported.** From inside the node, the maximum supported value is what the driver reports; setting beyond that silently caps:
+
+   ```bash
+   NODE=<worker-node>
+   IFACE=ens192
+   kubectl debug node/$NODE -it \
+     --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+     -- chroot /host ethtool -g $IFACE
+   ```
+
+   The output lists `Pre-set maximums` (driver ceiling) and `Current hardware settings` (running values).
+
+2. **Author a node-tuning profile for the chosen pool.** ACP runs the upstream Tuned daemon under its node-tuning surface; the same profile schema works. Target the worker pool (or a subset selected by label) and pin the device by udev regex so the profile only fires on the right NIC name.
+
+   ```yaml
+   apiVersion: tuned.alauda.io/v1
+   kind: Tuned
+   metadata:
+     name: increase-ring-buffer
+     namespace: cluster-node-tuning-operator
+   spec:
+     profile:
+       - name: increase-ring-buffer
+         data: |
+           [main]
+           summary=Raise NIC ring buffer to 4096/4096 on bursty workloads
+           include=cluster-node
+           [net]
+           type=net
+           devices_udev_regex=^INTERFACE=ens192
+           ring=rx 4096 tx 4096
+     recommend:
+       - machineConfigLabels:
+           node-role.kubernetes.io/worker: ""
+         priority: 20
+         profile: increase-ring-buffer
+   ```
+
+   Apply with `kubectl apply -f`. The Tuned DaemonSet picks up the new profile, evaluates the recommend rule on every selected node, and runs the equivalent of `ethtool -G ens192 rx 4096 tx 4096` once the kubelet is up.
+
+3. **Limit blast radius before rolling cluster-wide.** Move one or two test nodes into a labelled sub-pool (`workload-class=ring-tuned`) and switch the recommend rule to that label first. Watch packet drops disappear from those nodes, then widen the selector.
+
+4. **Plan around the boot window.** The new ring size only takes effect once the Tuned DaemonSet runs after kubelet start. For a few seconds at boot the NIC keeps the driver default. This is normally fine — nodes that need an enlarged ring at the very first packet should set the value through a kernel cmdline / module parameter via a node-configuration MachineConfig-equivalent instead.
+
+5. **Avoid sysctl-only and ad-hoc service workarounds.** Hand-rolled systemd units that call `ethtool` on every boot drift out of sync with the platform's reconcile loop and survive past their useful life. Express the tunable through the node-tuning CR so the same selector that drains/uncordons the node also rolls the change.
+
+## Diagnostic Steps
+
+Confirm the profile landed on the target node:
+
+```bash
+kubectl -n cluster-node-tuning-operator get profile.tuned.alauda.io/<node>
+kubectl -n cluster-node-tuning-operator logs ds/tuned -c tuned \
+  | grep -i increase-ring-buffer
+```
+
+Verify the ring size took effect:
+
+```bash
+kubectl debug node/$NODE -it \
+  --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+  -- chroot /host ethtool -g $IFACE
+```
+
+`Current hardware settings` should now show `RX: 4096` and `TX: 4096` (or the requested value, capped at `Pre-set maximums`). Re-run `ethtool -S $IFACE` after the workload exercises the link; `ring full` and `pkts rx OOB` should stop incrementing. If they continue, the bottleneck is downstream of the ring (CPU softirq saturation, NUMA-misaligned IRQs, qdisc) and a larger ring will only mask the symptom briefly.

--- a/docs/en/solutions/Increasing_NIC_Ring_Buffer_Size_via_Declarative_Node_Tuning.md
+++ b/docs/en/solutions/Increasing_NIC_Ring_Buffer_Size_via_Declarative_Node_Tuning.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Increasing NIC Ring Buffer Size via Declarative Node Tuning
 ## Issue
 
 Workloads on a node intermittently drop network packets and `ethtool -S <iface>` reports growing counters such as `ring full` on the transmit side and `pkts rx OOB` on the receive side:

--- a/docs/en/solutions/Increasing_NIC_Ring_Buffer_Size_via_Declarative_Node_Tuning.md
+++ b/docs/en/solutions/Increasing_NIC_Ring_Buffer_Size_via_Declarative_Node_Tuning.md
@@ -1,0 +1,73 @@
+---
+title: Diagnose and increase NIC ring buffer size on an Alauda Container Platform worker node
+component: networking
+scenario: how-to
+tags: [ethtool, nic, ring-buffer, node, troubleshooting]
+date_created: 2026-05-30
+date_updated: 2026-05-30
+---
+
+# Diagnose and increase NIC ring buffer size on an Alauda Container Platform worker node
+
+## Issue
+
+A worker node on Alauda Container Platform (kube v1.34.5 lab cluster, Ubuntu 22.04 nodes, containerd 2.2.1-5) shows signs that its NIC's rx or tx descriptor ring cannot keep up with traffic — packet drops, queue overflow counters incrementing, or `ring full` strings in offline node bundles. The driver-default ring buffer sizes are too small for the workload [ev:c1].
+
+The same symptom can be inspected after the fact from a node bundle / sosreport without going back to the live host, by grepping the captured `ethtool -S <iface>` outputs for per-queue counter lines [ev:c2].
+
+The remediation is to increase the per-NIC rx and tx ring buffer sizes (within the per-driver hardware maximum reported by `ethtool -g`) [ev:c3].
+
+## Diagnostic Steps
+
+Open a node-level debug pod and `chroot /host` to run `ethtool` against the worker's primary interface. On the KVM-backed lab cluster the primary interface is `eth0` (driver `virtio_net`); on other environments it can be `ens3`, `eno1`, or similar — list with `ip -br addr` first. The debug image `registry.alauda.cn:60070/acp/container-debug:v4.3.2` ships `ethtool` and standard host tools [ev:c1]:
+
+```bash
+kubectl debug node/<node-name> \
+    --image=registry.alauda.cn:60070/acp/container-debug:v4.3.2 \
+    -it=false -- chroot /host bash -c 'ip -br addr show; ethtool -i eth0; ethtool -g eth0'
+```
+
+`ethtool -g <iface>` prints both the per-driver hardware maximum and the currently-configured ring sizes [ev:c3]:
+
+```text
+Ring parameters for eth0:
+Pre-set maximums:
+RX:		256
+RX Mini:	n/a
+RX Jumbo:	n/a
+TX:		256
+Current hardware settings:
+RX:		256
+RX Mini:	n/a
+RX Jumbo:	n/a
+TX:		256
+```
+
+Read the per-queue NIC counters with `ethtool -S <iface>`; the exact spellings depend on the NIC driver. On `virtio_net` the per-queue counters surface as `rx_queue_N_{packets,bytes,drops,xdp_drops,kicks}` and `tx_queue_N_xdp_tx_drops`; other drivers (for example `vmxnet3`) instead expose `pkts rx OOB` and `ring full` lines for the same condition. Look for non-zero `*drops*` or per-queue overflow counters [ev:c1]:
+
+```bash
+kubectl debug node/<node-name> \
+    --image=registry.alauda.cn:60070/acp/container-debug:v4.3.2 \
+    -it=false -- chroot /host bash -c 'ethtool -S eth0 | grep -iE "drop|ring|oob|kicks"'
+```
+
+When a node bundle or sosreport has already been collected, the same signals can be searched offline against the captured `ethtool_-S_*` files. Use a grep pattern that covers the per-queue counter spellings the bundle's NIC driver emits — for example `Queue|ring full|OOB` for `vmxnet3`, or `rx_queue.*drops|kicks` for `virtio_net` [ev:c2]:
+
+```bash
+grep -E 'Queue|ring full|OOB|rx_queue.*drops|kicks' \
+    <sosreport_dir>/sos_commands/networking/ethtool_-S_*
+```
+
+## Resolution
+
+Once a NIC has been confirmed to be ring-buffer-bound and the per-driver hardware maximum (reported by `ethtool -g`) is larger than the current setting, raise the rx and tx ring sizes with `ethtool -G <iface> rx <N> tx <N>`. The target value must not exceed the `Pre-set maximums` line — for example on the `virtio_net` driver above the hard ceiling is 256, so a request for `rx 4096` would be rejected by the driver. On NICs that allow it (many physical drivers report maximums of 4096 or higher), 4096 is a common target [ev:c3]:
+
+```bash
+kubectl debug node/<node-name> \
+    --image=registry.alauda.cn:60070/acp/container-debug:v4.3.2 \
+    -it=false -- chroot /host bash -c 'ethtool -G eth0 rx 4096 tx 4096; ethtool -g eth0'
+```
+
+Re-run the diagnostic block above to confirm that `Current hardware settings` reflects the new value and that the per-queue drop counters stop incrementing under load [ev:c1][ev:c3].
+
+> Note: `ethtool -G` applies the new ring sizes immediately via a Linux net-driver ioctl, but the change is not persisted across a node reboot. For a persistent setting, the same `ethtool -G` invocation has to be wired into the node's boot-time configuration (for example a systemd oneshot unit ordered before the cluster networking stack starts, delivered at provisioning time). The exact persistence mechanism depends on how worker nodes are provisioned in the environment and is out of scope here.


### PR DESCRIPTION
新增一篇 ACP KB 文章，归入 `configure` 区域。

**⚠️ 自动化验证：无测试计划** — 本篇未登记验证计划，暂不自动合并，请人工确认内容后再合。

## `configure` 区域建议 reviewer

按 `kb/OWNERS.md`（来源：alauda-ai-base operator-list 的产品 owner）该区域候选自动挑选，@ 错了请无视。


没有 GitHub handle 的贡献者（本区域相关请人工 ping）：

- gangwang &lt;gangwang@alauda.io&gt;
- xdzhang &lt;xdzhang@alauda.io&gt;
