### PR TITLE
[configure] Application pod restart from OOMKilled and liveness probe timeout on ACP

### DIFF
--- a/docs/en/solutions/Application_Pod_Restarts_From_OOMKill_and_Liveness_Probe_Timeout.md
+++ b/docs/en/solutions/Application_Pod_Restarts_From_OOMKill_and_Liveness_Probe_Timeout.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Application Pod Restarts From OOMKill and Liveness Probe Timeout
 ## Issue
 
 An application pod restarts intermittently. The kubelet records two distinct symptoms back-to-back on the affected node, both pointing at the same workload:

--- a/docs/en/solutions/Application_Pod_Restarts_From_OOMKill_and_Liveness_Probe_Timeout.md
+++ b/docs/en/solutions/Application_Pod_Restarts_From_OOMKill_and_Liveness_Probe_Timeout.md
@@ -1,0 +1,120 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+An application pod restarts intermittently. The kubelet records two distinct symptoms back-to-back on the affected node, both pointing at the same workload:
+
+- A liveness probe times out:
+
+  ```text
+  prober.go: Liveness probe for "<pod>" failed (failure):
+    Get http://<podIP>:8080/health-check?type=ALIVE:
+    net/http: request canceled (Client.Timeout exceeded while awaiting headers)
+  ```
+
+- The kernel out-of-memory killer reaps the container shortly after, leaving a cgroup record:
+
+  ```text
+  kernel: memory: usage 2457600kB, limit 2457600kB, failcnt 176087
+  ```
+
+The crash usually appears under load — peak hours, a burst from an upstream caller, or a slow downstream that backs up the application's request queue. Once the load relaxes the pod runs cleanly again until the next spike.
+
+## Root Cause
+
+Both signals trace back to the same condition: the container is operating right at its memory limit and is starved of CPU at exactly the moment the kubelet probes it. The probe timeout fires because the application is too busy (or too memory-pressured) to answer the health endpoint within the configured window; the OOM kill fires because the working set has grown past the configured limit. The kubelet records the probe failure first because it polls on a faster cadence than the kernel's OOM accounting.
+
+The ratio of `requests` to `limits` aggravates the problem. A container that requests `2m` CPU but allows itself to burst to `1500m` is competing with every other burstable pod on the node every time it tries to scale up — and burstable pods receive CPU only after guaranteed-tier work has been served. Under contention, the application stalls, the probe fails, and the pod is restarted; under sustained pressure, it allocates past its memory limit and is killed.
+
+## Resolution
+
+1. **Right-size CPU and memory requests.** `requests` is what the scheduler reserves and what the kernel guarantees — not `limits`. If the workload routinely uses 800m CPU at peak, request 800m, not 2m. The same applies to memory: requests should reflect the steady-state working set so the scheduler does not pack the node beyond what the workload actually needs.
+
+   ```yaml
+   resources:
+     requests:
+       cpu: "800m"
+       memory: "2400Mi"
+     limits:
+       cpu: "1500m"
+       memory: "3000Mi"
+   ```
+
+   Leaving headroom between request and limit (memory in particular) reduces the chance of an OOM kill on a transient spike. A 1:1 request:limit on memory promotes the pod to the `Guaranteed` QoS class and prevents it from being evicted before lower-priority work — a sensible default for latency-sensitive workloads.
+
+2. **Tune the liveness probe so it survives a brief stall.** The default `timeoutSeconds: 1` is aggressive for any application that does work in its health endpoint. Increase it to 3–5 seconds, raise `failureThreshold` to 3, and add an `initialDelaySeconds` long enough for warm-up:
+
+   ```yaml
+   livenessProbe:
+     httpGet:
+       path: /health-check?type=ALIVE
+       port: 8080
+     initialDelaySeconds: 30
+     periodSeconds: 10
+     timeoutSeconds: 5
+     failureThreshold: 3
+   ```
+
+   Distinguish liveness from readiness. A readiness probe failure removes the pod from the Service endpoints; a liveness probe failure restarts the container. Many "OOM during peak" reports are actually the liveness probe restarting a healthy-but-slow pod into oblivion.
+
+3. **Distribute load across more replicas.** If a single pod cannot absorb the peak, scale horizontally rather than vertically. A `HorizontalPodAutoscaler` keyed off CPU (or, with metrics-server + an adapter, off a custom metric like queue depth) prevents the next spike from killing the pod set:
+
+   ```yaml
+   apiVersion: autoscaling/v2
+   kind: HorizontalPodAutoscaler
+   metadata:
+     name: app
+   spec:
+     scaleTargetRef:
+       apiVersion: apps/v1
+       kind: Deployment
+       name: app
+     minReplicas: 2
+     maxReplicas: 10
+     metrics:
+       - type: Resource
+         resource:
+           name: cpu
+           target:
+             type: Utilization
+             averageUtilization: 70
+   ```
+
+4. **Confirm the application is actually leak-free.** Repeated OOM kills with growing `failcnt` between restarts can mean the application's memory grows unboundedly under load. Capture a heap profile (or the equivalent for the runtime) at peak and walk back to the allocator before assuming the limits are too low.
+
+## Diagnostic Steps
+
+Inspect the pod's restart history and look for the OOM signature:
+
+```bash
+kubectl get pod <pod> -o jsonpath='{.status.containerStatuses[*].restartCount}{"\n"}'
+kubectl get pod <pod> -o jsonpath='{.status.containerStatuses[*].lastState.terminated.reason}{"\n"}'
+kubectl describe pod <pod> | sed -n '/Last State/,/Ready/p'
+```
+
+A `Reason: OOMKilled` confirms the kernel killed the container; pair that with the kubelet probe events:
+
+```bash
+kubectl describe pod <pod> | sed -n '/Events/,$p' | grep -E "Unhealthy|OOM|Killing"
+```
+
+Capture per-container memory usage to see how close the working set is to the limit:
+
+```bash
+kubectl top pod <pod> --containers
+```
+
+A container reporting memory `~95%` of its limit at idle is one transient spike away from an OOM kill. From the node, the kernel's OOM record gives the precise moment of death:
+
+```bash
+kubectl debug node/<node> -it --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+  -- chroot /host journalctl -k --since "1 hour ago" | grep -E "Killed process|oom-kill"
+```
+
+Cross-reference the timestamps with the application's own logs to confirm whether the kill landed mid-request or during a quiescent moment — a kill at idle points to a leak; a kill mid-request points to under-provisioned limits.

