### PR TITLE
[observability] Defunct Processes From Exec Probes Driving Worker Node Pressure

### DIFF
--- a/docs/en/solutions/Defunct_Processes_From_Exec_Probes_Driving_Worker_Node_Pressure.md
+++ b/docs/en/solutions/Defunct_Processes_From_Exec_Probes_Driving_Worker_Node_Pressure.md
@@ -1,0 +1,59 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Defunct Processes From Exec Probes Driving Worker Node Pressure
+
+## Issue
+
+On Alauda Container Platform worker nodes running Kubernetes v1.34.5, defunct (zombie) processes can accumulate in the node process table when failing exec probes keep spawning short-lived helper processes that the container's main process does not reap. Exec probes are an actively used surface on this platform — across the workload set, eight pods declare a `livenessProbe.exec` and nine declare a `readinessProbe.exec`, covering components such as the `argocd` redis-ha pods, the `kube-system` Kube-OVN and OVS pods, and the `kubevirt` CDI pods — so the trigger pattern lands on real worker process trees.
+
+The accumulation correlates with elevated node load and degraded responsiveness on the affected worker. The kubelet `stats/summary` endpoint exposes Pressure Stall Information for system containers, with `cpu.psi` reporting `full` and `some` averages over the standard `avg10` / `avg60` / `avg300` windows alongside `memory.availableBytes`, which is the native kubelet surface where the high-load signal becomes visible while zombies pile up.
+
+## Root Cause
+
+A defunct entry is a child process that has exited but whose parent has not collected its exit status, so the kernel keeps a slim task entry in the process table until reaping happens. When an exec probe re-fires on a tight interval and the container's main process does not reap the probe-spawned children, every failed probe iteration leaves another defunct entry behind, and the count grows for as long as the probe keeps firing against an unresponsive command. The probe-spawned children sit inside the container's process subtree under the container monitor / shim process that the kubelet drives through the CRI; the surviving subtree continues to accrue defunct rows for the same parent as the probe interval keeps re-firing.
+
+Because each zombie occupies a PID-table slot and the kubelet stays busy driving probes and container lifecycle work, the per-node PSI counters climb as the count grows, which is the same `cpu.psi` signal surfaced by `stats/summary` for the kubelet system containers.
+
+## Resolution
+
+Restart the pod that is generating the defunct processes once it is identified, provided the workload tolerates a restart. The `pods` resource exposes the `delete` verb on this server (`VERBS [create delete deletecollection get list patch update watch]`), so a single `kubectl delete pod` is sufficient — the owning controller recreates the pod and the new container starts with a clean process table, no platform-specific primitive needed.
+
+```bash
+# Identify the offending pod, then delete it; the controller recreates it.
+kubectl -n <namespace> delete pod <pod-name>
+
+# Wait for the recreated pod to become Ready before re-measuring.
+kubectl -n <namespace> wait --for=condition=Ready pod/<pod-name> --timeout=120s
+```
+
+If the same workload keeps re-producing defunct entries after the restart, address the underlying source: fix the application so its main process reaps its children, or correct the failing exec probe so it stops re-spawning commands that never get collected.
+
+## Diagnostic Steps
+
+List the defunct rows on the worker node and read the parent PID from the fifth field of the `ps -elfL` output. The ACP worker nodes run Ubuntu 22.04.1 with kernel 5.15 and the procps-ng `ps`, whose `ps -elfL` header is `F S UID PID PPID LWP C NLWP ...`, so the PPID column is the fifth field on every worker — that PPID identifies the parent process that is failing to reap its children.
+
+```bash
+# On the worker (via kubectl debug node), list defunct processes and read PPID (5th field).
+kubectl debug node/<node-name> -- chroot /host ps -elfL | grep defunct
+
+# Walk the process tree from that PPID to confirm the owning parent.
+kubectl debug node/<node-name> -- chroot /host pstree -lp <ppid>
+```
+
+Walk the tree from the PPID with `pstree -lp` to confirm which container subtree owns the parent — the defunct rows sit under the container monitor / shim process that anchors the container's process hierarchy, with the parent being the container's own main process.
+
+Watch the high-load signal on the affected worker through the kubelet `stats/summary` endpoint, which returns `systemContainers[].cpu.psi` with `full` and `some` `avg10` / `avg60` / `avg300` values plus `memory.availableBytes`, so the rising PSI averages can be tracked while the defunct count keeps climbing.
+
+```bash
+# Read PSI from the kubelet stats/summary endpoint via the apiserver proxy.
+kubectl get --raw "/api/v1/nodes/<node-name>/proxy/stats/summary"
+```
+
+If the count keeps climbing after a restart, the source workload is still active — the trigger surface remains the same set of pods that declare exec probes (for example the `argocd` redis-ha, `kube-system` Kube-OVN / OVS, and `kubevirt` CDI pods), so re-check whether one of those probes is failing in a tight loop.

