### PR TITLE
[extend] Subscription Stuck on CatalogSource Removed When the Catalog Still Exists

### DIFF
--- a/docs/en/solutions/Subscription_Stuck_on_CatalogSource_Removed_When_the_Catalog_Still_Exists.md
+++ b/docs/en/solutions/Subscription_Stuck_on_CatalogSource_Removed_When_the_Catalog_Still_Exists.md
@@ -1,0 +1,144 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+The extend / installed-operators surface shows an operator with `Cannot update` and `CatalogSource was removed` (or `CatalogSource not found`), even though the named `CatalogSource` is present and serving fine. The catalog-operator pod logs in the OLM namespace report repeated `ResolutionFailed` warnings of the form:
+
+```text
+constraints not satisfiable: subscription <name> exists,
+subscription <name> requires <catalog>/<catalog-ns>/<channel>/<csv-name>,
+clusterserviceversion <csv-name> exists and is not referenced by a subscription,
+... and @existing/<install-ns>//<csv-name> provide <CRD>
+```
+
+Other phrasings of the same root pattern appear with multi-version conflicts such as `@existing/<install-ns>//<csv>.v1.4.2 and ...//.v1.4.3 provide <Service> ...`. The Subscription, CSV, and CatalogSource are all present individually, yet the resolver cannot pick a satisfying solution and refuses to upgrade.
+
+A separate but related question that comes up at the same time: when the operator was installed in **All Namespaces** mode, OLM creates a *master* CSV in the install namespace plus *copied* CSVs in every watched namespace. Which set should be deleted to recover?
+
+## Root Cause
+
+OLM treats the cluster's existing CSVs as part of the input set the resolver must satisfy. When a Subscription disappears (deletion, namespace recreation, GitOps reconcile, etc.) but the CSV it was managing remains, the CSV is *orphaned*: still in the cluster, no longer owned by any Subscription. Re-creating the Subscription a moment later does not re-bind it; the resolver now sees both:
+
+- the new Subscription, asking for the CSV from a catalog channel; and
+- the orphaned CSV, sitting in the namespace under `@existing/...`, providing the same CRD/API.
+
+Two independent supplies of the same API satisfy nothing — the resolver flags the result as `constraints not satisfiable` and reports it as `CatalogSource was removed`, which is misleading. The catalog is fine; the in-cluster state has two providers for the same API and OLM cannot choose.
+
+The same situation arises when the user pinned a `startingCSV` in the recreated Subscription that also matches the orphaned CSV; the resolver still cannot reconcile two providers.
+
+## Resolution
+
+The repair is mechanically simple: drop the orphaned CSV *and* the (recreated) Subscription, wait for OLM to garbage-collect, then re-create the Subscription cleanly. The order matters — leaving either side behind reproduces the same wedge.
+
+### 1. Back up the Subscription before deleting
+
+The Subscription holds the channel, install-plan policy, and any `startingCSV` that need to be preserved. Save it to disk so the recreate step is mechanical.
+
+```bash
+NS=<operator-ns>
+SUB=<subscription-name>
+kubectl -n $NS get subscription $SUB -o yaml > subscription_backup.yaml
+```
+
+Edit the backup before re-applying:
+
+- Remove the entire `status` block.
+- Remove `metadata.creationTimestamp`, `metadata.uid`, `metadata.resourceVersion`, and `metadata.generation`.
+- If `spec.startingCSV` is set and its value is the same CSV that the resolver is complaining about, **delete `spec.startingCSV` from the backup**. Pinning the orphaned version reproduces the conflict on the next reconcile.
+
+### 2. Delete the Subscription and the orphaned CSV
+
+Delete both objects, in either order, and wait for both to disappear before recreating anything.
+
+```bash
+NS=<operator-ns>
+SUB=<subscription-name>
+CSV=<csv-name>          # e.g. jaeger-operator.v1.28.0
+
+kubectl -n $NS delete subscription $SUB
+kubectl -n $NS delete csv $CSV
+
+# wait for both to be gone
+kubectl -n $NS get subscription
+kubectl -n $NS get csv
+```
+
+For an **All-Namespaces** install, only the *master* CSV (in the namespace where the operator was actually installed) needs to be deleted. The copied CSVs in tenant namespaces are managed by OLM and will be cleaned up automatically once the master is removed.
+
+```bash
+# The "master" CSV always lives in the install namespace.
+# Copied CSVs in other namespaces are owned by OLM and will follow.
+kubectl get csv -A | grep $CSV
+```
+
+### 3. Re-create the Subscription at the desired version
+
+Apply the cleaned backup. Pin `startingCSV` to the exact version that was running before so an automatic upgrade does not silently jump to a newer CRD schema mid-recovery.
+
+```bash
+kubectl apply -f subscription_backup.yaml -n $NS
+```
+
+OLM resolves the new Subscription, generates a fresh InstallPlan, and re-creates the CSV. Confirm the resolution succeeded:
+
+```bash
+kubectl -n $NS get sub $SUB \
+  -o jsonpath='{.status.conditions}' | jq .
+kubectl -n $NS get csv
+```
+
+### 4. Recycle the OLM pods if reconciliation is sluggish
+
+OLM caches the resolver state in-memory; after a recovery, deleting the catalog-operator and olm-operator pods forces a clean read. Do this only when the recreated Subscription is sitting in `UpgradePending` for more than a few minutes.
+
+```bash
+LM_NS=<olm-namespace>          # platform OLM namespace
+kubectl -n $LM_NS delete pods -l 'app in (catalog-operator, olm-operator)'
+```
+
+### 5. Avoid recreating the wedge
+
+Two operational habits keep this from recurring:
+
+- When deleting a Subscription as part of a clean-up, delete the matching CSV in the same step. Never leave the CSV behind under the assumption that the next Subscription will adopt it — it will not.
+- When recreating a Subscription via GitOps, declare the CSV as a managed resource as well, so a Subscription resync also resyncs the CSV side.
+
+## Diagnostic Steps
+
+Confirm the Subscription, CSV, and CatalogSource all exist before assuming the catalog is missing:
+
+```bash
+NS=<operator-ns>
+kubectl -n $NS get sub
+kubectl -n $NS get csv
+kubectl -n $NS get sub <name> \
+  -o jsonpath='{.spec.source}{" "}{.spec.sourceNamespace}{"\n"}'
+
+# Then check the catalog actually exists where the Subscription points:
+kubectl -n <catalog-ns> get catalogsource
+```
+
+Pull the resolver decision out of the catalog-operator log — it prints a precise reason for each `ResolutionFailed`:
+
+```bash
+LM_NS=<olm-namespace>
+kubectl -n $LM_NS get pods
+kubectl -n $LM_NS logs deploy/catalog-operator --tail=300 \
+  | grep -E 'ResolutionFailed|constraints not satisfiable'
+```
+
+Look for the giveaway in the message:
+
+```text
+... clusterserviceversion <name>.v<x.y.z> exists and is not referenced by a subscription
+```
+
+That phrase confirms the CSV is orphaned; once cleaned up, the Subscription resolves on the next reconcile.
+
+If multiple operators show the same condition simultaneously, check whether something cluster-wide deleted the Subscriptions (e.g. a GitOps prune that did not also prune CSVs). The fix is identical per-operator, but the *cause* should be addressed at the GitOps source.

