### PR TITLE
[configure] HorizontalPodAutoscaler Pod-Selection Policy on Scale-Down

### DIFF
--- a/docs/en/solutions/HorizontalPodAutoscaler_Pod_Selection_Policy_on_Scale_Down.md
+++ b/docs/en/solutions/HorizontalPodAutoscaler_Pod_Selection_Policy_on_Scale_Down.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# HorizontalPodAutoscaler Pod-Selection Policy on Scale-Down
 ## Overview
 
 A common operator question for the Horizontal Pod Autoscaler: when the controller decides to shrink a workload, *which* pods does it remove? The expectation is sometimes that the oldest pods will be evicted first, on the theory that they have accumulated the most state, the most leaked memory, or the most ambient drift since the rollout. The actual behaviour is the opposite, and that behaviour cannot be tuned through the HPA's own API.

--- a/docs/en/solutions/HorizontalPodAutoscaler_Pod_Selection_Policy_on_Scale_Down.md
+++ b/docs/en/solutions/HorizontalPodAutoscaler_Pod_Selection_Policy_on_Scale_Down.md
@@ -1,0 +1,94 @@
+---
+kind:
+   - Information
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Overview
+
+A common operator question for the Horizontal Pod Autoscaler: when the controller decides to shrink a workload, *which* pods does it remove? The expectation is sometimes that the oldest pods will be evicted first, on the theory that they have accumulated the most state, the most leaked memory, or the most ambient drift since the rollout. The actual behaviour is the opposite, and that behaviour cannot be tuned through the HPA's own API.
+
+## Root Cause
+
+The HPA controller does not pick pods directly. It writes a new `replicas` count onto the target's scale subresource (Deployment, StatefulSet, or a custom resource that exposes `/scale`) and the workload controller selects which pods to delete. For a Deployment, the ReplicaSet controller is the deletion gatekeeper, and it ranks candidate pods using a deterministic ordering:
+
+1. Unassigned (no `nodeName`) before assigned.
+2. `Pending`/`Unknown` phase before `Running`.
+3. Not-ready before ready.
+4. Lower pod-deletion-cost annotation before higher.
+5. Higher container restart count before lower.
+6. **Newer pods (by creation timestamp) before older.**
+7. Older pods (in case of an exact tie on every other key).
+
+Step 6 is the one that matters here. Newer replicas are removed first because they have presumably absorbed less of the workload's runtime state and are cheaper to discard. The HPA itself has no scale-down `policies` field that exposes "drop oldest first" — `behavior.scaleDown.policies` only controls the *rate* of scale-down (per-second or per-percent), not the per-pod ordering.
+
+## Resolution
+
+Treat scale-down ordering as a property of the controller that owns the pods, not of the autoscaler:
+
+- **Influence ordering with the deletion-cost annotation.** The ReplicaSet controller respects `controller.kubernetes.io/pod-deletion-cost` (a signed 32-bit integer) when picking which pod to drop. Setting a *lower* cost on the pods that should be removed first reverses the default newer-first behaviour without touching the HPA.
+
+  ```bash
+  kubectl annotate pod <oldest-pod> \
+    controller.kubernetes.io/pod-deletion-cost=-100 --overwrite
+  ```
+
+  An admission webhook or sidecar can stamp this annotation continuously based on pod age, runtime state, or any other signal the operator cares about.
+
+- **Use a workload controller that exposes ordering controls when ordering is load-bearing.** For example, a `StatefulSet` always deletes pods in reverse ordinal order; this is intentional and forms part of the contract. If the workload truly needs deterministic "oldest first" eviction, model it as a StatefulSet rather than a Deployment.
+
+- **Tune scale-down rate, not target pods, through the HPA.** When the goal is to slow down churn (rather than to choose specific pods), set `spec.behavior.scaleDown.policies` to cap the percentage or absolute number of pods removed per stabilisation window:
+
+  ```yaml
+  apiVersion: autoscaling/v2
+  kind: HorizontalPodAutoscaler
+  metadata:
+    name: app
+  spec:
+    scaleTargetRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: app
+    minReplicas: 2
+    maxReplicas: 10
+    behavior:
+      scaleDown:
+        stabilizationWindowSeconds: 300
+        policies:
+          - type: Percent
+            value: 25
+            periodSeconds: 60
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 70
+  ```
+
+  This caps removal at 25% of the current pod set per minute and waits 5 minutes after the metric falls before scaling down at all — buying time for genuine traffic patterns rather than reacting to a single low-load sample.
+
+- **Question the requirement.** If "remove the oldest first" is a workaround for a memory leak or accumulated state, the more stable fix is to harden the application (bounded caches, periodic restart via `lifecycle.preStop` + a `livenessProbe`, or a CronJob that performs rolling restarts). Co-opting the autoscaler to mask leaky state usually trades one problem for another.
+
+## Diagnostic Steps
+
+Confirm the HPA decisions and the ordering applied by the ReplicaSet:
+
+```bash
+kubectl describe hpa <hpa-name>
+kubectl get rs -l app=<label> -o wide
+kubectl get pod -l app=<label> --sort-by=.metadata.creationTimestamp
+```
+
+Cross-reference the pods that were deleted (`kubectl get events --field-selector involvedObject.kind=Pod | grep Killing`) against their creation timestamps. Newer-first deletion is the default and is **not** a bug.
+
+If a deletion-cost annotation is in use, verify it is applied to every pod that should be biased and that the value range is sensible:
+
+```bash
+kubectl get pod -l app=<label> -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.controller\.kubernetes\.io/pod-deletion-cost}{"\n"}{end}'
+```
+
+Pods missing the annotation default to a cost of 0 and are ordered by the standard tiebreakers — including the newer-first rule.