--- a/docs/en/solutions/Worker_Nodes_Accumulate_Zombies_and_High_Load_From_Exec_Probe_Leak.md
+++ b/docs/en/solutions/Worker_Nodes_Accumulate_Zombies_and_High_Load_From_Exec_Probe_Leak.md
@@ -1,0 +1,137 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A worker node is loaded far above its normal baseline. Common observations:
+
+- thousands of `<defunct>` (zombie) processes are visible in `top` and `ps`;
+- the run-queue is saturated and load average is several multiples of the CPU count;
+- interactive logins to the node are extremely slow — an SSH session to start a shell can take minutes, not seconds;
+- the container runtime (`crio`) and `kubelet` are at the top of the CPU usage list, often together with one or two application processes.
+
+A `top` snapshot from a node hitting this issue typically looks similar to:
+
+```text
+PID    USER     %CPU  %MEM   COMMAND
+1760   root     314.2  0.3   crio
+1810   root      17.2  5.0   kubelet
+2522139 1972     99.7  0.0   python3.6
+1      root      99.0  0.8   systemd
+... (many <defunct> entries below) ...
+```
+
+The application pods on the node are still running, but probes are flapping and the kubelet event log shows recurring `Liveness probe failed` / `Readiness probe failed` lines for unrelated workloads, because the runtime cannot keep up with the probe-exec rate.
+
+## Root Cause
+
+The pattern — high load, runaway runtime CPU, and tens of thousands of defunct children whose parent (`PPID`) is a `conmon` instance — is a classic exec-probe leak in the OCI runtime stack.
+
+For each `exec` probe (`livenessProbe.exec`, `readinessProbe.exec`, `startupProbe.exec`) the kubelet asks the runtime to spawn a short-lived process inside the target container. The runtime executes it through `conmon`, which forks the probe binary and is supposed to reap the child once it exits. Under sustained pressure (high probe frequency, slow filesystem, high concurrent exec count) the runtime can lose the reap signal and leave the exited probe as a zombie. With a probe that runs every couple of seconds across many pods, the zombie count grows quickly into the thousands — at which point the runtime spends most of its CPU on bookkeeping, kubelet probe latencies climb, and unrelated probes start failing.
+
+A defining feature of this leak: the parent of each zombie is **not** the application — it is `conmon`, with the runtime as the grandparent. Application code is not the source.
+
+## Resolution
+
+The long-term fix is a runtime-level patch (the leak has been addressed in current releases of the runtime that ACP ships). Confirm the runtime version on the affected node and upgrade if it is below the fixed version; the upgrade is delivered through the platform's node-config / Immutable Infrastructure surface, not through manual rpm operations on the host.
+
+If the node is already on a fixed runtime version and the same symptom recurs, treat it as a fresh investigation rather than the same leak — see the diagnostic steps below to identify the source.
+
+### Tactical: restart the offending pods
+
+Until the node-level fix is in place, the leak can be drained by restarting the pods whose `conmon` parents are accumulating zombies. The pods themselves are healthy; the parent runtime processes that are leaking will be re-created clean when the pod restarts.
+
+1. Identify the pods. Map the `PPID` of zombies back to a `conmon` PID, then back to a container ID, then to a pod (see Diagnostic Steps).
+2. Validate that the workload tolerates a single-pod restart. For replicated services this is usually trivial; for singleton workloads, plan a maintenance window.
+3. Restart by deleting the pod (the controller re-creates it):
+
+   ```bash
+   kubectl -n <ns> delete pod <pod>
+   ```
+
+This drops the leaked zombies attached to that pod's `conmon` and resets the leak counter. It does not fix the leak — the same pod will accumulate again.
+
+### Strategic: reduce exec-probe pressure
+
+While the runtime fix rolls out, reducing the amount of exec-probe work that the runtime has to do also pushes the leak rate down:
+
+- **Replace `exec` probes with `httpGet` or `tcpSocket` probes** wherever the application exposes a reachable endpoint. HTTP and TCP probes are handled by the kubelet directly and never spawn a child process.
+- **Lengthen `periodSeconds`** on probes whose tight cadence is not actually needed. Going from `1s` to `10s` cuts the spawn rate by a factor of ten.
+- **Drop redundant probes.** A startup probe followed by a liveness probe that runs the same command is doing the work twice.
+
+These changes are workload-side and survive any node restart.
+
+### Drain and reboot when the leak is severe
+
+If a node has tens of thousands of zombies, the cleanest recovery is to drain it and reboot — `conmon` cleanup at startup is reliable, and the new boot starts from zero.
+
+```bash
+NODE=<worker>
+kubectl cordon $NODE
+kubectl drain $NODE --ignore-daemonsets --delete-emptydir-data
+# trigger a reboot via the platform node surface, not via direct host commands
+kubectl uncordon $NODE
+```
+
+Reboot through the platform's node-config surface so the action is visible in the audit trail; do not `ssh` and `reboot` directly.
+
+## Diagnostic Steps
+
+1. **Confirm the node is loaded and find the top consumers**:
+
+   ```bash
+   kubectl debug node/<node> -it \
+     --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+     -- chroot /host top -bn1 | head -n 30
+   ```
+
+   `crio` and `kubelet` near the top with very high `%CPU` is the first clue.
+
+2. **Count zombies and find their parents**. From a debug pod on the node:
+
+   ```bash
+   chroot /host bash -c 'ps -elfL | awk "\$2==\"Z\" {print \$5}" | sort | uniq -c | sort -rn | head'
+   ```
+
+   The output is `<count> <ppid>`; high counts under a small number of `PPIDs` is the leak signature.
+
+3. **Check that the parents are `conmon`**, not the application itself. A leaking `conmon` is the runtime issue; a leaking application parent is something else.
+
+   ```bash
+   chroot /host bash -c 'for ppid in <ppid1> <ppid2>; do echo "--- $ppid ---"; ps -p $ppid -o pid,ppid,comm; done'
+   ```
+
+   The `comm` should be `conmon`. The grandparent will be the container runtime.
+
+4. **Map `conmon` back to a pod**. The `conmon` cgroup path encodes the container ID; from there, the pod is one runtime call away:
+
+   ```bash
+   chroot /host bash -c 'cat /proc/<conmon-pid>/cgroup'
+   chroot /host crictl ps --no-trunc | grep <container-id-prefix>
+   chroot /host crictl inspect <container-id> | jq '.info.config.labels'
+   ```
+
+   The labels include `io.kubernetes.pod.namespace` and `io.kubernetes.pod.name`.
+
+5. **Inspect the pod's probes** to see whether they are `exec`-based and how often they run:
+
+   ```bash
+   kubectl -n <ns> get pod <pod> -o yaml \
+     | yq '.spec.containers[].livenessProbe, .spec.containers[].readinessProbe, .spec.containers[].startupProbe'
+   ```
+
+   `exec` probes with very small `periodSeconds` are the workloads most likely to be feeding the leak.
+
+6. **Cross-check across the cluster** to find every pod with the same probe pattern, so the workaround can be applied at the source rather than per-pod:
+
+   ```bash
+   kubectl get pods -A -o json \
+     | jq -r '.items[]
+              | select(.spec.containers[]?.livenessProbe.exec)
+              | "\(.metadata.namespace)/\(.metadata.name)"'
+   ```

--- a/docs/en/solutions/Worker_Nodes_Accumulate_Zombies_and_High_Load_From_Exec_Probe_Leak.md
+++ b/docs/en/solutions/Worker_Nodes_Accumulate_Zombies_and_High_Load_From_Exec_Probe_Leak.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Worker Nodes Accumulate Zombies and High Load From Exec Probe Leak
 ## Issue
 
 A worker node is loaded far above its normal baseline. Common observations:


### PR DESCRIPTION
新增一篇 ACP KB 文章。