--- a/docs/en/solutions/Subscription_Stuck_on_CatalogSource_Removed_When_the_Catalog_Still_Exists.md
+++ b/docs/en/solutions/Subscription_Stuck_on_CatalogSource_Removed_When_the_Catalog_Still_Exists.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Subscription Stuck on CatalogSource Removed When the Catalog Still Exists
 ## Issue
 
 The extend / installed-operators surface shows an operator with `Cannot update` and `CatalogSource was removed` (or `CatalogSource not found`), even though the named `CatalogSource` is present and serving fine. The catalog-operator pod logs in the OLM namespace report repeated `ResolutionFailed` warnings of the form:

--- a/docs/en/solutions/Subscription_Stuck_on_CatalogSource_Removed_When_the_Catalog_Still_Exists.md
+++ b/docs/en/solutions/Subscription_Stuck_on_CatalogSource_Removed_When_the_Catalog_Still_Exists.md
@@ -1,0 +1,92 @@
+---
+title: Recover an OLM operator stuck on ResolutionFailed after a Subscription was deleted
+component: extend
+scenario: troubleshooting
+tags: [olm, subscription, csv, catalogsource, operatorbundle, resolutionfailed]
+date_created: 2026-05-30
+date_updated: 2026-05-30
+---
+
+# Recover an OLM operator stuck on ResolutionFailed after a Subscription was deleted
+
+## Issue
+
+On Alauda Container Platform, OperatorBundles are managed by OLM (`registry.alauda.cn:60080/3rdparty/operator-framework/olm:v4.3.2`) running in the `cpaas-system` namespace. An operator's `Subscription` (`operators.coreos.com/v1alpha1`) produces an `InstallPlan` whose `ownerReferences[0]` points back at the Subscription, and that InstallPlan creates the `ClusterServiceVersion` (CSV) for the named operator version — so the CSV is indirectly owned by the Subscription via the InstallPlan [ev:c1]. If the Subscription is deleted (or recreated against a different operator version) without first deleting the CSV, the CSV remains in the namespace with no Subscription pointing at it and OLM marks it orphaned with the message `clusterserviceversion <name> exists and is not referenced by a subscription` [ev:c1_b].
+
+While the CSV is orphaned, the OLM catalog-operator running in `cpaas-system` cannot resolve a fresh install path and emits repeated `Warning` events on the namespace with `reason: ResolutionFailed`, including a `constraints not satisfiable` message naming the orphaned CSV. The events are surfaced both by `kubectl describe subscription <name> -n <ns>` and in the catalog-operator log (`kubectl -n cpaas-system logs deploy/catalog-operator`); the same log line format (`level=info msg=...`) is shared with upstream OLM because ACP uses the same binary [ev:c2_a].
+
+## Root Cause
+
+The Subscription and the CSV are linked through an InstallPlan: the Subscription is the owner of an InstallPlan whose `spec.clusterServiceVersionNames` lists the target CSV, and OLM's reconciler treats a CSV with no owning Subscription as an orphan that blocks further upgrades on that operator [ev:c1]. Deleting only the Subscription (for example to clean up a misconfigured install or switch channels) breaks the chain — the orphaned CSV persists, OLM refuses to install a new CSV that would conflict with the orphan, and the namespace's Subscription enters a permanent `ResolutionFailed` state [ev:c1_b][ev:c2_a].
+
+## Resolution
+
+Recovery clears the orphan and re-establishes Subscription ownership of the CSV. Because each operator's CSV is created by an InstallPlan that lists it in `spec.clusterServiceVersionNames` and is owned by the Subscription that produced the InstallPlan, removing both the Subscription and the named CSV in the namespace puts OLM back in a state where a freshly-created Subscription generates a new InstallPlan and a new CSV ownership chain for the same operator version [ev:c1]. The recovery sequence is the same regardless of whether the operator was installed in its own namespace (`OwnNamespace` mode) or globally — on ACP the global install namespace is `operators` (with the `global-operators` OperatorGroup), and `AllNamespaces`-mode bundles keep their master CSV in the namespace where the Subscription and OperatorGroup live [ev:c5_a]. Because ACP enables OLM's `disableCopiedCSVs: true` feature (`kubectl get olmconfig cluster -o jsonpath='{.spec.features.disableCopiedCSVs}'` returns `true`), there are no `reason=Copied` CSV objects in other namespaces to chase down — the master CSV in the install namespace is the only CSV to delete [ev:c5_a].
+
+Save the current Subscription manifest before deleting it so it can be re-applied unchanged where possible:
+
+```bash
+NS=<operator-install-namespace>
+SUB=<subscription-name>
+kubectl get subscription "$SUB" -n "$NS" -o yaml > /tmp/${SUB}-backup.yaml
+kubectl get csv -n "$NS"
+```
+
+Delete the Subscription and the named CSV [ev:c1_b]:
+
+```bash
+kubectl delete subscription "$SUB" -n "$NS"
+kubectl delete csv <csv-name> -n "$NS"
+kubectl get subscription -n "$NS"
+kubectl get csv -n "$NS"
+```
+
+Before re-applying the saved manifest, edit `/tmp/${SUB}-backup.yaml` to remove the `status:` section and the `metadata.creationTimestamp` field — both are populated by the API server and rejected on create [ev:c4_a]. If `spec.startingCSV` is set in the backup and the value matches the CSV named in the `ResolutionFailed` event, clear `spec.startingCSV` as well — leaving it in causes OLM to attempt to resolve the same problematic CSV again [ev:c4_b]. The Subscription CRD defines `spec.startingCSV` as a plain string field in the v1alpha1 schema, so removing or editing it is a straightforward YAML edit [ev:c7].
+
+Re-create the Subscription:
+
+```bash
+kubectl create -f /tmp/${SUB}-backup.yaml -n "$NS"
+```
+
+When the goal is to restore the operator at the version that was previously installed (rather than to upgrade), set `spec.startingCSV` in the recreated manifest to that exact CSV name. Pinning the starting CSV avoids an unintended upgrade through a channel head that may ship CRD or CR shape changes the existing in-cluster resources cannot satisfy [ev:c7].
+
+After the Subscription is re-created, OLM's catalog-operator and olm-operator (both Deployments in `cpaas-system` with the labels `app=catalog-operator` and `app=olm-operator`) need a short reconcile window to generate a new InstallPlan and re-bind it to the existing operator workload [ev:c6_a]. If reconciliation appears stuck, force a fresh reconcile by deleting the controller pods so their Deployments reschedule them [ev:c6_b]:
+
+```bash
+kubectl -n cpaas-system delete pod -l 'app in (catalog-operator,olm-operator)'
+```
+
+## Diagnostic Steps
+
+Confirm the orphaned-CSV signature before applying the recovery. Listing the namespace's Subscription and CSV inventory tells whether the symptom matches: a Subscription present, a CSV present, but no recent InstallPlan tying them together is the classic shape [ev:c1].
+
+```bash
+NS=<operator-install-namespace>
+kubectl get subscription -n "$NS"
+kubectl get csv -n "$NS"
+kubectl get installplan -n "$NS"
+```
+
+Verify the CatalogSource the Subscription points at actually exists. On ACP the standard CatalogSources are `platform`, `system`, and `custom`, all in `cpaas-system`; a Subscription targets one of them through `spec.source` and `spec.sourceNamespace: cpaas-system` (vs `spec.startingCSV` which is an optional pin on the desired CSV name) [ev:c4_a].
+
+```bash
+kubectl get subscription "$SUB" -n "$NS" -o yaml | grep -A1 'source\|sourceNamespace\|startingCSV'
+kubectl get catalogsource -n cpaas-system
+```
+
+Read the `ResolutionFailed` events directly off the catalog-operator log to confirm which CSV is named as the orphan — the line referencing `clusterserviceversion <name> exists and is not referenced by a subscription` is the one to clear in the resolution above [ev:c2_a].
+
+```bash
+kubectl -n cpaas-system logs deploy/catalog-operator --tail=200 \
+ | grep -E 'ResolutionFailed|constraints not satisfiable|exists and is not referenced'
+kubectl get events -n "$NS" --field-selector reason=ResolutionFailed
+```
+
+For globally-scoped operators, confirm whether the install was `AllNamespaces`-mode by reading the OperatorGroup's `status.namespaces`: an entry of `[""]` indicates AllNamespaces and locates the master CSV in the same namespace as the OperatorGroup (e.g. `operators` for the global `global-operators` group). Because ACP runs OLM with `disableCopiedCSVs: true`, no copies of that CSV exist in other namespaces — only the master CSV needs to be deleted in the recovery sequence [ev:c5_a].
+
+```bash
+kubectl get operatorgroup -A \
+ -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name} status.namespaces={.status.namespaces}{"\n"}{end}'
+kubectl get olmconfig cluster -o jsonpath='{.spec.features.disableCopiedCSVs}'
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章，归入 `extend` 区域。

**⚠️ 自动化验证：无测试计划** — 本篇未登记验证计划，暂不自动合并，请人工确认内容后再合。

## `extend` 区域建议 reviewer

按 `kb/OWNERS.md`（来源：alauda-ai-base operator-list 的产品 owner）该区域候选自动挑选，@ 错了请无视。


没有 GitHub handle 的贡献者（本区域相关请人工 ping）：

- xdzhang &lt;xdzhang@alauda.io&gt;
- xxhe &lt;xxhe@alauda.io&gt;
- clyi &lt;clyi@alauda.io&gt;
- chengli &lt;chengli@alauda.io&gt;
- jcwang &lt;jcwang@alauda.io&gt;
