### PR TITLE
[networking] Reading the ovn-controller Thread Model Inside the Node Networking Pod

### DIFF
--- a/docs/en/solutions/Reading_the_ovn_controller_Thread_Model_Inside_the_Node_Networking_Pod.md
+++ b/docs/en/solutions/Reading_the_ovn_controller_Thread_Model_Inside_the_Node_Networking_Pod.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Reading the ovn-controller Thread Model Inside the Node Networking Pod
 ## Overview
 
 `ovn-controller` is the per-node daemon that turns the global OVN southbound database into the local OpenFlow rules a node actually programs into Open vSwitch. It runs inside the node-side OVN pod (its name and namespace differ between distributions, but the daemon role is identical). When operators see an `ovn-controller` process consuming *several hundred percent CPU* on a single node, the first instinct is to assume a leak; the reality is usually that multiple threads are doing legitimate work in parallel and the host's `top` output is summing them.

--- a/docs/en/solutions/Reading_the_ovn_controller_Thread_Model_Inside_the_Node_Networking_Pod.md
+++ b/docs/en/solutions/Reading_the_ovn_controller_Thread_Model_Inside_the_Node_Networking_Pod.md
@@ -10,77 +10,104 @@ ProductsVersion:
 # Reading the ovn-controller Thread Model Inside the Node Networking Pod
 ## Overview
 
-`ovn-controller` is the per-node daemon that turns the global OVN southbound database into the local OpenFlow rules a node actually programs into Open vSwitch. It runs inside the node-side OVN pod (its name and namespace differ between distributions, but the daemon role is identical). When operators see an `ovn-controller` process consuming *several hundred percent CPU* on a single node, the first instinct is to assume a leak; the reality is usually that multiple threads are doing legitimate work in parallel and the host's `top` output is summing them.
+`ovn-controller` is the per-node daemon that turns the global OVN southbound database into the local OpenFlow rules a node actually programs into Open vSwitch. When operators see an `ovn-controller` process consuming *several hundred percent CPU* on a single node, the first instinct is to assume a leak; the reality is usually that multiple threads are doing legitimate work in parallel and a process-level CPU view is summing them.
 
 This note explains the thread model of `ovn-controller` so operators can read CPU samples correctly and decide whether what they see is steady-state work, an actual hot loop, or a configuration shape that produces avoidable churn.
 
 ## Resolution
 
-### ACP Networking Context
+### Where ovn-controller Runs in ACP (Kube-OVN)
 
-The ACP CNI is **Kube-OVN** (`docs/en/networking/`), which embeds OVN/OVS in the same way the upstream OVN-Kubernetes implementation does. The thread model described below is a property of the OVN project, not of any one distribution — it applies equally to a node running the ACP Kube-OVN agent and to any other OVN-based CNI. For day-to-day diagnosis, the ACP `networking` surface exposes per-node OVN telemetry through the platform observability stack; reach for that first before logging into a node directly.
+ACP uses **Kube-OVN** as its CNI. Unlike host-level OVN deployments, `ovn-controller` does **not** run as a process on the node — it runs inside the per-node networking Pod. The concrete shape on this platform is:
+
+| Component | Value |
+|---|---|
+| DaemonSet | `kube-ovn-cni` |
+| Namespace | `kube-system` |
+| Container | `cni-server` |
+| Pod label selector | `app=kube-ovn-cni` |
+
+Every diagnostic command in this article runs through `kubectl exec` into that container — `kubectl debug node` + `chroot /host` will not find the process and is rejected by the cluster Pod Security Admission policy on ACP.
+
+Pick the Pod for the node under inspection:
+
+```bash
+NODE=<node-name>
+POD=$(kubectl -n kube-system get pod -l app=kube-ovn-cni \
+        --field-selector=spec.nodeName=$NODE,status.phase=Running \
+        -o jsonpath='{.items[0].metadata.name}')
+echo $POD
+```
 
 ### The Threads
 
 `ovn-controller` is **multi-threaded** by design. The threads share the same southbound-DB view but specialise on different work types:
 
-| Thread | Role | Hot signal |
+| Thread (top -H name) | Role | Hot signal |
 |---|---|---|
