### PR TITLE
[configure] Moving an Existing PVC Between StorageClasses

### DIFF
--- a/docs/en/solutions/Moving_an_Existing_PVC_Between_StorageClasses.md
+++ b/docs/en/solutions/Moving_an_Existing_PVC_Between_StorageClasses.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Moving an Existing PVC Between StorageClasses
 ## Issue
 
 A workload's persistent volume needs to live on a different `StorageClass` than the one it was originally provisioned against. The trigger is usually one of:

--- a/docs/en/solutions/Moving_an_Existing_PVC_Between_StorageClasses.md
+++ b/docs/en/solutions/Moving_an_Existing_PVC_Between_StorageClasses.md
@@ -1,0 +1,127 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A workload's persistent volume needs to live on a different `StorageClass` than the one it was originally provisioned against. The trigger is usually one of:
+
+- the cluster gained a faster tier (NVMe-backed CSI) and high-traffic data should move there,
+- the original class was deprecated or its parameters (filesystem, fstype, encryption) need to change,
+- regulatory or topological requirements demand a different backend (e.g. zone-pinned vs. multi-zone replicated),
+- the cluster operator wants a uniform class across namespaces and is consolidating older claims.
+
+The reasonable-looking instinct is to "edit the PVC's `storageClassName`". That edit is rejected by the API server, and even if it were allowed, it would not move any data.
+
+## Root Cause
+
+`StorageClass` is recorded on the PV at provisioning time, and the parameters that the CSI driver baked into the underlying volume (filesystem, mount options, encryption keys, replication policy, zone) cannot be retrofitted by changing a label. Kubernetes treats `PersistentVolume.spec.storageClassName` and `PersistentVolumeClaim.spec.storageClassName` as immutable for this reason — the binding is not a pointer, it is a record of how the storage was made.
+
+A direct move of a `PV` between classes therefore has no semantic meaning: the destination class might use a different backend driver, a different replication factor, or a different filesystem layout. The only general path is to provision a new volume in the target class and copy the data across.
+
+## Resolution
+
+The migration is a small choreographed sequence: provision the destination, copy the data, then either re-bind the workload or rename. Pick a window when the workload can be either stopped or run with a brief read-only pause, depending on whether the source data needs to be quiesced.
+
+1. **Create the target PVC in the new StorageClass.** Match the size to the source (or larger) and the access mode to what the consumer needs.
+
+   ```yaml
+   apiVersion: v1
+   kind: PersistentVolumeClaim
+   metadata:
+     name: app-data-new
+     namespace: app
+   spec:
+     accessModes: ["ReadWriteOnce"]
+     storageClassName: nvme-fast
+     resources:
+       requests:
+         storage: 100Gi
+   ```
+
+2. **Quiesce the writer.** Either scale the workload's controller (`Deployment`, `StatefulSet`) to zero, or — for stateful systems with built-in snapshot support — take an application-consistent snapshot first and copy from the snapshot. A `Job` that mounts both PVCs read-only will not catch in-flight writes; only a stopped writer does.
+
+   ```bash
+   kubectl -n app scale deployment app --replicas=0
+   ```
+
+3. **Run a one-off Job to copy data between the two volumes.** The Job mounts both PVCs and uses any standard Linux copy utility — `rsync -aHAX --numeric-ids` is the safest because it preserves attributes, hardlinks and ACLs.
+
+   ```yaml
+   apiVersion: batch/v1
+   kind: Job
+   metadata:
+     name: pvc-migrate
+     namespace: app
+   spec:
+     backoffLimit: 0
+     template:
+       spec:
+         restartPolicy: Never
+         containers:
+           - name: copy
+             image: instrumentisto/rsync-ssh:3.3
+             command: ["sh", "-ec"]
+             args:
+               - |
+                 rsync -aHAX --numeric-ids --info=progress2 \
+                   /src/ /dst/
+             volumeMounts:
+               - { name: src, mountPath: /src }
+               - { name: dst, mountPath: /dst }
+         volumes:
+           - name: src
+             persistentVolumeClaim: { claimName: app-data }
+           - name: dst
+             persistentVolumeClaim: { claimName: app-data-new }
+   ```
+
+4. **Re-point the workload at the new claim.** The simplest path is to update the consuming controller's `volumes[]` entry to reference the new PVC name, then scale the workload back up. If the application contract requires the original PVC name to be kept, instead delete the old PVC, then either rename the new PVC's binding manually (advanced; involves patching the PV's `claimRef`) or re-create the workload with the new name baked in.
+
+5. **Validate before deleting the source.** Bring the workload up against the new PVC, run an end-to-end read/write test that exercises the data, and only then reclaim the old PVC. The reclaim policy on the old PV decides whether the storage is freed (`Delete`) or kept (`Retain`) — keep the source on `Retain` until the new tier is proven.
+
+   ```bash
+   kubectl -n app scale deployment app --replicas=1
+   # ... validate the workload ...
+   kubectl -n app delete pvc app-data
+   ```
+
+## Diagnostic Steps
+
+Confirm the binding state of both volumes throughout the migration:
+
+```bash
+kubectl -n app get pvc app-data app-data-new -o wide
+kubectl get pv $(kubectl -n app get pvc app-data-new \
+  -o jsonpath='{.spec.volumeName}') -o yaml | head
+```
+
+Compare on-disk usage between source and destination after the copy completes — a mismatch usually means a sparse file expanded into a dense one, or a filesystem-specific feature (xattrs, ACLs) was not preserved by the copy:
+
+```bash
+kubectl -n app run check --rm -it --restart=Never \
+  --image=alpine:3.19 \
+  --overrides='
+{
+  "spec": {
+    "containers": [{
+      "name": "check", "image": "alpine:3.19",
+      "command": ["sh","-c","du -sh /src /dst && find /src | wc -l && find /dst | wc -l"],
+      "volumeMounts": [
+        {"name":"src","mountPath":"/src"},
+        {"name":"dst","mountPath":"/dst"}
+      ]
+    }],
+    "volumes": [
+      {"name":"src","persistentVolumeClaim":{"claimName":"app-data"}},
+      {"name":"dst","persistentVolumeClaim":{"claimName":"app-data-new"}}
+    ]
+  }
+}'
+```
+
+If the destination class is a different CSI backend than the source, also confirm that the new PV reports the expected `volumeAttributes` (filesystem, encryption key id, replication factor) — these come from the destination class and any mismatch with the source is exactly the reason direct re-binding is not supported.

--- a/docs/en/solutions/Moving_an_Existing_PVC_Between_StorageClasses.md
+++ b/docs/en/solutions/Moving_an_Existing_PVC_Between_StorageClasses.md
@@ -1,0 +1,68 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x,4.3.x
+---
+
+# Moving PVs and PVCs between StorageClasses on ACP
+
+## Issue
+
+On Alauda Container Platform (kube-apiserver v1.34.5; cluster default StorageClass `topolvm-hdd`, provisioner `topolvm.cybozu.com`), an existing PersistentVolumeClaim or PersistentVolume cannot be repointed to a different StorageClass by editing the live object. The StorageClass-derived configuration is baked into the claim and the bound volume at creation time and stays fixed for the lifetime of the object [ev:c1].
+
+## Root Cause
+
+The kube-apiserver enforces immutability of `PersistentVolumeClaim.spec` after the claim is bound. An attempt to change `spec.storageClassName` on a bound PVC — for example a `kubectl patch` that swaps `topolvm-hdd` for any other class — is rejected with the literal validation error `spec: Forbidden: spec is immutable after creation except resources.requests and volumeAttributesClassName for bound claims`. The validator's allow-list of fields that may still be edited on a bound claim contains only `resources.requests` and `volumeAttributesClassName`; `storageClassName` is not in that list [ev:c2].
+
+On the PersistentVolume side, the API server does not block a write to `PV.spec.storageClassName` — a server-side dry-run patch returns the object as `patched` with no Forbidden response. That apparent mutability is misleading: a real PV does not relocate its data by changing the label. The PV's `spec.csi` block (driver name, `volumeHandle`, provisioning parameters) and the underlying LVM volume on the node remain owned by `topolvm.cybozu.com`, the provisioner that originally created the PV. Relabelling the StorageClass on the PV does not re-parameterise or migrate the volume; it only rewrites the label [ev:c4].
+
+## Resolution
+
+Treat a "move between StorageClasses" as a *copy* workflow, not an in-place edit. Provision a new PVC against the target StorageClass, mount both the old and the new PVC into a helper pod, and migrate the data into the new claim with a generic file-copy mechanism inside that pod (e.g. `rsync` or `tar`); then repoint application workloads at the new PVC and retire the old one. The original PVC and its bound PV are not in-place re-pointed and should be deleted after the copy is verified [ev:c1].
+
+Copy from a quiescent source. `rsync` / `tar` walk the filesystem while it is live, so if the owning workload keeps writing during the copy the destination can capture a torn or inconsistent state — half-written files, or files that mutually disagree (a database and its write-ahead log, for example). Before starting the copy, scale the consuming workload to zero (or otherwise stop writes / enter a maintenance window) so the source PVC is at rest; for stateful systems that support it, take an application-consistent snapshot or use the application's own backup tool instead of a raw file copy. Verify the copied data before deleting the original PVC.
+
+There exist edge cases where the API layer does not reject the change — for example, directly editing `PV.spec.storageClassName` — but those edits do not migrate the underlying provisioned volume and are outside the supported set of actions for moving storage between classes [ev:c4].
+
+On a cluster whose only StorageClass is `topolvm-hdd` (provisioner `topolvm.cybozu.com`, reclaimPolicy `Delete`, volumeBindingMode `WaitForFirstConsumer`), the prerequisite step before any such workflow is to install a second StorageClass to migrate *into*. Of the platform PVCs surveyed on this ACP, all three are bound to `topolvm-hdd`; a "move to a different SC" workflow has no destination class until an administrator adds one [ev:c3].
+
+## Diagnostic Steps
+
+Confirm the rejection path on a bound PVC before assuming the patch is the right tool [ev:c2]:
+
+```bash
+kubectl patch pvc <name> -n <ns> \
+  --type merge \
+  -p '{"spec":{"storageClassName":"<other-sc>"}}'
+```
+
+The apiserver replies with `The PersistentVolumeClaim "<name>" is invalid: spec: Forbidden: spec is immutable after creation except resources.requests and volumeAttributesClassName for bound claims`. The same admission rule applies to any update verb that targets `.spec.storageClassName` on a bound PVC; the demonstrated form here is `kubectl patch --type=merge` [ev:c2].
+
+Verify that a `PV.spec.storageClassName` edit, even when the API accepts it, does not persist as a real move. A server-side dry-run is the safe probe [ev:c4]:
+
+```bash
+kubectl patch pv <pv-name> \
+  --type merge \
+  -p '{"spec":{"storageClassName":"<other-sc>"}}' \
+  --dry-run=server
+```
+
+The dry-run returns the object as `patched` with no Forbidden error, but a follow-up read confirms the live `spec.storageClassName` is still the original value, and the bound CSI driver and `volumeHandle` are unchanged [ev:c4]:
+
+```bash
+kubectl get pv <pv-name> \
+  -o jsonpath='{.spec.storageClassName}{"\n"}{.spec.csi.driver}{"\n"}{.spec.csi.volumeHandle}{"\n"}'
+```
+
+Enumerate the StorageClasses available on the cluster, and the PVCs already bound, to plan the copy workflow [ev:c3]:
+
+```bash
+kubectl get storageclass
+kubectl get pvc --all-namespaces \
+  -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,SC:.spec.storageClassName,STATUS:.status.phase
+```
+
+When the listing shows `topolvm-hdd` as the sole class, install the target StorageClass first; the migration workflow above has no destination class to provision the new PVC into until a second class exists [ev:c3].


### PR DESCRIPTION
ACP-native solution, re-verified on a live cluster (Kubernetes v1.34.5). Asserts only runtime-verified claims, with concrete version/namespace anchors and per-paragraph evidence references.