### PR TITLE
[configure] When the etcd Auto-Defragmentation Loop Stays Quiet

### DIFF
--- a/docs/en/solutions/When_the_etcd_Auto_Defragmentation_Loop_Stays_Quiet.md
+++ b/docs/en/solutions/When_the_etcd_Auto_Defragmentation_Loop_Stays_Quiet.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# When the etcd Auto-Defragmentation Loop Stays Quiet
 ## Issue
 
 The control-plane etcd database keeps growing on disk and operators expect the automatic defragmentation loop to reclaim the slack. Instead, no defragmentation events are observed in the operator logs even though:

--- a/docs/en/solutions/When_the_etcd_Auto_Defragmentation_Loop_Stays_Quiet.md
+++ b/docs/en/solutions/When_the_etcd_Auto_Defragmentation_Loop_Stays_Quiet.md
@@ -1,0 +1,114 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+The control-plane etcd database keeps growing on disk and operators expect the automatic defragmentation loop to reclaim the slack. Instead, no defragmentation events are observed in the operator logs even though:
+
+- the defragmentation feature has not been explicitly disabled,
+- a manual `etcdctl defrag` against a single member visibly shrinks the on-disk size,
+- the cluster is not under maintenance pause.
+
+The question is therefore not "why does defragmentation fail" but "why does the controller decide there is nothing to do".
+
+## Root Cause
+
+The etcd controller's defragmentation loop is not driven by absolute size — it is driven by **two** thresholds that must both be satisfied before a member is considered a candidate:
+
+| Threshold | Default | Meaning |
+|---|---|---|
+| Fragmentation ratio | 45 % | `(size_on_disk - size_in_use) / size_on_disk` must exceed this value |
+| Minimum DB size | 100 MiB | absolute on-disk size must exceed this floor |
+
+The ratio guards against churning members that already pack tightly; the floor guards against running expensive offline compaction on small databases that gain little from it. A cluster sitting at, say, **30 % fragmentation on a 4 GB store** clears the floor easily but is still well below the ratio threshold — so the controller logs the measurement and does nothing. From the operator's perspective the loop is "broken"; from the controller's perspective it is correctly waiting until a single defragmentation will reclaim a meaningful amount.
+
+A useful way to think about it: a manual defrag will *always* shrink the file because BoltDB rewrites it in pack-tight order. The interesting question is whether the cost (a brief leader pause, stop-the-world compaction on the member) is worth it for the bytes returned. The 45 % default is the controller's answer.
+
+## Resolution
+
+### Step 1 — Confirm the controller is observing the cluster
+
+Inspect the etcd operator's defrag controller log line on each member; it reports the live ratio and absolute size:
+
+```bash
+kubectl -n <etcd-operator-namespace> logs deploy/etcd-operator \
+  | grep -i defrag | tail -n 20
+```
+
+A healthy line looks like:
+
+```text
+defragcontroller.go:... etcd member "node-1.example" backend store fragmented:
+30.95 %, dbSize: 4238577664
+```
+
+If those lines are present and the ratio is below the threshold, the controller is doing its job — it is reporting "below threshold, no action".
+
+### Step 2 — Decide whether the threshold should be lowered
+
+For most clusters the defaults are correct. Consider lowering the ratio only when:
+
+- the etcd disk is small enough that 45 % slack is operationally painful (e.g. a 200 MiB DB on a small lab),
+- write amplification on the underlying storage makes free pages expensive,
+- a downstream tool (backup, snapshot transfer) is sensitive to the on-disk file size, not the in-use size.
+
+If the threshold needs to be relaxed, change it through the cluster's etcd configuration object rather than by patching the operator deployment — patches to the deployment are reverted on the next reconcile.
+
+### Step 3 — When an immediate manual defrag is needed
+
+For a one-off reclaim (for example before snapshotting or before increasing the DB size limit), defrag each member sequentially, **never in parallel**, and observe the leader after each pass. The exec is run inside the etcd container of each control-plane pod:
+
+```bash
+for pod in $(kubectl -n kube-system get pod -l component=etcd \
+              -o jsonpath='{.items[*].metadata.name}'); do
+  echo "===== $pod"
+  kubectl -n kube-system exec "$pod" -c etcd -- sh -c "
+    ETCDCTL_API=3 etcdctl \
+      --endpoints=https://127.0.0.1:2379 \
+      --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+      --cert=/etc/kubernetes/pki/etcd/server.crt \
+      --key=/etc/kubernetes/pki/etcd/server.key \
+      defrag
+  "
+  sleep 30
+done
+```
+
+Defragmentation is a stop-the-world operation on the targeted member — clients pin to a different member while it runs. Pacing the loop avoids two members being unavailable at the same time and forcing a leader election under load.
+
+## Diagnostic Steps
+
+Watch the in-use vs. on-disk numbers per member:
+
+```bash
+for pod in $(kubectl -n kube-system get pod -l component=etcd \
+              -o jsonpath='{.items[*].metadata.name}'); do
+  echo "===== $pod"
+  kubectl -n kube-system exec "$pod" -c etcd -- sh -c "
+    ETCDCTL_API=3 etcdctl \
+      --endpoints=https://127.0.0.1:2379 \
+      --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+      --cert=/etc/kubernetes/pki/etcd/server.crt \
+      --key=/etc/kubernetes/pki/etcd/server.key \
+      endpoint status -w table
+  "
+done
+```
+
+The `DB SIZE` column is the on-disk file; cross-check it against `etcdctl endpoint status` `RAFT INDEX` and `RAFT TERM` to make sure the members agree on history before deciding whether the size delta is fragmentation or genuine growth.
+
+If a single member is dramatically larger than the others, the cause is usually a stale alarm that pinned the database — clear it before defragmenting:
+
+```bash
+kubectl -n kube-system exec "<member-pod>" -c etcd -- sh -c "
+  ETCDCTL_API=3 etcdctl alarm list
+  ETCDCTL_API=3 etcdctl alarm disarm
+"
+```
+
+If the database is still growing after a successful defrag, the cause is not fragmentation but live volume — look for a workload churning ConfigMaps, leases, or events. The store will not shrink while the producer keeps writing.

