### PR TITLE
[networking] Intermittent image-pull i/o timeout from a single ACP node

### DIFF
--- a/docs/en/solutions/Intermittent_Image_Pull_io_Timeout_from_a_Single_Node.md
+++ b/docs/en/solutions/Intermittent_Image_Pull_io_Timeout_from_a_Single_Node.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Intermittent Image Pull i/o Timeout from a Single Node
 ## Issue
 
 Pods scheduled on one node go into `ImagePullBackOff` while the same image pulls successfully on the rest of the cluster. Manual probes with `skopeo` or `podman pull` from inside the affected node reproduce the failure with the same `i/o timeout` symptom:

--- a/docs/en/solutions/Intermittent_Image_Pull_io_Timeout_from_a_Single_Node.md
+++ b/docs/en/solutions/Intermittent_Image_Pull_io_Timeout_from_a_Single_Node.md
@@ -1,0 +1,125 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+Pods scheduled on one node go into `ImagePullBackOff` while the same image pulls successfully on the rest of the cluster. Manual probes with `skopeo` or `podman pull` from inside the affected node reproduce the failure with the same `i/o timeout` symptom:
+
+```text
+FATA Get https://<registry-host>/v2/<repo>/blobs/sha256:<digest>:
+       dial tcp <registry-ip>:443: i/o timeout
+```
+
+The error is intermittent — some pulls return small manifests within milliseconds, larger blob downloads stall and trip the timeout. Because the failure is per-node, the cluster's image pull retry policy keeps churning the pod between `ImagePullBackOff` and `ContainerCreating` rather than scheduling it elsewhere or surfacing a clear authentication error.
+
+## Root Cause
+
+`i/o timeout` from `dial tcp` is a TCP-layer event: the node opened a socket to the registry but the kernel's send queue did not drain within the configured deadline. There are three families of cause that all surface this way, only the first one is truly a registry problem:
+
+- **Path-MTU mismatch.** The node's egress interface advertises a higher MTU than something on the path (usually a tunnel or NAT box) actually supports. Small packets (manifest API calls) succeed, large packets (blob bodies) get black-holed because ICMP fragmentation-needed messages are dropped on the way back. The connection stalls until the timeout fires.
+- **Per-node firewall or proxy drift.** The node either lacks a route, lacks a NO_PROXY exemption, or sits behind a proxy that mid-stream-rate-limits large downloads. The fact that only one node fails is the giveaway: the platform-wide proxy is fine, but this host's per-interface configuration is not.
+- **Upstream registry congestion.** Genuinely a registry-side issue, but rare; if it were the cause, every node would see slowdowns at the same time.
+
+Pinpointing which family applies takes ten minutes of probing and saves hours of guessing at registry mirrors.
+
+## Resolution
+
+1. **Confirm the pull failure is reachable from the affected node only.** Use `kubectl debug` to drop into the node host and probe the registry endpoint directly. A deliberately tiny request that returns `401 Unauthorized` confirms reachability without needing credentials:
+
+   ```bash
+   NODE=<affected-node>
+   REG=<registry-host>          # e.g. ghcr.io / quay.io / a private registry
+   kubectl debug node/$NODE -it \
+     --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+     -- chroot /host /bin/sh -c "
+       curl -sS -o /dev/null -w 'http=%{http_code} dns=%{time_namelookup}s
+                                   connect=%{time_connect}s total=%{time_total}s\n' \
+            https://$REG/v2/
+     "
+   ```
+
+   `http=401` is normal — the API requires auth. `http=000` plus a long `time_connect` means the TCP handshake itself never completed; jump to step 3.
+
+2. **Drive a large transfer to expose MTU issues.** A 1×1 manifest pull can succeed while a 50 MiB blob hangs. Probe a known-large path through the same TLS connection:
+
+   ```bash
+   kubectl debug node/$NODE -it \
+     --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+     -- chroot /host /bin/sh -c "
+       curl -sS -o /dev/null -w 'speed=%{speed_download} bytes=%{size_download}\n' \
+            -m 30 https://$REG/v2/<large-public-blob>
+     "
+   ```
+
+   If the transfer stalls after the first dozen kilobytes, MTU is the prime suspect. Confirm with a packet-size probe:
+
+   ```bash
+   kubectl debug node/$NODE -it \
+     --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+     -- chroot /host /bin/sh -c "
+       ping -M do -s 1472 -c 3 $REG;     # OK at 1500 MTU
+       ping -M do -s 1372 -c 3 $REG      # OK if path MTU is 1400
+     "
+   ```
+
+   The largest unfragmented size that succeeds, plus 28 bytes of IP+ICMP overhead, is the path MTU. If it is below the interface MTU, lower the interface MTU through the platform's node-configuration surface or fix the misbehaving middlebox.
+
+3. **Compare per-node networking against a healthy peer.** When step 1 already showed the connect failing, it is almost always a route, proxy, or firewall delta on this single host:
+
+   ```bash
+   kubectl debug node/$NODE -it \
+     --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+     -- chroot /host /bin/sh -c '
+       ip route get $(getent hosts <registry-host> | awk "{print \$1}")
+       cat /etc/resolv.conf
+       env | grep -iE "https?_proxy|no_proxy"
+     '
+   ```
+
+   Run the same block on a node that pulls successfully and diff the output. The difference is usually a missing default route after a NIC bond change, a stale `no_proxy` that doesn't include the registry, or an outbound rule on a node-local firewall that has not been re-applied.
+
+4. **Make the cluster pull credentials match.** If `time_connect` is fast but the actual pull returns `401`, the failing node has a stale or missing image-pull secret. Reapply credentials cluster-wide via the kubelet's pull-secret surface — never patch `/var/lib/kubelet/config.json` by hand on a single node.
+
+5. **Reduce blast radius while diagnosing.** Cordon the node so no further pods are scheduled until the network or credentials are fixed:
+
+   ```bash
+   kubectl cordon $NODE
+   # ...investigate, fix, validate by step 1 again...
+   kubectl uncordon $NODE
+   ```
+
+## Diagnostic Steps
+
+Identify the failing pods and the exact image they are stuck on:
+
+```bash
+kubectl get pods -A -o wide \
+  | awk '$4 ~ /ImagePullBackOff|ErrImagePull/'
+kubectl describe pod -n <ns> <pod> \
+  | sed -n '/Events:/,$p'
+```
+
+Pull credentials and registry config are read by the container runtime on the node. Inspect what the runtime sees, not what the cluster object says it should see:
+
+```bash
+kubectl debug node/$NODE -it \
+  --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+  -- chroot /host /bin/sh -c '
+    crictl info | grep -iE "registr|mirror"
+    cat /etc/containers/registries.conf.d/*.conf 2>/dev/null | head
+  '
+```
+
+After a fix lands, the cleanest validation is to delete a stuck pod and watch the next pull complete from end to end:
+
+```bash
+kubectl -n <ns> delete pod <stuck-pod>
+kubectl -n <ns> get events --sort-by=.lastTimestamp | tail -n 20
+```
+
+A `Pulled` event with a non-zero byte count confirms the path is healthy.

