### PR TITLE
[networking] Misleading istiod webhook UPDATE errors when the control plane runs more than one replica

### DIFF
--- a/docs/en/solutions/Misleading_Webhook_Update_Errors_When_Scaling_istiod_Replicas.md
+++ b/docs/en/solutions/Misleading_Webhook_Update_Errors_When_Scaling_istiod_Replicas.md
@@ -1,0 +1,79 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+After increasing the `istiod` Deployment replica count beyond a single pod, every replica continuously logs failed updates against the validating admission webhook. The error spam looks like a control-plane outage but the data plane keeps working:
+
+```text
+info  starting gRPC discovery service at [::]:15010
+info  starting webhook service at [::]:15017
+info  validationController Endpoint successfully rejected invalid config. Switching to fail-close.
+error validationController failed to updated: Operation cannot be fulfilled on
+       validatingwebhookconfigurations.admissionregistration.k8s.io
+       "istio-validator-istio-system": the object has been modified;
+       please apply your changes to the latest version and try again
+       name=istio-validator-istio-system resource version=5150402
+error controllers error handling istio-validator-istio-system, retrying (retry count: 1):
+       fail to update webhook ... controller=validation
+```
+
+Sidecar injection still happens, traffic still flows, but logs and alerting noise make the cluster look unhealthy.
+
+## Root Cause
+
+Each `istiod` replica owns an independent reconcile loop for the cluster-wide `ValidatingWebhookConfiguration` named `istio-validator-istio-system`. When two or more replicas race to write the same object, the API server accepts the first PUT and rejects the rest with the standard optimistic-concurrency conflict (`the object has been modified`). The losing replicas back off and retry, but on a steady state they keep racing and keep losing.
+
+Functionally this is harmless — only the webhook payload (CA bundle, failure policy) needs to be reconciled and one writer is enough — but the loop is not gated by leader election, so every replica logs an error on every retry. Upstream tracks this as an `istiod` defect; the contract for the webhook reconcile loop should be "one writer at a time". Until the upstream fix is rolled into the platform's Istio image, the messages are cosmetic.
+
+## Resolution
+
+ACP ships managed Istio control planes through the `service_mesh` capability area. Before treating the noise as an outage, follow the platform-preferred path and only fall back to a workaround if the noise breaks alerting:
+
+1. **Check the control-plane status surface.** In the `service_mesh` view, the istiod Deployment is reported per-revision. Confirm that:
+
+   - the configured replica count matches the running pods,
+   - data-plane proxies show `SYNCED` against every relevant resource (CDS/EDS/RDS/LDS),
+   - sidecar injection on a fresh test pod still annotates and mutates the spec.
+
+   If all three are green, the webhook errors are cosmetic — proceed to step 2 to silence them rather than rolling back the scale-out.
+
+2. **Suppress the noise at the alerting layer, not by scaling down.** Add an Alertmanager inhibition (or a Prometheus recording rule) for the `istio-validator-istio-system` conflict line so that operators are not paged on the racing reconcile. Keep the alert on **other** istiod errors (xDS push failures, Pilot config validation rejections); only the webhook conflict line is benign.
+
+3. **Mitigation for clusters that need clean logs.** If log-pipeline cost or compliance requires zero error spam, scale `istiod` back to a single replica until the upstream patch lands in the platform's Istio build. Single-replica istiod is supported; the only loss is a brief reconciliation gap during pod restart, which proxies tolerate (they keep their last good config and re-sync once a replacement is up).
+
+4. **Track the upstream fix.** The reconcile loop needs a leader-election guard. Subscribe to platform release notes for the `service_mesh` capability — the fix will arrive via an Istio control-plane image bump rather than any user-side configuration change.
+
+## Diagnostic Steps
+
+Confirm the conflict is on the validating webhook and not on a different resource:
+
+```bash
+kubectl -n istio-system logs deploy/istiod \
+  --all-containers --tail=200 | grep -E "validator|webhook" | head -20
+```
+
+Verify the webhook itself is healthy and reachable from the API server:
+
+```bash
+kubectl get validatingwebhookconfiguration istio-validator-istio-system \
+  -o jsonpath='{.webhooks[*].clientConfig.service}{"\n"}'
+kubectl -n istio-system get svc istiod -o wide
+kubectl -n istio-system get endpoints istiod
+```
+
+A healthy webhook returns a Service with at least one ready endpoint per istiod replica. If endpoints are empty, the issue is *not* the cosmetic conflict — the webhook is genuinely down.
+
+Inspect the resource version churn to confirm the race rather than a real config drift:
+
+```bash
+kubectl get validatingwebhookconfiguration istio-validator-istio-system \
+  -w -o jsonpath='{.metadata.resourceVersion}{"\n"}'
+```
+
+Resource version increments by one on every successful PUT. Under the racing reconcile pattern, the version increments steadily but the spec content is identical between bumps — `kubectl get ... -o yaml` taken five seconds apart should be byte-equal except for the version field. If the spec actually changes between bumps, something else is rewriting the webhook and the noise is *not* the cosmetic istiod race.

--- a/docs/en/solutions/Misleading_Webhook_Update_Errors_When_Scaling_istiod_Replicas.md
+++ b/docs/en/solutions/Misleading_Webhook_Update_Errors_When_Scaling_istiod_Replicas.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Misleading Webhook Update Errors When Scaling istiod Replicas
 ## Issue
 
 After increasing the `istiod` Deployment replica count beyond a single pod, every replica continuously logs failed updates against the validating admission webhook. The error spam looks like a control-plane outage but the data plane keeps working:

--- a/docs/en/solutions/Misleading_istiod_webhook_UPDATE_errors_when_the_control_plane_runs_more_than_one_replica.md
+++ b/docs/en/solutions/Misleading_istiod_webhook_UPDATE_errors_when_the_control_plane_runs_more_than_one_replica.md
@@ -1,0 +1,55 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Misleading istiod webhook UPDATE errors when the control plane runs more than one replica
+
+## Issue
+
+On Alauda Container Platform (Kubernetes `v1.34.5`), when an Istio control plane is installed through the Alauda Service Mesh path — for example via the `asm-operator` package (PackageManifest `asm-operator`, current CSV `asm.v4.3.3`, channel `alpha`) or the `servicemesh-operator2` package, with the `asm-global` ModulePlugin (chart `asm/chart-global-asm` v4.3.1) registering Istio at the cluster level — the istiod Deployment in the `istio-system` namespace packages upstream Istio unchanged. Operators following istiod logs in a multi-replica control-plane configuration see paired error lines reporting that an UPDATE of the `istio-validator-<rev>` ValidatingWebhookConfiguration could not be fulfilled. The lines look like genuine validation-controller failures but originate from the standard kube-apiserver optimistic-concurrency check rather than from a malformed webhook update.
+
+## Root Cause
+
+Every istiod pod runs its own validation controller, and each controller independently attempts to update the same cluster-scoped `istio-validator-<rev>` ValidatingWebhookConfiguration object. When the istiod Deployment is scaled to more than one replica, multiple controllers race to write the same object on overlapping reconcile cycles.
+
+The kube-apiserver enforces optimistic concurrency on every UPDATE call: if the request body carries a `metadata.resourceVersion` that no longer matches the object's current resourceVersion, the request is rejected with the canonical error string beginning `Operation cannot be fulfilled on <resource>.<group> "<name>":` and ending with `the object has been modified, please apply your changes to the latest version and try again`. This behavior is built into the apiserver admission stack and applies to the entire generic `admissionregistration.k8s.io/v1` family (MutatingWebhookConfiguration, ValidatingWebhookConfiguration, and the ValidatingAdmissionPolicy(Binding) shapes), which is the same shape available on ACP.
+
+When two or more istiod replicas reconcile the validator webhook on the same loop, only the first UPDATE in each round wins; the rest carry a now-stale resourceVersion and are rejected by the apiserver under exactly that rule. The losing reconcilers surface the rejection in istiod's logs as a pair of lines — a validationController message of the form `error validationController failed to updated: Operation cannot be fulfilled on validatingwebhookconfigurations.admissionregistration.k8s.io "istio-validator-istio-system"` followed by the standard stale-resourceVersion tail and a `resource version=<N>` token, and an immediately paired `error controllers error handling istio-validator-istio-system, retrying (retry count: 1): fail to update webhook: Operation cannot be fulfilled ... controller=validation` line from the controller layer indicating that the reconciler will retry on the next loop.
+
+## Resolution
+
+Treat these log lines as an expected artifact of running more than one istiod replica against a single shared ValidatingWebhookConfiguration object — they are an emergent property of the generic apiserver concurrency rule applied to a multi-writer Istio control plane, not a webhook misconfiguration. No change to the validator webhook, to the istiod Deployment manifest, or to the apiserver is required for the validation pipeline itself to keep working.
+
+To stop the noise outright, run the istiod Deployment with a single replica when the workload does not require horizontal scaling of the control plane. With one writer there is no concurrent UPDATE against `istio-validator-<rev>` and the optimistic-concurrency rejections do not arise.
+
+When multiple istiod replicas are required for availability or capacity reasons, leave the Deployment scaled out and filter the paired lines (validationController plus controllers/validation retry) out of istiod log alerting so that benign concurrency rejections do not generate operator pages. The underlying ACP packaging — the `asm-operator` package (CSV `asm.v4.3.3`) or `servicemesh-operator2`, surfaced on the cluster via the `asm-global` ModulePlugin (chart `asm/chart-global-asm` v4.3.1) — ships upstream istiod with the standard validation controller; the same log shape applies once an Istio control plane is instantiated.
+
+## Diagnostic Steps
+
+Confirm the istiod replica count in the Istio control-plane namespace (the convention is `istio-system`); a count greater than one is the precondition for the concurrent-UPDATE race that produces the log noise:
+
+```bash
+kubectl get deployment -n istio-system -l app=istiod \
+ -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.replicas}{"\n"}{end}'
+```
+
+Inspect istiod logs for the paired validationController and controllers/validation lines. The first message identifies the failing UPDATE against the cluster-scoped ValidatingWebhookConfiguration; the second confirms the reconciler is treating it as a retryable error:
+
+```bash
+kubectl logs -n istio-system -l app=istiod --tail=2000 \
+ | grep -E 'validationController failed to updated|controllers error handling istio-validator'
+```
+
+Verify that the target object is the single cluster-scoped ValidatingWebhookConfiguration named after the Istio revision (default revision: `istio-validator-istio-system`), at the generic `admissionregistration.k8s.io/v1` shape — the same primitive available on any conformant Kubernetes cluster including ACP:
+
+```bash
+kubectl get validatingwebhookconfiguration \
+ -l app=istiod -o name
+```
+
+If the cluster has not yet had an Istio control plane instantiated — for example when `asm-operator` and `servicemesh-operator2` are only available as PackageManifests, the `asm-global` ModulePlugin is registered, but no `ClusterPluginInstance` and no Istio control-plane CR have been created — the istiod Deployment does not exist and these log lines cannot appear. Create the Istio control-plane instance first, and only then revisit istiod logs for the paired error pattern.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