--- a/docs/en/solutions/Application_pod_restart_from_OOMKilled_and_liveness_probe_timeout_on_ACP.md
+++ b/docs/en/solutions/Application_pod_restart_from_OOMKilled_and_liveness_probe_timeout_on_ACP.md
@@ -1,0 +1,122 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Application pod restart from OOMKilled and liveness probe timeout on ACP
+
+## Issue
+
+On Alauda Container Platform (Kubernetes v1.34.5, Ubuntu 22.04.1 LTS nodes, kernel 5.15.0-56-generic), an application container is terminated when its memory usage reaches the configured `resources.limits.memory`. The kubelet stamps the container's terminated state with the canonical reason value `OOMKilled`, which surfaces on the Pod status under `status.containerStatuses[].state.terminated.reason` or, after a restart, under `status.containerStatuses[].lastState.terminated.reason` (with the matching `exitCode`, `finishedAt`, `signal`, and `containerID` fields populated per the upstream Pod v1 shape).
+
+When the same container is restarted by the kubelet and is OOM-killed again on each retry, the kubelet escalates the restart policy into a back-off loop and reports the container under `status.containerStatuses[].state.waiting.reason` with the canonical reason value `CrashLoopBackOff` — the standard upstream Pod v1 reason for a container that repeatedly fails to come up.
+
+Under the same memory pressure, the kubelet's liveness probe against the container can also fail before the cgroup limit is reached, because the upstream `Probe` shape defaults `timeoutSeconds` to `1` (with `periodSeconds` `10` and `failureThreshold` `3`); when the application thread is paused by the kernel memory subsystem, a 1-second HTTP probe times out and the kubelet logs a `prober.go:NNN] Liveness probe for <pod>:<container> failed (failure): Get http://...: net/http: request canceled (Client.Timeout exceeded while awaiting headers)` line that is then visible via the kubelet's journal unit.
+
+## Root Cause
+
+The container's working-set memory under load exceeds the value set in `resources.limits.memory`. When the cgroup memory controller terminates the offending process, the container ends with `state.terminated.reason=OOMKilled` and the kill is reflected on the Pod object; if the Pod's `restartPolicy` permits, the container is restarted, and repeated failures of the same form surface `state.waiting.reason=CrashLoopBackOff` on subsequent attempts.
+
+The same memory pressure also stalls in-process work long enough that the default 1-second liveness probe timeout fires; the kubelet treats successive failures (default `failureThreshold=3`) as a failed probe and restarts the container, which compounds the OOM-driven restart cycle observed on the Pod status.
+
+## Resolution
+
+Raise the container's memory budget on the workload's Deployment (or other controller) by setting `resources.requests.memory` and `resources.limits.memory` to values that cover the application's peak working set. The Pod spec field shape `containers[].resources.{limits,requests}` is the upstream `map[string]Quantity` (keys `memory`, `cpu`, `ephemeral-storage`) and is identical on ACP, so a standard manifest applies verbatim:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: my-app
+          image: my-app:latest
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+```
+
+Apply the change with a standard rollout:
+
+```bash
+kubectl apply -f my-app-deployment.yaml
+kubectl rollout status deploy/my-app
+```
+
+Where the liveness probe is also tripping under load, relax the probe budget so the 1-second default does not fire during transient memory pressure. The `Probe` shape exposes `timeoutSeconds`, `periodSeconds`, and `failureThreshold` directly on the container spec, and raising `timeoutSeconds` (and, if needed, `failureThreshold`) gives the application time to respond when the kernel briefly pauses it:
+
+```yaml
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          timeoutSeconds: 5
+          periodSeconds: 10
+          failureThreshold: 3
+```
+
+For workloads whose memory footprint scales with traffic (peak-hour load, batch windows), pair the limit increase with a `HorizontalPodAutoscaler` so that replica count grows before any single replica reaches its limit. The HPA api-group `autoscaling/v2` (`HorizontalPodAutoscaler`, short name `hpa`) is present on ACP unchanged and accepts the standard upstream spec:
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: my-app
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-app
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75
+```
+
+```bash
+kubectl apply -f my-app-hpa.yaml
+kubectl get hpa my-app
+```
+
+## Diagnostic Steps
+
+Identify the killed container and confirm the terminated reason on the Pod object directly. The `OOMKilled` reason is what the kubelet writes when the cgroup memory controller terminates the container process, and it appears on `state.terminated.reason` on the current attempt or on `lastState.terminated.reason` after the container has been restarted:
+
+```bash
+kubectl get pod <pod> -o yaml
+kubectl get pod <pod> \
+  -o jsonpath='{.status.containerStatuses[*].lastState.terminated.reason}'
+kubectl get pod <pod> \
+  -o jsonpath='{.status.containerStatuses[*].state.terminated.reason}'
+```
+
+Check whether the same container is now in a back-off loop. The waiting reason `CrashLoopBackOff` on the container status is the kubelet's canonical signal for repeated failures, and on a pod that keeps OOM-killing this is the value that appears:
+
+```bash
+kubectl get pod <pod> \
+  -o jsonpath='{.status.containerStatuses[*].state.waiting.reason}'
+kubectl describe pod <pod>
+```
+
+When liveness-probe failures are suspected as a contributing trigger, read the kubelet journal on the node where the pod was scheduled — the `prober.go` log line surfaces probe failures in the upstream format and the kubelet on ACP nodes runs as a plain systemd unit `kubelet.service`, so `journalctl -u kubelet` exposes the same line shape:
+
+```bash
+kubectl get pod <pod> -o jsonpath='{.spec.nodeName}'
+journalctl -u kubelet --since "1 hour ago" | grep -E 'prober.go.*Liveness probe'
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章。
