### PR TITLE
[configure] Reverting Cluster Nodes Back to UTC After a Custom Timezone Was Pinned

### DIFF
--- a/docs/en/solutions/Reverting_Cluster_Nodes_Back_to_UTC_After_a_Custom_Timezone_Was_Pinned.md
+++ b/docs/en/solutions/Reverting_Cluster_Nodes_Back_to_UTC_After_a_Custom_Timezone_Was_Pinned.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Reverting Cluster Nodes Back to UTC After a Custom Timezone Was Pinned
 ## Issue
 
 A cluster's nodes were earlier reconfigured to a regional timezone (for example `Africa/Cairo`) through a node-level systemd unit, and the operator now needs them back on UTC for log correlation, scheduled jobs, and audit consistency. Removing the original node-config object alone does **not** undo the change — after a reboot the node still reports the regional zone:

--- a/docs/en/solutions/Reverting_Cluster_Nodes_Back_to_UTC_After_a_Custom_Timezone_Was_Pinned.md
+++ b/docs/en/solutions/Reverting_Cluster_Nodes_Back_to_UTC_After_a_Custom_Timezone_Was_Pinned.md
@@ -1,0 +1,116 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A cluster's nodes were earlier reconfigured to a regional timezone (for example `Africa/Cairo`) through a node-level systemd unit, and the operator now needs them back on UTC for log correlation, scheduled jobs, and audit consistency. Removing the original node-config object alone does **not** undo the change — after a reboot the node still reports the regional zone:
+
+```text
+$ kubectl debug node/<node> -- chroot /host ls -l /etc/localtime
+lrwxrwxrwx. 1 root root 34 Jan 15 2025 /etc/localtime -> ../usr/share/zoneinfo/Africa/Cairo
+
+$ kubectl debug node/<node> -- chroot /host timedatectl
+   Local time: Tue 2025-08-26 15:57:18 EEST
+Universal time: Tue 2025-08-26 12:57:18 UTC
+      Time zone: Africa/Cairo (EEST, +0300)
+```
+
+## Root Cause
+
+The earlier customization called `timedatectl set-timezone <zone>`, which is just a wrapper around the `tzdata` convention of pointing `/etc/localtime` at a zone file under `/usr/share/zoneinfo/`. The symlink is an artefact of the **last** explicit set-timezone call; deleting the configuration that placed it does not roll the symlink back. The system therefore stays on the regional zone until something explicitly writes UTC into `/etc/localtime`.
+
+In a declaratively-managed cluster the right shape is a new node-config object that writes UTC, replacing the previous one. Trying to fix this with a one-shot `chroot` on the node is fragile — the next configuration reconcile or node re-image will revert any out-of-band change.
+
+## Resolution
+
+### Preferred: ACP Immutable Infrastructure / Node Config Surface
+
+ACP exposes node configuration through `configure/clusters/nodes` (in-core) and the **Immutable Infrastructure** extension. Drive the reset through that surface: replace the existing custom-timezone node-config object with a UTC variant, let the controller pause the affected node pool, drain, reboot, and resume. The platform handles ordering across pools, so control-plane and worker reboots do not collide.
+
+### Underlying Mechanics
+
+For environments not yet onboarded to that surface (or for emergency one-cluster fixes), the same outcome can be reached by hand using the equivalent node-config CRDs that ship with the platform:
+
+1. **Pause the affected node pool** so a single reboot wave covers the swap. The label below assumes the original object targeted `master`; adapt for `worker` pools as needed.
+
+   ```bash
+   kubectl get mc 99-master-custom-timezone-configuration \
+     -o jsonpath='{.metadata.labels}{"\n"}'
+   kubectl patch mcp/master --type merge \
+     -p '{"spec":{"paused":true}}'
+   ```
+
+2. **Remove the previous node-config object** that pinned the regional timezone:
+
+   ```bash
+   kubectl delete machineconfig/99-master-custom-timezone-configuration
+   ```
+
+3. **Create a replacement node-config object** that runs `timedatectl set-timezone UTC` once at boot via a systemd unit. Write `/etc/localtime` deterministically, regardless of what the previous symlink pointed at:
+
+   ```yaml
+   apiVersion: machineconfiguration.k8s.io/v1
+   kind: MachineConfig
+   metadata:
+     labels:
+       node-role.kubernetes.io/master: ""
+     name: 99-master-custom-timezone-configuration
+   spec:
+     config:
+       ignition:
+         version: 3.4.0
+       systemd:
+         units:
+           - name: custom-timezone.service
+             enabled: true
+             contents: |
+               [Unit]
+               Description=Reset node timezone to UTC
+               After=network-online.target
+               [Service]
+               Type=oneshot
+               ExecStart=/usr/bin/timedatectl set-timezone UTC
+               [Install]
+               WantedBy=multi-user.target
+   ```
+
+4. **Apply it and unpause the pool** so the controller drains, reboots, and re-evaluates each node in order:
+
+   ```bash
+   kubectl apply -f 99-master-custom-timezone-configuration.yaml
+   kubectl patch mcp/master --type merge \
+     -p '{"spec":{"paused":false}}'
+   ```
+
+5. **Confirm the result.** Once the rollout completes, every node should report UTC:
+
+   ```text
+   $ kubectl debug node/<node> -- chroot /host timedatectl
+        Time zone: UTC (UTC, +0000)
+      Local time: Tue 2025-08-26 14:39:20 UTC
+   Universal time: Tue 2025-08-26 14:39:20 UTC
+
+   $ kubectl debug node/<node> -- chroot /host ls -l /etc/localtime
+   lrwxrwxrwx. 1 root root 25 Aug 24 19:19 /etc/localtime -> ../usr/share/zoneinfo/UTC
+   ```
+
+## Diagnostic Steps
+
+If a node finishes the rollout but still shows the old timezone, the `timedatectl` unit either did not run or crashed. Inspect the unit status from a debug session:
+
+```bash
+NODE=<node>
+kubectl debug node/$NODE -it -- chroot /host \
+  systemctl status custom-timezone.service --no-pager
+kubectl debug node/$NODE -it -- chroot /host \
+  journalctl -u custom-timezone.service --no-pager
+```
+
+A common failure is the unit running before `/usr/share/zoneinfo/` is writable — keep `After=network-online.target` (or another late-boot target) on the unit and avoid `Type=simple` so the executable is allowed to terminate.
+
+Persistent local-time confusion across pods (containers showing one zone, host showing another) is almost always a missing `TZ` env var or a missing `/etc/localtime` mount in the workload — fix it at the container layer rather than on the node.

