### PR TITLE
[security] Meaning of an Empty apiGroups Field in a Role or ClusterRole

### DIFF
--- a/docs/en/solutions/Meaning_of_an_Empty_apiGroups_Field_in_a_Role_or_ClusterRole.md
+++ b/docs/en/solutions/Meaning_of_an_Empty_apiGroups_Field_in_a_Role_or_ClusterRole.md
@@ -1,0 +1,135 @@
+---
+kind:
+   - Information
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Meaning of an Empty apiGroups Field in a Role or ClusterRole
+## Overview
+
+A common point of confusion when authoring RBAC for the first time is what the empty string means in an `apiGroups` rule:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list"]
+```
+
+The empty string is *not* a wildcard or a typo. It is the canonical way to refer to the Kubernetes **core API group** — the original, unnamed group that hosts the foundational resources Pods, Services, ConfigMaps, Secrets, Nodes, and so on. Understanding this distinction is the first step to writing RBAC that actually grants what was intended.
+
+## Resolution
+
+### Why the core group is named with an empty string
+
+Kubernetes evolved from a single API surface served at `/api/v1` into a system of named API groups served at `/apis/<group>/<version>`. Resources that predate the named-group scheme stayed at the original path. To keep RBAC syntax uniform across both shapes, the RBAC schema requires every rule to declare an `apiGroups` field — and the literal `""` was reserved as the identifier for that legacy, path-`/api/v1` group.
+
+So:
+
+| Rule | Resolves to | API path |
+|---|---|---|
+| `apiGroups: [""]` + `resources: ["pods"]` | core/v1 Pod | `/api/v1/namespaces/<ns>/pods` |
+| `apiGroups: ["apps"]` + `resources: ["deployments"]` | apps/v1 Deployment | `/apis/apps/v1/namespaces/<ns>/deployments` |
+| `apiGroups: ["batch"]` + `resources: ["jobs"]` | batch/v1 Job | `/apis/batch/v1/namespaces/<ns>/jobs` |
+
+A rule with `apiGroups: ["*"]` *is* a wildcard and grants every group; the empty string is much narrower and grants only the core group.
+
+### What lives in the core group
+
+The core group is small but contains the most-used resources on any cluster. Listing it explicitly makes the surface area obvious:
+
+```bash
+kubectl api-resources --api-group="" -o wide
+```
+
+Expected output (abbreviated):
+
+```text
+NAME                    SHORTNAMES   APIVERSION   NAMESPACED   KIND
+bindings                             v1           true         Binding
+configmaps              cm           v1           true         ConfigMap
+endpoints               ep           v1           true         Endpoints
+events                  ev           v1           true         Event
+limitranges             limits       v1           true         LimitRange
+namespaces              ns           v1           false        Namespace
+nodes                   no           v1           false        Node
+persistentvolumeclaims  pvc          v1           true         PersistentVolumeClaim
+persistentvolumes       pv           v1           false        PersistentVolume
+pods                    po           v1           true         Pod
+podtemplates                         v1           true         PodTemplate
+replicationcontrollers  rc           v1           true         ReplicationController
+resourcequotas          quota        v1           true         ResourceQuota
+secrets                              v1           true         Secret
+serviceaccounts         sa           v1           true         ServiceAccount
+services                svc          v1           true         Service
+```
+
+A Role that needs to also list, say, Deployments must add a second rule with `apiGroups: ["apps"]` — granting `["", "apps"]` resources `pods,deployments` does not work, because the rule is the cross-product of all three lists and there is no Pod in the `apps` group.
+
+### Author rules group-by-group, not as a flat union
+
+The trap most people fall into is collapsing several groups into one rule:
+
+```yaml
+# WRONG — claims to grant Deployments under the core group
+rules:
+  - apiGroups: ["", "apps"]
+    resources: ["pods", "deployments"]
+    verbs: ["get", "list"]
+```
+
+The schema accepts this, but at evaluation time the rule is interpreted as "any of these groups, any of these resources, any of these verbs". The above grants `pods` *and* `deployments` under both groups — but since Deployments do not exist in the core group and Pods do not exist in the `apps` group, half of each combination silently does nothing. It works only because the desired combinations *also* match. Fix by splitting:
+
+```yaml
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
+```
+
+This form makes intent explicit and reviews easier.
+
+### Subresources still attach to the parent's group
+
+`pods/log`, `pods/exec`, and `pods/status` are subresources of Pod and live in the **same** group as Pod itself — the core group. A rule that lets a service account read pod logs is therefore:
+
+```yaml
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list"]
+```
+
+The same convention applies to `deployments/scale` (apps), `jobs/status` (batch), etc.
+
+## Diagnostic Steps
+
+When an RBAC rule does not seem to grant what was intended, walk it back from the API path. `kubectl auth can-i` reports the effective decision and is faster than re-reading the YAML:
+
+```bash
+kubectl auth can-i list pods --as=system:serviceaccount:default:pod-reader -n default
+kubectl auth can-i get deployments --as=system:serviceaccount:default:pod-reader -n default
+```
+
+In a stock Kubernetes cluster the first should return `yes` and the second `no` (Deployments are in `apps`, not in the core group). If the second returns `yes` on a stock cluster, the binding is broader than intended.
+
+**On ACP this negative test does not narrow down a Role.** The platform ships a `cpaas-default-authz` ClusterRoleBinding that binds the `system:authenticated` group to a broad ClusterRole, so any authenticated subject — including every ServiceAccount — already passes most `can-i --as=` checks regardless of what the Role grants. To verify a Role actually narrows, read the rules directly (`kubectl describe role pod-reader -n default`) and walk through them by hand, or run the negative `can-i` test with a subject that is *not* `system:authenticated` (for example, an unauthenticated user or a user explicitly excluded from `cpaas-default-authz`).
+
+For the inverse — discovering which group a given resource lives in — round-trip through `api-resources`:
+
+```bash
+kubectl api-resources | awk '$1=="deployments"'
+# deployments    deploy   apps/v1   true   Deployment
+```
+
+The third column is `<group>/<version>`. Strip the version and that is the value to put in `apiGroups`. For a resource at `v1` with no slash, the group is empty — write `apiGroups: [""]`.

--- a/docs/en/solutions/Meaning_of_an_Empty_apiGroups_Field_in_a_Role_or_ClusterRole.md
+++ b/docs/en/solutions/Meaning_of_an_Empty_apiGroups_Field_in_a_Role_or_ClusterRole.md
@@ -1,0 +1,84 @@
+---
+title: Meaning of an Empty apiGroups Field in a Role or ClusterRole
+component: security
+scenario: information
+tags: [rbac, role, clusterrole, apigroups, core-api]
+date_created: 2026-05-30
+date_updated: 2026-05-30
+---
+
+# Meaning of an Empty apiGroups Field in a Role or ClusterRole
+
+## Overview
+
+In a Role or ClusterRole on Alauda Container Platform, a `PolicyRule` whose `apiGroups` entry is the empty string `""` targets the Kubernetes core API group. The apiserver's own field description states this verbatim: `"" represents the core API group and "*" represents all API groups` [ev:c1]. The same wording appears in the live OpenAPI v3 schema served by the cluster at `/openapi/v3/apis/rbac.authorization.k8s.io/v1` for the `PolicyRule` type [ev:c1].
+
+The core API group is the legacy unnamed group whose resources are served at the REST path `/api/v1` (named groups live under `/apis/<group>/<version>`). On the verification cluster (Kubernetes v1.34.5), `kubectl get --raw=/api/v1` returns `groupVersion: v1` with no group prefix, confirming the core group's distinct REST root [ev:c1].
+
+## Core API Group Resources
+
+The resources that belong to the core group use the `v1` apiVersion (no group prefix). The set can be listed directly:
+
+```bash
+kubectl api-resources --api-group=""
+```
+
+The output names each core resource, its short name, the `v1` apiVersion, whether it is namespaced, and its Kind [ev:c3]. On the verification cluster the command returned the following 17 resources, all at APIVERSION `v1` [ev:c2][ev:c3]:
+
+```text
+NAME                     SHORTNAMES   APIVERSION   NAMESPACED   KIND
+bindings                              v1           true         Binding
+componentstatuses        cs           v1           false        ComponentStatus
+configmaps               cm           v1           true         ConfigMap
+endpoints                ep           v1           true         Endpoints
+events                   ev           v1           true         Event
+limitranges              limits       v1           true         LimitRange
+namespaces               ns           v1           false        Namespace
+nodes                    no           v1           false        Node
+persistentvolumeclaims   pvc          v1           true         PersistentVolumeClaim
+persistentvolumes        pv           v1           false        PersistentVolume
+pods                     po           v1           true         Pod
+podtemplates                          v1           true         PodTemplate
+replicationcontrollers   rc           v1           true         ReplicationController
+resourcequotas           quota        v1           true         ResourceQuota
+secrets                               v1           true         Secret
+serviceaccounts          sa           v1           true         ServiceAccount
+services                 svc          v1           true         Service
+```
+
+The cluster-shipped `view` ClusterRole already demonstrates the same idiom: one of its rules carries `apiGroups: [""]` and lists `configmaps`, `endpoints`, `persistentvolumeclaims`, `pods`, `replicationcontrollers`, `serviceaccounts`, and `services` (plus the `/status` subresources) [ev:c1][ev:c2].
+
+## How the Rule Grants Access
+
+A PolicyRule authorizes a request when its three dimensions — `apiGroups`, `resources`, and `verbs` — each match the inbound request. Listing the core group in `apiGroups` only opens the group dimension; the `resources` list still narrows access to the named resources, and the rule remains namespaced when written into a Role (cluster-scoped when written into a ClusterRole) [ev:c4].
+
+The article's reference Role illustrates the pattern:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: pod-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+```
+
+A binding of this Role to a subject grants that subject `get / watch / list` on Pods in the Role's namespace, and nothing more — no other core resource (Service, ConfigMap, Secret), no resource in any named API group (Deployment in `apps`, NetworkPolicy in `networking.k8s.io`), and no Pod in any other namespace [ev:c4].
+
+On the verification cluster, applying the Role above (with a ServiceAccount bound to it) and probing with the ServiceAccount's own token showed exactly this scope [ev:c4]:
+
+```text
+== can-i list pods (in-ns):           yes
+== can-i list services (in-ns):       no
+== can-i list deployments (apps):     no
+== can-i list pods cross-namespace:   no
+```
+
+The apiserver's `Forbidden` response surfaces the apiGroup literally, which is useful when diagnosing RBAC denials: for a core-group resource the message ends `... cannot list resource "services" in API group ""`, while for a named-group resource it ends `deployments.apps is forbidden: ... in API group "apps"` [ev:c4]. Seeing the empty string `API group ""` in the error confirms that the request targeted the core group and the rule's group dimension is the one to widen.
+
+## Summary
+
+In `apiGroups`, the empty string `""` is the canonical reference to the Kubernetes core API group — the group served at `/api/v1` whose resources use the bare `v1` apiVersion [ev:c1]. Listing those resources with `kubectl api-resources --api-group=""` enumerates the kinds a rule with `apiGroups: [""]` can grant verbs over [ev:c3], and the rule's authorization scope is still constrained by the `resources`, `verbs`, and (for Role) namespace dimensions of the PolicyRule [ev:c4].


### PR DESCRIPTION
新增一篇 ACP KB 文章，归入 `security` 区域。

**✅ 自动化验证通过 — 可自动合并** — 2 / 2 条验证步骤在真实 Kubernetes 集群上按文章命令跑通（2026-05-02T15:17:16Z）。

## `security` 区域建议 reviewer

按 `kb/OWNERS.md`（来源：alauda-ai-base operator-list 的产品 owner）该区域候选自动挑选，@ 错了请无视。


没有 GitHub handle 的贡献者（本区域相关请人工 ping）：

- xdzhang &lt;xdzhang@alauda.io&gt;
- chaowang1 &lt;chaowang1@alauda.io&gt;
- jhshi &lt;jhshi@alauda.io&gt;