--- a/docs/en/solutions/When_the_etcd_Auto_Defragmentation_Loop_Stays_Quiet.md
+++ b/docs/en/solutions/When_the_etcd_Auto_Defragmentation_Loop_Stays_Quiet.md
@@ -1,0 +1,102 @@
+---
+title: When etcd auto-defragmentation does not run on Alauda Container Platform
+component: configure
+scenario: troubleshooting
+tags: [etcd, defragmentation, kube-system, control-plane]
+date_created: 2026-05-30
+date_updated: 2026-05-30
+---
+
+# When etcd auto-defragmentation does not run on Alauda Container Platform
+
+## Issue
+
+On Alauda Container Platform (kube v1.34.5), the etcd database size keeps growing on the control plane and never appears to shrink on its own. Operators expect a periodic, automatic defragmentation cycle, but the on-disk size reported by `etcdctl endpoint status` stays flat or grows even though etcd itself is healthy and accepting writes. A manual defragmentation, on the other hand, reliably reduces the on-disk size [ev:c4].
+
+The platform ships etcd as a kubeadm-managed static pod (`etcd-<control-plane-IP>` in the `kube-system` namespace), running the upstream `tkestack/etcd:v3.5.28-260421` image. The kubelet starts whatever manifest is in `/etc/kubernetes/manifests/etcd.yaml`; no higher-level controller reconciles defragmentation policy on top of it [ev:c4].
+
+## Root Cause
+
+The upstream etcd binary supports defragmentation as a client-driven operation (`etcdctl defrag`), but it does not defragment itself on a schedule [ev:c4]. The static-pod manifest enables only the periodic compaction loop (`--auto-compaction-mode=periodic --auto-compaction-retention=24h`), which reclaims logical revisions in the MVCC store but leaves the underlying BoltDB file allocated. Compaction reduces `current-db-size-in-use-bytes`; defragmentation is the separate operation that shrinks `current-db-size-bytes` back down to match [ev:c4][ev:c2].
+
+The signal that tells an operator whether defragmentation is worthwhile is the fragmentation ratio, computed from the two size fields etcd already exposes:
+
+```text
+fragmentation = (size_on_disk - size_in_use) / size_on_disk
+```
+
+Where `size_on_disk` is the BoltDB file's allocated bytes and `size_in_use` is the bytes occupied by live (post-compaction) revisions [ev:c2]. A high ratio means the file has accumulated free pages that only `defrag` will reclaim.
+
+## Resolution
+
+Read the fragmentation telemetry from the etcd pod's own log, then run a manual defragmentation when the ratio justifies it [ev:c2][ev:c4].
+
+The periodic compaction loop emits one log line every five minutes that carries both size fields:
+
+```bash
+kubectl -n kube-system logs etcd-<control-plane-IP> --tail=200 \
+  | grep 'finished scheduled compaction'
+```
+
+A representative entry looks like:
+
+```text
+{"level":"info","caller":"mvcc/kvstore_compaction.go:72","msg":"finished scheduled compaction",
+ "compact-revision":1198057,"took":"216.242588ms",
+ "current-db-size-bytes":99495936,"current-db-size":"100 MB",
+ "current-db-size-in-use-bytes":62197760,"current-db-size-in-use":"62 MB"}
+```
+
+Compute the ratio from `current-db-size-bytes` and `current-db-size-in-use-bytes` in that line — that is the same arithmetic the upstream rule of thumb uses [ev:c2]. Operators typically run defragmentation once the ratio crosses roughly 45% on a database larger than ~100 MiB; below that threshold the reclaimable space is usually not worth the brief write blocking that defragmentation incurs [ev:c2].
+
+When the ratio justifies it, run defragmentation directly against the local member. The etcd image ships the standard `etcdctl` binary and the kubeadm-style PKI paths are mounted at `/etc/kubernetes/pki/etcd/` inside the pod [ev:c4]:
+
+```bash
+kubectl -n kube-system exec etcd-<control-plane-IP> -- \
+  etcdctl \
+    --endpoints=https://127.0.0.1:2379 \
+    --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+    --cert=/etc/kubernetes/pki/etcd/server.crt \
+    --key=/etc/kubernetes/pki/etcd/server.key \
+    defrag
+```
+
+Confirm the on-disk size shrank by re-reading endpoint status:
+
+```bash
+kubectl -n kube-system exec etcd-<control-plane-IP> -- \
+  etcdctl \
+    --endpoints=https://127.0.0.1:2379 \
+    --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+    --cert=/etc/kubernetes/pki/etcd/server.crt \
+    --key=/etc/kubernetes/pki/etcd/server.key \
+    endpoint status -w table
+```
+
+The `DB SIZE` column is the same number `current-db-size-bytes` reports in the compaction log; a successful defragmentation drops it close to the in-use value [ev:c4].
+
+In a multi-master deployment, repeat the defragmentation per member, one at a time, against each member's `etcd-<control-plane-IP>` pod — etcd serves reads and writes from the surviving quorum while one peer is briefly blocked during its own defrag [ev:c4].
+
+## Diagnostic Steps
+
+Inspect the live database state with `etcdctl endpoint status` against the local member; the `DB SIZE` column reflects the on-disk allocation that defragmentation would shrink [ev:c4]:
+
+```bash
+kubectl -n kube-system exec etcd-<control-plane-IP> -- \
+  etcdctl \
+    --endpoints=https://127.0.0.1:2379 \
+    --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+    --cert=/etc/kubernetes/pki/etcd/server.crt \
+    --key=/etc/kubernetes/pki/etcd/server.key \
+    endpoint status -w table
+```
+
+To estimate the fragmentation ratio without invoking `etcdctl`, scrape the most recent `mvcc/kvstore_compaction.go` line from the etcd pod log and apply the arithmetic above against `current-db-size-bytes` and `current-db-size-in-use-bytes` [ev:c2]:
+
+```bash
+kubectl -n kube-system logs etcd-<control-plane-IP> --tail=400 \
+  | grep -oE '"current-db-size-bytes":[0-9]+|"current-db-size-in-use-bytes":[0-9]+' \
+  | tail -2
+```
+
+If the ratio remains high after a defragmentation, run the defrag command again — a single pass cannot reclaim pages still pinned by an in-flight transaction, and a second pass usually completes the reclaim [ev:c4].


### PR DESCRIPTION
新增一篇 ACP KB 文章，归入 `configure` 区域。

**⚠️ 自动化验证：无测试计划** — 本篇未登记验证计划，暂不自动合并，请人工确认内容后再合。

## `configure` 区域建议 reviewer

按 `kb/OWNERS.md`（来源：alauda-ai-base operator-list 的产品 owner）该区域候选自动挑选，@ 错了请无视。


没有 GitHub handle 的贡献者（本区域相关请人工 ping）：

- gangwang &lt;gangwang@alauda.io&gt;
- xdzhang &lt;xdzhang@alauda.io&gt;