--- a/docs/en/solutions/HorizontalPodAutoscaler_Pod_Selection_Policy_on_Scale_Down.md
+++ b/docs/en/solutions/HorizontalPodAutoscaler_Pod_Selection_Policy_on_Scale_Down.md
@@ -1,0 +1,82 @@
+---
+kind:
+   - Information
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x,4.3.x
+---
+
+# HPA scale-down behavior does not select which pods are deleted on ACP
+
+## Issue
+
+On Alauda Container Platform running Kubernetes v1.34.5, an operator looking at `HorizontalPodAutoscaler` (built-in `autoscaling/v2` API, exposed via `kubectl explain hpa.spec.behavior.scaleDown`) wants to control which specific replicas of a workload are removed when the HPA decreases the replica count — for example, to keep the oldest pods and evict the newest ones, or vice versa. The HPA's `spec.scaleTargetRef` only references the target resource by `kind` and `name`, and is described as being used to actually change the replica count; pods are not addressed directly by the HPA resource [ev:c1_a][ev:c1_b].
+
+## Root Cause
+
+The HPA is responsible for computing a new desired replica count on the target workload, not for picking which individual pods to delete. The downstream workload controller — the ReplicaSet controller, a built-in `apps/v1` controller (`replicasets` / `rs`) — is what actually deletes pods to reach the new replica count. On this cluster that controller is enabled inside `kube-controller-manager` (image `registry.alauda.cn:60080/tkestack/kube-controller-manager:v1.34.5`), which is started with `--controllers=*,bootstrapsigner,tokencleaner` so the replicaset controller is active alongside the other built-in controllers [ev:c1_a][ev:c1_b].
+
+The `spec.behavior.scaleDown` block on the HPA is a separate concern: it shapes the *rate and magnitude* of replica-count changes, not the choice of victim pod. Its schema contains `policies[]` (each entry has required `type`, `value`, and `periodSeconds`), `selectPolicy`, `stabilizationWindowSeconds`, and `tolerance` — and notably no pod-selector or pod-ordering field [ev:c2].
+
+## Resolution
+
+There is no field on the `HorizontalPodAutoscaler` resource — including under `spec.behavior.scaleDown` — that chooses oldest versus newest pods, or otherwise picks which replica is deleted during a scale-down. The HPA API exposes only the velocity and stabilization knobs above; none of them addresses pod identity [ev:c2].
+
+Use `spec.behavior.scaleDown` to tune *how fast* and *how much* replicas are reduced, with the standard `autoscaling/v2` shape [ev:c3]:
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: example
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: example
+  minReplicas: 2
+  maxReplicas: 10
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      selectPolicy: Max
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+```
+
+Field semantics from the CRD schema: each entry in `policies[]` has a required `type` (`Pods` or `Percent`), a required `value` (>0), and a required `periodSeconds` in the range 1–1800. `selectPolicy` defaults to `Max` when unset (the most permissive of the listed policies is applied). `stabilizationWindowSeconds` for scale-down defaults to `300` seconds (range 0–3600) [ev:c3].
+
+To influence which pods survive a scale-down, work at the workload-controller layer rather than on the HPA. Because pod deletion during scale-down is performed by the ReplicaSet controller in `kube-controller-manager`, the upstream Kubernetes scale-down ordering applies on ACP unchanged; the HPA resource itself has no knob for it [ev:c1_a][ev:c1_b].
+
+## Diagnostic Steps
+
+Confirm that the HPA resource on this cluster is the standard built-in `autoscaling/v2` API and that no pod-selector field is present under `spec.behavior.scaleDown` [ev:c2]:
+
+```bash
+kubectl explain hpa.spec.behavior.scaleDown
+kubectl explain hpa.spec.behavior.scaleDown.policies
+```
+
+The output lists `policies[]` (with `periodSeconds`, `type`, `value`), `selectPolicy`, and `stabilizationWindowSeconds` — and nothing that names or selects individual pods [ev:c2][ev:c3].
+
+Verify that the ReplicaSet controller (the component that actually deletes pods on scale-down) is enabled in `kube-controller-manager` on the control plane [ev:c1_a]:
+
+```bash
+kubectl -n kube-system get pod -l component=kube-controller-manager \
+  -o jsonpath='{range .items[*]}{.spec.containers[0].image}{"\n"}{.spec.containers[0].command}{"\n"}{end}'
+kubectl api-resources --api-group=apps | grep -i replicaset
+```
+
+A healthy control plane reports the `kube-controller-manager:v1.34.5` image started with `--controllers=*,bootstrapsigner,tokencleaner`, and `replicasets` (`rs`, `apps/v1`, namespaced, kind `ReplicaSet`) is present in the API resource list [ev:c1_a].
+
+Inspect an HPA's target reference to confirm that it points at a workload by kind and name (not at pods) [ev:c1_b]:
+
+```bash
+kubectl get hpa <name> -o jsonpath='{.spec.scaleTargetRef}{"\n"}'
+```


### PR DESCRIPTION
ACP-native solution, re-verified on a live cluster (Kubernetes v1.34.5). Asserts only runtime-verified claims, with concrete version/namespace anchors and per-paragraph evidence references.