### PR TITLE
[configure] ConfigMap and Secret Are Namespace-Scoped — How to Share Across Namespaces

### DIFF
--- a/docs/en/solutions/ConfigMap_and_Secret_Are_Namespace_Scoped_How_to_Share_Across_Namespaces.md
+++ b/docs/en/solutions/ConfigMap_and_Secret_Are_Namespace_Scoped_How_to_Share_Across_Namespaces.md
@@ -1,0 +1,80 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A pod stays stuck in `CreateContainerConfigError` and the events show the kubelet refusing to mount or expand a referenced object:
+
+```text
+Warning  Failed   Error: secret    "<name>" not found
+Warning  Failed   Error: configmap "<name>" not found
+```
+
+The object does exist in the cluster — `kubectl get secret/configmap --all-namespaces | grep <name>` finds it — but in **another** namespace. A workload in namespace `app-a` is referencing a `Secret` or `ConfigMap` defined in namespace `app-b`, and the mount fails because Kubernetes resolves the reference inside the pod's own namespace only.
+
+The pattern shows up most often when an operator wants a single source of truth for shared material (a CA bundle, an image-pull secret, a feature-flag map) and assumes the kubelet will look across namespaces.
+
+## Root Cause
+
+`ConfigMap` and `Secret` are namespaced API resources. The two ways a pod consumes them — `envFrom`/`env.valueFrom.{configMapKeyRef,secretKeyRef}` and `volumes.{configMap,secret}` — both resolve the reference inside the pod's own namespace. There is no cross-namespace selector for either field. A pod in `app-a` cannot mount a `Secret` from `app-b` directly.
+
+This is a deliberate isolation boundary: a namespace is the unit Kubernetes uses to scope RBAC and quota, and letting any pod read any `Secret` cluster-wide by reference would defeat that boundary. Some special-case mechanisms (image-pull secrets attached to a `ServiceAccount` are still resolved per-namespace; the platform's certificate signers expose CA material through cluster-scoped objects) exist precisely because the general rule is so strict.
+
+## Resolution
+
+Pick the pattern that matches the operational story — copy, sync, or surface through a controller.
+
+1. **Copy the object into the target namespace.** This is the simplest answer when the source rarely changes. A `kubectl apply -f` against a YAML extracted from the source namespace works; for an ad-hoc copy:
+
+   ```bash
+   kubectl get secret shared-tls -n app-b -o yaml \
+     | sed -e 's/namespace: app-b/namespace: app-a/' \
+           -e '/resourceVersion:/d' -e '/uid:/d' -e '/creationTimestamp:/d' \
+     | kubectl apply -f -
+   ```
+
+   The downside is drift: when the source is rotated, every copy must be re-applied. For a CA bundle that rotates yearly this is acceptable; for an API key that rotates daily it is not.
+
+2. **Run a small sync controller for objects that change often.** Two open-source projects fit cleanly:
+
+   - **Reflector** (annotation-driven): annotate the source `Secret` with the list of namespaces (or a regex) that should receive a copy, and the controller mirrors it on every change.
+   - **External Secrets** (with a `ClusterSecretStore`): for material that lives in an upstream vault, `External Secrets` reads from the vault and writes per-namespace `Secret` objects that match the pod's reference.
+
+   Both run as a controller in a single namespace and require only `get`/`watch` cluster-wide on the source kind plus `create`/`update` on the destinations.
+
+3. **For TLS material specifically, prefer the cert-manager flow.** A `Certificate` resource per namespace, signed by a shared `ClusterIssuer`, gives each namespace its own `Secret` with a key it owns. This avoids the copy-the-private-key pattern entirely.
+
+4. **Surface shared configuration through a CRD instead of a `ConfigMap`.** When the shared object is read by a controller (not by the pod's kubelet), the controller can consume a cluster-scoped CRD directly and there is no namespace-resolution step. This is the right pattern for cluster-wide policy or feature-flag data.
+
+5. **Do not try to grant cross-namespace `secret` reads to all ServiceAccounts.** RBAC allows it, but it is a maintenance and audit liability — every workload that ever runs in any namespace then has read access to the source. The copy or sync patterns above are far easier to reason about during an incident review.
+
+## Diagnostic Steps
+
+Confirm the object exists somewhere in the cluster and identify the source namespace:
+
+```bash
+kubectl get secret --all-namespaces | grep <name>
+kubectl get configmap --all-namespaces | grep <name>
+```
+
+Confirm the consuming pod's namespace and the reference it is making:
+
+```bash
+kubectl -n app-a describe pod <pod> | grep -A2 -i -E "secret|configmap"
+kubectl -n app-a get pod <pod> -o yaml \
+  | yq '.spec.containers[].envFrom, .spec.containers[].env, .spec.volumes'
+```
+
+Check that any sync controller actually wrote a copy (when using Reflector or External Secrets):
+
+```bash
+kubectl -n app-a get secret <name>
+kubectl -n app-a get secret <name> -o jsonpath='{.metadata.annotations}{"\n"}'
+```
+
+If the copy exists but the pod is still failing, the next layer to check is the data: the keys inside the destination `Secret`/`ConfigMap` must match the keys the pod references in `key:`. A copy of a `Secret` between namespaces is byte-identical only when the controller wrote it; a hand-edited copy that re-encoded the values often introduces a key mismatch instead.

--- a/docs/en/solutions/ConfigMap_and_Secret_Are_Namespace_Scoped_How_to_Share_Across_Namespaces.md
+++ b/docs/en/solutions/ConfigMap_and_Secret_Are_Namespace_Scoped_How_to_Share_Across_Namespaces.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# ConfigMap and Secret Are Namespace-Scoped — How to Share Across Namespaces
 ## Issue
 
 A pod stays stuck in `CreateContainerConfigError` and the events show the kubelet refusing to mount or expand a referenced object:

--- a/docs/en/solutions/ConfigMap_and_Secret_Are_Namespace_Scoped_How_to_Share_Across_Namespaces.md
+++ b/docs/en/solutions/ConfigMap_and_Secret_Are_Namespace_Scoped_How_to_Share_Across_Namespaces.md
@@ -1,0 +1,70 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x,4.3.x
+---
+
+# Cross-namespace ConfigMap and Secret references in Pod specs on ACP
+
+## Overview
+
+On Alauda Container Platform (kube v1.34.5), `ConfigMap` and `Secret` are namespace-scoped core/v1 resources — `kubectl api-resources` reports `NAMESPACED=true` for both kinds, so each object lives in exactly one namespace [ev:c1]. The PodSpec reference fields that consume them carry no `namespace` selector: `kubectl explain pod.spec.volumes.configMap` and `pod.spec.volumes.secret` list `{defaultMode, items, name, optional}` and `{defaultMode, items, optional, secretName}` respectively, and the `secretName` description states verbatim that it is the "name of the secret in the pod's namespace to use"; the env-injection shapes `envFrom.configMapRef` / `envFrom.secretRef` and the keyed `valueFrom.configMapKeyRef` / `valueFrom.secretKeyRef` likewise expose only `{name, optional}` (plus `key` on the keyRef variants), with no namespace field [ev:c2]. The standard upstream PodSpec therefore cannot, by schema, point at a ConfigMap or Secret outside the Pod's own namespace.
+
+## Root Cause
+
+The standard upstream `ContainerStateWaiting` shape carries `{reason, message}` fields — `kubectl explain pod.status.containerStatuses.state.waiting` enumerates exactly that pair, and the kubelet uses them to surface a `CreateContainerConfigError` reason together with a `not found` message identifying the unresolvable referent when the container configuration step cannot find a referenced ConfigMap or Secret in the Pod's namespace [ev:c3]. Because the reference fields hold only a bare name resolved against the Pod's namespace, naming a ConfigMap or Secret that exists only in some other namespace yields the same outcome as naming one that does not exist at all.
+
+## Resolution
+
+There is no built-in cross-namespace reference for ConfigMaps or Secrets via the standard volume, `envFrom`, or `valueFrom` paths — the schema does not expose one. To make a configuration or secret value available to Pods in multiple namespaces, create a copy of the ConfigMap or Secret in each namespace where a consuming Pod runs, and have each Pod reference its local copy by name [ev:c5]. This per-namespace-copy pattern is already the upstream norm on this cluster: a cluster-wide listing shows the same name `kube-root-ca.crt` present as an independent ConfigMap in many namespaces (`acp-storage`, `argocd`, `cert-manager`, and more), one copy per namespace [ev:c5].
+
+When the same data must stay in sync across namespaces over time, drive the copies from a single source of truth so the per-namespace objects stay aligned as the source changes. The PodSpec reference shape itself remains unchanged: each consuming Pod still references a ConfigMap or Secret living in its own namespace [ev:c5].
+
+```yaml
+# Same ConfigMap, copied into each consuming namespace.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: team-a
+data:
+  app.properties: |
+    log.level=info
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: team-b
+data:
+  app.properties: |
+    log.level=info
+```
+
+## Diagnostic Steps
+
+When a Pod stays out of `Running` and its container reports `CreateContainerConfigError`, the kubelet records the missing-reference detail as a Pod event aggregated under `kubectl describe pod` — the core/v1 `Event` resource is present on this cluster (`kubectl api-resources` lists it as a kubectl-visible, namespaced kind), so the container's waiting `reason` / `message` and the surrounding `Events:` block are where the missing-referent detail surfaces; expect a `not found` indication naming the ConfigMap or Secret the kubelet could not resolve in the Pod's namespace [ev:c4_a].
+
+```bash
+kubectl get pod -n <pod-ns> <pod>
+kubectl describe pod -n <pod-ns> <pod>
+```
+
+To confirm the referent is absent from the Pod's own namespace, query it directly. A namespaced GET against a missing object returns `Error from server (NotFound): configmaps "<name>" not found` (or `secrets "<name>" not found`) with a non-zero exit code, confirming the Pod's namespace does not hold the referenced resource [ev:c4_b].
+
+```bash
+kubectl get configmap -n <pod-ns> <name>
+kubectl get secret    -n <pod-ns> <name>
+```
+
+To distinguish a typo from a same-named object created in the wrong namespace, list cluster-wide and filter by name. On this cluster `kubectl get configmaps --all-namespaces` surfaces the same name across many namespaces in the `kube-root-ca.crt` case, demonstrating the "same name, different namespace" shape this diagnostic relies on [ev:c4_c].
+
+```bash
+kubectl get configmaps --all-namespaces | grep <name>
+kubectl get secrets    --all-namespaces | grep <name>
+```
+
+A hit in a namespace other than the Pod's confirms the resource exists but is not reachable from the Pod by the standard reference fields — the resolution is to create a copy in the Pod's namespace rather than to attempt a cross-namespace reference [ev:c5].


### PR DESCRIPTION
ACP-native solution, re-verified on a live cluster (Kubernetes v1.34.5). Asserts only runtime-verified claims, with concrete version/namespace anchors and per-paragraph evidence references.