-| **main** | Processes southbound-DB changes; computes and installs OpenFlow flows on the local bridge | CPU correlates with logical-flow churn (Pod create/delete, port bindings, ACL changes) |
-| **pinctrl** | Handles packets that have been punted to userspace (PACKET_IN), including ARP/NDP responses and DNS interception | CPU correlates with userspace packet rate, often spikes during connectivity storms |
-| **statctrl** | Refreshes FDB (forwarding DB) and MAC-binding entries from the datapath | CPU correlates with churn in the L2 neighbour set; chatty in large flat networks |
+| **ovn-controller** (main) | Processes southbound-DB changes; computes and installs OpenFlow flows on the local bridge | CPU correlates with logical-flow churn (Pod create/delete, port bindings, ACL changes) |
+| **ovn_pinctrl0** | Handles packets that have been punted to userspace (PACKET_IN), including ARP/NDP responses and DNS interception | CPU correlates with userspace packet rate, often spikes during connectivity storms |
+| **ovn_statctrl3** | Refreshes FDB (forwarding DB) and MAC-binding entries from the datapath | CPU correlates with churn in the L2 neighbour set; chatty in large flat networks |
 
-A combined `top` view easily exceeds 100 % when even two of these threads are warm; sustained `300 %` is consistent with a node that is simultaneously installing flows, handling punted packets, and refreshing a large MAC-binding table. That is *not* an anomaly on its own.
+A combined process-CPU view easily exceeds 100 % when even two of these threads are warm; sustained `300 %` is consistent with a node that is simultaneously installing flows, handling punted packets, and refreshing a large MAC-binding table. That is *not* an anomaly on its own.
 
 ### When the High CPU Is a Real Symptom
 
 The thread model should be used as a filter for genuine pathology:
 
-- **main thread pinned alone** at high CPU usually means the local node is repeatedly recomputing the same flows — look for a control-plane hot loop creating/deleting Pods, or a churning NetworkPolicy that the node is recompiling.
-- **pinctrl thread pinned alone** points at a packet path that should not be in userspace at all — a misconfigured load balancer that is hairpinning, or a broken ACL forcing the slow path.
-- **statctrl thread pinned alone** points at MAC-binding churn — a flapping endpoint or a network with too many concurrent ARP/NDP entries.
+- **main thread (`ovn-controller`) pinned alone** at high CPU usually means the local node is repeatedly recomputing the same flows — look for a control-plane hot loop creating/deleting Pods, or a churning NetworkPolicy that the node is recompiling.
+- **`ovn_pinctrl0` pinned alone** points at a packet path that should not be in userspace at all — a misconfigured load balancer that is hairpinning, or a broken ACL forcing the slow path.
+- **`ovn_statctrl3` pinned alone** points at MAC-binding churn — a flapping endpoint or a network with too many concurrent ARP/NDP entries.
 
 The point is that the thread *which* is hot is more diagnostic than the absolute CPU figure.
 
 ## Diagnostic Steps
 
-Read live per-thread CPU on a target node — `top -H` lists threads, not just processes:
+Read live per-thread CPU. `top -H` lists threads, not just processes; run it inside the `cni-server` container:
 
 ```bash
-NODE=<node>
-kubectl debug node/$NODE -it -- chroot /host \
-  top -H -b -n 1 -p $(pgrep -d, -x ovn-controller) | head -n 40
+NODE=<node-name>
+POD=$(kubectl -n kube-system get pod -l app=kube-ovn-cni \
+        --field-selector=spec.nodeName=$NODE,status.phase=Running \
+        -o jsonpath='{.items[0].metadata.name}')
+
+PID=$(kubectl -n kube-system exec $POD -c cni-server -- pgrep -x ovn-controller)
+kubectl -n kube-system exec $POD -c cni-server -- top -H -b -n 1 -p $PID | head -n 40
 ```
 
-The `COMMAND` column reveals which of the three threads (main / pinctrl / statctrl) holds the CPU.
+The `COMMAND` column reveals which thread holds the CPU.
 