--- a/docs/en/solutions/Reverting_Cluster_Nodes_Back_to_UTC_After_a_Custom_Timezone_Was_Pinned.md
+++ b/docs/en/solutions/Reverting_Cluster_Nodes_Back_to_UTC_After_a_Custom_Timezone_Was_Pinned.md
@@ -1,0 +1,97 @@
+---
+title: Revert ACP cluster nodes to UTC after a custom timezone was applied
+component: configure
+scenario: troubleshooting
+tags: [nodes, timezone, systemd, tzdata, kubectl-debug]
+date_created: 2026-05-30
+date_updated: 2026-05-30
+---
+
+# Revert ACP cluster nodes to UTC after a custom timezone was applied
+
+## Issue
+
+A custom non-UTC timezone (for example `Africa/Cairo`) has been applied
+to one or more ACP cluster nodes, and the active timezone — reported by
+the `Time zone` field of `timedatectl` — now needs to be returned to UTC
+for log-correlation consistency across the platform [ev:c2].
+
+On a Linux node, the active timezone is encoded by the `/etc/localtime`
+symlink pointing into the `/usr/share/zoneinfo/` tree shipped by the
+`tzdata` package; the cluster nodes observed here run kubelet `v1.34.5-1`
+on Ubuntu 22.04.1 LTS with systemd 249 and `tzdata 2022f`, and
+`/etc/localtime` resolves to `/usr/share/zoneinfo/Etc/UTC` in the
+nominal UTC state [ev:c1].
+
+```text
+lrwxrwxrwx 1 root root 27 /etc/localtime -> /usr/share/zoneinfo/Etc/UTC
+```
+
+`timedatectl` exposes the current timezone state through a fixed field
+set — `Local time`, `Universal time`, `RTC time`, `Time zone`,
+`System clock synchronized`, `NTP service`, and `RTC in local TZ` — and
+the `Time zone` field is the authoritative readout of the current
+zone [ev:c2].
+
+## Root Cause
+
+`timedatectl set-timezone <Zone>` changes the active timezone by
+re-pointing `/etc/localtime` to `/usr/share/zoneinfo/<Zone>`; the
+operation is an in-place symlink rewrite, and the binary is shipped at
+`/usr/bin/timedatectl` with the `set-timezone ZONE` subcommand
+documented by `timedatectl --help` itself [ev:c3]. Because the symlink
+is the only persistent record of the active zone, the timezone state on
+a node is exactly the current `/etc/localtime` target — no separate
+"desired zone" file exists on disk for a controller or a wrapper to
+re-read [ev:c1].
+
+## Resolution
+
+The revert is therefore a forward action: explicitly invoke
+`timedatectl set-timezone UTC` on each affected node (or otherwise
+re-point `/etc/localtime` to `/usr/share/zoneinfo/UTC`); merely deleting
+the wrapper that previously set the non-UTC zone is insufficient
+[ev:c5_a]. The destination path is available on the platform's nodes:
+`/usr/share/zoneinfo/UTC` is shipped as a symlink to `Etc/UTC` by the
+node's `tzdata` package.
+
+A `kubectl debug` host-namespace session is the in-cluster way to run
+the revert without arranging direct SSH to every node. The host
+filesystem is mounted at `/host` inside the debug container, so the
+revert command runs against the node's real `/etc` via `chroot /host`
+[ev:c8_b].
+
+```bash
+kubectl debug node/<node-name> -it --image=<registry-internal-image> \
+  -- chroot /host timedatectl set-timezone UTC
+```
+
+Repeat the command for every node that needs to return to UTC; once
+the `set-timezone` call returns, the `/etc/localtime` symlink on that
+node points at `/usr/share/zoneinfo/UTC` (which itself resolves to
+`Etc/UTC`) and `timedatectl` reports the `Time zone` field as
+`Etc/UTC (UTC, +0000)` [ev:c2].
+
+## Diagnostic Steps
+
+Use the same `kubectl debug` shape to read the live state on a node
+without mutating it; the host root is mounted at `/host`, so the
+inspection commands run via `chroot /host` against the node's real
+`/etc` and `/usr/share/zoneinfo` [ev:c8_b].
+
+```bash
+kubectl debug node/<node-name> -it --image=<registry-internal-image> \
+  -- chroot /host timedatectl
+```
+
+```bash
+kubectl debug node/<node-name> -it --image=<registry-internal-image> \
+  -- chroot /host ls -l /etc/localtime
+```
+
+The first command prints the seven `timedatectl` status fields,
+including the authoritative `Time zone` row [ev:c2]. The second command
+prints the `/etc/localtime` symlink target, which encodes the active
+zone directly; a `Time zone` row of `Etc/UTC (UTC, +0000)` plus an
+`/etc/localtime` target of `/usr/share/zoneinfo/Etc/UTC` confirms a
+node is back on UTC [ev:c1].


### PR DESCRIPTION
新增一篇 ACP KB 文章，归入 `configure` 区域。

**⚠️ 自动化验证：无测试计划** — 本篇未登记验证计划，暂不自动合并，请人工确认内容后再合。

## `configure` 区域建议 reviewer

按 `kb/OWNERS.md`（来源：alauda-ai-base operator-list 的产品 owner）该区域候选自动挑选，@ 错了请无视。


没有 GitHub handle 的贡献者（本区域相关请人工 ping）：

- gangwang &lt;gangwang@alauda.io&gt;
- xdzhang &lt;xdzhang@alauda.io&gt;