--- a/docs/en/solutions/Intermittent_image_pull_io_timeout_from_a_single_ACP_node.md
+++ b/docs/en/solutions/Intermittent_image_pull_io_timeout_from_a_single_ACP_node.md
@@ -1,0 +1,44 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Intermittent image-pull i/o timeout from a single ACP node
+
+## Issue
+
+On an Alauda Container Platform cluster (kube-apiserver image `registry.alauda.cn:60080/tkestack/kube-apiserver:v1.34.5`, Kubernetes `v1.34.5`), a workload pod stays in `ImagePullBackOff` while pods of the same image start normally on other nodes. The kubelet event surfaced for the failing node carries a Go-style network error of the form `Failed to pull image "...": ... dial tcp <registry-ip>:443: i/o timeout`, indicating the node could not complete the TCP handshake to the registry endpoint inside the container runtime's image-pull timeout window.
+
+## Root Cause
+
+The error string is emitted verbatim by the container runtime when the underlying `net.Dial` to the registry's HTTPS endpoint exceeds the pull deadline. It is not a registry-side rejection, an authentication problem, or a manifest issue — the request never reaches HTTP at all. When the same image pulls correctly from other nodes in the same cluster, the failure is localized to the affected node's outbound network path to the registry rather than to the registry service or to cluster-wide settings.
+
+Image-pull traffic on this cluster comes from the kubelet and container runtime on the node's host network stack rather than from inside a pod's network namespace, and is therefore not subject to pod-network NetworkPolicy enforcement regardless of which NetworkPolicy objects exist in the cluster. The fix surface is the node host's outbound path — firewall, web proxy, or upstream network device on the egress route — rather than any Kubernetes-level policy object.
+
+## Resolution
+
+Restore reachability from the affected node to the registry endpoint on TCP/443. Verify the node's egress firewall rules permit the registry IP and port, that any web proxy configured for the runtime is reachable and forwarding correctly, and that intermediate network devices on the node's path are not dropping or rate-limiting the connection. Once the host-level path to the registry is healthy, the container runtime's next pull attempt completes the TCP handshake and the pod proceeds out of `ImagePullBackOff`.
+
+When the registry is a self-hosted one — on ACP the in-cluster registry is `registry.alauda.cn:60080`, from which every workload pulls — also inspect the registry's own service logs for the same time window. A service-side error or rate limit on the registry can present alongside, or independently of, node-side network faults, and the registry's logs are the primary place to confirm or rule out a service-side cause on ACP.
+
+## Diagnostic Steps
+
+Reproduce the pull directly on the affected node using the runtime's manual-pull tooling. ACP nodes run `containerd://2.2.1-5` on Ubuntu 22.04.1 LTS, so the manual-pull diagnostic is `crictl pull` (or `nerdctl pull`) against the same image reference the failing pod requested. If the manual pull returns the same `dial tcp ...:443: i/o timeout`, the failure is at the node-to-registry network layer, independent of the kubelet's image-pull bookkeeping or any pod-level configuration. Substitute the failing pod's exact image reference for `REPO/IMAGE:TAG` below (for example `tkestack/kube-apiserver:v1.34.5`):
+
+```bash
+crictl pull registry.alauda.cn:60080/REPO/IMAGE:TAG
+```
+
+Localize the problem to a single node by attempting the same pull from a second, healthy worker. The cluster topology (one control-plane plus three workers, each with its own InternalIP) makes per-node comparison straightforward: identify the node whose pull times out by InternalIP, and confirm at least one other node completes the same pull. A pull that succeeds on the other node and times out only on the affected node confirms the failure is bound to that node's egress, not to the registry or to cluster-wide configuration.
+
+Distinguish network-layer failure from a registry-side or auth-side failure by issuing an unauthenticated probe to the registry's `/v2/` endpoint from the affected node. Any conformant OCI Distribution registry — including `registry.alauda.cn:60080` — replies to an unauthenticated `GET /v2/` with HTTP `401 UNAUTHORIZED` when the endpoint is reachable:
+
+```bash
+curl -v https://registry.alauda.cn:60080/v2/
+```
+
+A `401 UNAUTHORIZED` response from this command shows that the TCP/443 path from the node to the registry is open and the registry's HTTP front end is responsive; the symptom is then not a network-path failure, and investigation should move to credentials or the specific repository being pulled. A `connect: timed out`, `connection refused`, or no-response outcome from the same `curl -v` indicates the network path itself is broken, matching the runtime's `dial tcp ...:443: i/o timeout` and pointing back at the node's egress firewall, proxy, or route.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