-Sample `ovn-controller`'s own profiling counters via the local `unixctl`:
+Sample `ovn-controller`'s own profiling counters via the local `unixctl` socket — `ovn-appctl` is shipped inside the same container and talks to the daemon directly:
 
 ```bash
-NODE=<node>
-kubectl debug node/$NODE -it -- chroot /host \
+kubectl -n kube-system exec $POD -c cni-server -- \
   ovn-appctl -t ovn-controller coverage/show
 ```
 
 `coverage/show` exposes counters such as `flow_install`, `pinctrl_run`, and `lflow_run` — increments per second translate directly to the workload each thread is doing. A low `lflow_run` rate combined with high main-thread CPU is the signature of repeated no-op recomputation.
 
-Inspect southbound-DB churn from the node:
+Inspect southbound-DB churn. The SB database is hosted by the **`ovn-central`** Deployment (3 replicas under `kube-system`); query it from any of those Pods. The `kube-ovn-cni` pod *can* see the SB socket only on nodes that happen to also host an ovn-central replica (shared `hostPath`), so do not rely on it from arbitrary worker nodes.
 
 ```bash
-kubectl debug node/$NODE -it -- chroot /host \
-  ovn-sbctl --columns=_uuid,name,external_ids list Port_Binding | wc -l
+CENTRAL=$(kubectl -n kube-system get pod -l app=ovn-central \
+            -o jsonpath='{.items[0].metadata.name}')
+
+kubectl -n kube-system exec $CENTRAL -- \
+  ovn-sbctl --no-leader-only \
+    --columns=_uuid,logical_port,external_ids list Port_Binding | wc -l
 ```
+
+`--no-leader-only` is required because ovn-central runs as a 3-replica Raft cluster — without it `ovn-sbctl` may refuse to query a follower. In the OVN southbound schema the `Port_Binding` table uses `logical_port`, not `name`.
 
 A port-binding count that grows continuously without a matching workload increase usually points to a controller leak in the cluster (Pods not being garbage-collected from the SB database) — surface that to the network operator team rather than treating it as a node-local issue.
 
 For deeper traces, redirect `ovn-controller` to verbose logging *briefly* and capture a 30-second window:
 
 ```bash
-NODE=<node>
-kubectl debug node/$NODE -it -- chroot /host \
+kubectl -n kube-system exec $POD -c cni-server -- \
   ovn-appctl -t ovn-controller vlog/set ANY:console:dbg
 sleep 30
-kubectl debug node/$NODE -it -- chroot /host \
+kubectl -n kube-system exec $POD -c cni-server -- \
   ovn-appctl -t ovn-controller vlog/set ANY:console:info
 ```
 

--- a/docs/en/solutions/Reading_the_ovn_controller_Thread_Model_Inside_the_Node_Networking_Pod.md
+++ b/docs/en/solutions/Reading_the_ovn_controller_Thread_Model_Inside_the_Node_Networking_Pod.md
@@ -1,0 +1,85 @@
+---
+kind:
+   - Information
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Overview
+
+`ovn-controller` is the per-node daemon that turns the global OVN southbound database into the local OpenFlow rules a node actually programs into Open vSwitch. It runs inside the node-side OVN pod (its name and namespace differ between distributions, but the daemon role is identical). When operators see an `ovn-controller` process consuming *several hundred percent CPU* on a single node, the first instinct is to assume a leak; the reality is usually that multiple threads are doing legitimate work in parallel and the host's `top` output is summing them.
+
+This note explains the thread model of `ovn-controller` so operators can read CPU samples correctly and decide whether what they see is steady-state work, an actual hot loop, or a configuration shape that produces avoidable churn.
+
+## Resolution
+
+### ACP Networking Context
+
+The ACP CNI is **Kube-OVN** (`docs/en/networking/`), which embeds OVN/OVS in the same way the upstream OVN-Kubernetes implementation does. The thread model described below is a property of the OVN project, not of any one distribution — it applies equally to a node running the ACP Kube-OVN agent and to any other OVN-based CNI. For day-to-day diagnosis, the ACP `networking` surface exposes per-node OVN telemetry through the platform observability stack; reach for that first before logging into a node directly.
+
+### The Threads
+
+`ovn-controller` is **multi-threaded** by design. The threads share the same southbound-DB view but specialise on different work types:
+
+| Thread | Role | Hot signal |
+|---|---|---|
+| **main** | Processes southbound-DB changes; computes and installs OpenFlow flows on the local bridge | CPU correlates with logical-flow churn (Pod create/delete, port bindings, ACL changes) |
+| **pinctrl** | Handles packets that have been punted to userspace (PACKET_IN), including ARP/NDP responses and DNS interception | CPU correlates with userspace packet rate, often spikes during connectivity storms |
+| **statctrl** | Refreshes FDB (forwarding DB) and MAC-binding entries from the datapath | CPU correlates with churn in the L2 neighbour set; chatty in large flat networks |
+
+A combined `top` view easily exceeds 100 % when even two of these threads are warm; sustained `300 %` is consistent with a node that is simultaneously installing flows, handling punted packets, and refreshing a large MAC-binding table. That is *not* an anomaly on its own.
+
+### When the High CPU Is a Real Symptom
+
+The thread model should be used as a filter for genuine pathology:
+
+- **main thread pinned alone** at high CPU usually means the local node is repeatedly recomputing the same flows — look for a control-plane hot loop creating/deleting Pods, or a churning NetworkPolicy that the node is recompiling.
+- **pinctrl thread pinned alone** points at a packet path that should not be in userspace at all — a misconfigured load balancer that is hairpinning, or a broken ACL forcing the slow path.
+- **statctrl thread pinned alone** points at MAC-binding churn — a flapping endpoint or a network with too many concurrent ARP/NDP entries.
+
+The point is that the thread *which* is hot is more diagnostic than the absolute CPU figure.
+
+## Diagnostic Steps
+
+Read live per-thread CPU on a target node — `top -H` lists threads, not just processes:
+
+```bash
+NODE=<node>
+kubectl debug node/$NODE -it -- chroot /host \
+  top -H -b -n 1 -p $(pgrep -d, -x ovn-controller) | head -n 40
+```
+
+The `COMMAND` column reveals which of the three threads (main / pinctrl / statctrl) holds the CPU.
+
+Sample `ovn-controller`'s own profiling counters via the local `unixctl`:
+
+```bash
+NODE=<node>
+kubectl debug node/$NODE -it -- chroot /host \
+  ovn-appctl -t ovn-controller coverage/show
+```
+
+`coverage/show` exposes counters such as `flow_install`, `pinctrl_run`, and `lflow_run` — increments per second translate directly to the workload each thread is doing. A low `lflow_run` rate combined with high main-thread CPU is the signature of repeated no-op recomputation.
+
+Inspect southbound-DB churn from the node:
+
+```bash
+kubectl debug node/$NODE -it -- chroot /host \
+  ovn-sbctl --columns=_uuid,name,external_ids list Port_Binding | wc -l
+```
+
+A port-binding count that grows continuously without a matching workload increase usually points to a controller leak in the cluster (Pods not being garbage-collected from the SB database) — surface that to the network operator team rather than treating it as a node-local issue.
+
+For deeper traces, redirect `ovn-controller` to verbose logging *briefly* and capture a 30-second window:
+
+```bash
+NODE=<node>
+kubectl debug node/$NODE -it -- chroot /host \
+  ovn-appctl -t ovn-controller vlog/set ANY:console:dbg
+sleep 30
+kubectl debug node/$NODE -it -- chroot /host \
+  ovn-appctl -t ovn-controller vlog/set ANY:console:info
+```
+
+Verbose logs grow fast — keep the window short and do not leave the level at `dbg`.


### PR DESCRIPTION
新增一篇 ACP KB 文章，归入 `networking` 区域。

**✅ 自动化验证通过 — 可自动合并** — 2 / 2 条验证步骤在真实 Kubernetes 集群上按文章命令跑通（2026-05-02T14:55:38Z）。

## `networking` 区域建议 reviewer

按 `kb/OWNERS.md`（来源：alauda-ai-base operator-list 的产品 owner）该区域候选自动挑选，@ 错了请无视。


没有 GitHub handle 的贡献者（本区域相关请人工 ping）：

- zjzhang &lt;zjzhang@alauda.io&gt;
- congwu &lt;congwu@alauda.io&gt;
- clyi &lt;clyi@alauda.io&gt;
- xdzhang &lt;xdzhang@alauda.io&gt;
- chengli &lt;chengli@alauda.io&gt;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive troubleshooting guide for diagnosing node networking thread performance and CPU usage patterns. Includes practical methods for thread identification and monitoring, correlates CPU usage with specific workload scenarios, and provides advanced diagnostic techniques using profiling tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->