### PR TITLE
[virtualization] virt-launcher Sync VMI loop on KubeVirt VMs with multiple secondary networks on ACP

### DIFF
--- a/docs/en/solutions/virt_launcher_Sync_VMI_Loop_on_VMs_with_Multiple_Secondary_Networks.md
+++ b/docs/en/solutions/virt_launcher_Sync_VMI_Loop_on_VMs_with_Multiple_Secondary_Networks.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# virt-launcher Sync VMI Loop on VMs with Multiple Secondary Networks
 ## Issue
 
 Specific virtual machines exhibit a cluster of related symptoms that all trace back to the same churn:

--- a/docs/en/solutions/virt_launcher_Sync_VMI_Loop_on_VMs_with_Multiple_Secondary_Networks.md
+++ b/docs/en/solutions/virt_launcher_Sync_VMI_Loop_on_VMs_with_Multiple_Secondary_Networks.md
@@ -1,0 +1,128 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+Specific virtual machines exhibit a cluster of related symptoms that all trace back to the same churn:
+
+- The platform console renders extremely slowly when viewing the affected VMs.
+- A *Pending Changes* banner appears, disappears, and reappears every few seconds.
+- The VM's IP field on the corresponding `VirtualMachineInstance` (VMI) flickers between values.
+- The `virt-launcher` pod log is flooded with `Synced vmi` lines several times per second:
+
+```text
+{"component":"virt-launcher","level":"info","msg":"Synced vmi",
+ "name":"vm-multinic","namespace":"default",
+ "timestamp":"2025-09-16T01:38:35.979577Z"}
+{"component":"virt-launcher","level":"info","msg":"Synced vmi",
+ "name":"vm-multinic","namespace":"default",
+ "timestamp":"2025-09-16T01:38:35.996711Z"}
+{"component":"virt-launcher","level":"info","msg":"Synced vmi",
+ "name":"vm-multinic","namespace":"default",
+ "timestamp":"2025-09-16T01:38:36.179636Z"}
+... (dozens per second)
+```
+
+The shared trigger is that the VM has **two or more secondary networks** attached in addition to the default pod network. VMs with only the pod network (or with one secondary network) do not loop.
+
+## Root Cause
+
+KubeVirt's reconcile loop on the VMI rewrites `status.interfaces` from two sources:
+
+1. The active state observed in the launcher pod (libvirt domain interfaces, IP from the guest agent).
+2. The desired state derived from the VM spec template, which lists interfaces in declaration order.
+
+When two or more secondary networks are present, the order in which interfaces appear can disagree between those two sources — the guest agent enumerates interfaces in kernel order, the spec lists them in declaration order, and the controller's diff classifies the mismatch as a meaningful change. It writes the spec-ordering version, immediately observes the agent-ordering version, classifies that as a change too, and the loop runs continuously.
+
+The loop is harmless to the data plane (the VM keeps running) but expensive on:
+
+- API server traffic from the unending PUT/PATCH against VMI,
+- the platform console, which subscribes to VMI updates and re-renders on every event,
+- log volume on `virt-launcher` and on any logging pipeline downstream.
+
+Two related bugs have been tracked upstream — one fixed in the 4.20-line image, one still open at the time of writing — and the workaround for both is the same: ensure the *first* interface in the VM spec is the pod network. With the pod network at index 0, the controller's diffing logic does not flip-flop on the secondary network ordering.
+
+## Resolution
+
+ACP delivers KubeVirt-based VM workloads through the `virtualization` capability area. The platform-preferred path is to consume the upstream fix through a managed virtualization-stack version bump rather than to hand-edit launcher pods:
+
+1. **Upgrade the platform's virtualization stack to a version that includes the KubeVirt 4.20+ fix.** From the `virtualization` admin surface, check the running KubeVirt image; a stack older than the 4.20 fix line will keep the loop even with the workaround in place. Schedule the upgrade through the platform — KubeVirt control-plane components (virt-controller, virt-handler, virt-api) must move together, and the platform handles the order.
+
+2. **Re-order interfaces in the VM spec so the pod network is first.** Before *and* after the upgrade, the safe authoring pattern is to declare the default pod network as the first entry under `spec.template.spec.domain.devices.interfaces` and as the first entry under `spec.template.spec.networks`. The reconciler stops flipping order when this invariant holds.
+
+   ```yaml
+   apiVersion: kubevirt.io/v1
+   kind: VirtualMachine
+   metadata:
+     name: vm-multinic
+     namespace: default
+   spec:
+     template:
+       spec:
+         domain:
+           devices:
+             interfaces:
+               - name: default       # pod network FIRST
+                 masquerade: {}
+                 model: virtio
+               - name: trunk0        # secondary networks AFTER
+                 bridge: {}
+                 model: virtio
+               - name: storage-net
+                 bridge: {}
+                 model: virtio
+         networks:
+           - name: default
+             pod: {}
+           - name: trunk0
+             multus:
+               networkName: br0-trunk
+           - name: storage-net
+             multus:
+               networkName: storage-vlan
+   ```
+
+   Apply with `kubectl apply -f vm.yaml`. The VM must be **stopped and started** (not live-migrated) to take effect — the launcher pod re-reads the spec only on fresh start, and a live migration carries the existing libvirt domain across.
+
+3. **For VMs that cannot tolerate a stop/start, isolate the noise downstream.** Until the VM can be restarted:
+
+   - Drop `Synced vmi` log lines at the log-collector layer (Vector/Fluentd filter on `msg == "Synced vmi"`) so the logging backend does not page on the volume.
+   - Suppress the console subscription to that VM's VMI watch (most consoles let an operator switch off live updates per object); the *Pending Changes* banner toggle is harmless apart from the visual noise.
+
+4. **Monitor for recurrence after the upgrade.** The companion upstream issue is still open, so a small subset of VMs may continue to loop even on the 4.20 line. Treat any VM whose `virt-launcher` log shows more than a couple of `Synced vmi` per minute as suspect, re-check the interface ordering, and capture a YAML diff of `kubectl get vmi <name> -o yaml` taken five seconds apart. If the diff is purely on `status.interfaces` ordering, the workaround did not stick — re-apply step 2 and confirm the spec really has the pod network at index 0 (not just *present*; index matters).
+
+## Diagnostic Steps
+
+Confirm the loop and identify the affected VMs:
+
+```bash
+kubectl -n <ns> logs -l vm.kubevirt.io/name=<vm> -c compute --tail=200 \
+  | grep -c "Synced vmi"
+```
+
+Anything in the dozens for a 200-line tail (covering only a few seconds) is the loop. A healthy VM shows `Synced vmi` only at start, on configuration changes, and on migration.
+
+Inspect the VMI for spec/status interface ordering:
+
+```bash
+kubectl -n <ns> get vmi <vm> -o jsonpath='{.spec.domain.devices.interfaces[*].name}{"\n"}'
+kubectl -n <ns> get vmi <vm> -o jsonpath='{.status.interfaces[*].name}{"\n"}'
+```
+
+If the two lists are not in the same order *or* the spec list does not start with the pod network's interface name, the workaround applies. Re-author the VM with the pod network as the first interface, stop the VM, and start it again.
+
+To confirm the fix has landed, take two snapshots of the VMI five seconds apart:
+
+```bash
+kubectl -n <ns> get vmi <vm> -o yaml > /tmp/vmi-1.yaml
+sleep 5
+kubectl -n <ns> get vmi <vm> -o yaml > /tmp/vmi-2.yaml
+diff /tmp/vmi-1.yaml /tmp/vmi-2.yaml | head -40
+```
+
+A healthy VMI shows differences only on `metadata.resourceVersion` and on a handful of timestamp/heartbeat fields. A VMI still in the loop shows differences on `status.interfaces` (order, IPs, or names flipping back and forth) — that is the fingerprint that the reconciler is still racing on this VM.

--- a/docs/en/solutions/virt_launcher_Sync_VMI_loop_on_KubeVirt_VMs_with_multiple_secondary_networks_on_ACP.md
+++ b/docs/en/solutions/virt_launcher_Sync_VMI_loop_on_KubeVirt_VMs_with_multiple_secondary_networks_on_ACP.md
@@ -1,0 +1,83 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# virt-launcher Sync VMI loop on KubeVirt VMs with multiple secondary networks on ACP
+
+## Issue
+
+On Alauda Container Platform with the `kubevirt-operator` bundle installed (CSV `kubevirt-hyperconverged-operator.v4.3.5`, channel `alpha`, HCO singleton in the `kubevirt` namespace, KubeVirt at `v1.7.0-alauda.2`), a KubeVirt VirtualMachine configured with two or more secondary networks attached via Multus can drive its virt-launcher pod into a high-rate reconcile loop. The virt-launcher container (`registry.alauda.cn:60080/3rdparty/kubevirt/virt-launcher:v1.7.0-alauda.2`) emits many `Synced vmi` info lines per second from `pos=server.go:208`, each line a one-line JSON record of the shape `{component:"virt-launcher", level:"info", msg:"Synced vmi", pos:"server.go:208", timestamp:...}` carrying the VMI's name, namespace, and UID.
+
+On the same trigger the VM's IP address visibly flaps in the VirtualMachineInstance status. The VMI CRD (`kubevirt.io` group, kinds `VirtualMachineInstance` at versions `v1` and `v1alpha3`) defines `.status.interfaces[]` entries that carry `ipAddress`, `ipAddresses[]`, `mac`, `name`, `interfaceName`, `podInterfaceName`, `linkState`, and `infoSource`; while the loop is active these entries — including the reported IP — are rewritten on every reconcile iteration and appear to come and go when watched with `kubectl get vmi -o yaml`.
+
+## Root Cause
+
+`.status.interfaces[]` on a VMI is a merged view fed by multiple producers: the `infoSource` field on each entry is an enum with the values `domain`, `guest-agent`, and `multus-status`, identifying which subsystem contributed the data. When a VM carries more than one Multus-attached secondary network, the producers disagree on what the merged interface set should look like, so each reconcile pass writes a new desired state. The node-agent (`virt-handler`, image `build-harbor.alauda.cn/3rdparty/kubevirt/virt-handler:v1.7.0-alauda.2`) issues a fresh per-VMI Sync RPC into the virt-launcher cmd-server for every such update, while the control-plane controller (`virt-controller`, image `build-harbor.alauda.cn/3rdparty/kubevirt/virt-controller:v1.7.0-alauda.2`) keeps driving the VMI reconcile — together producing the per-second `Synced vmi` log line and the visible IP flap in `.status.interfaces[]`.
+
+## Resolution
+
+Reorder the interface list in the VirtualMachine template so the pod-network interface is the first entry. The VM CRD on ACP is `kubevirt.io/VirtualMachine` (versions `v1` and `v1alpha3`), and the per-VM template interface list lives at `spec.template.spec.domain.devices.interfaces[]`; the matching `spec.template.spec.networks[]` block supports both the stock `pod` network type and the `multus` network type, where `multus.networkName` references a `NetworkAttachmentDefinition` (`k8s.cni.cncf.io/v1`) name. Editing the VM YAML to move the interface entry whose `name` matches the `pod`-network entry in `networks[]` into the first position of `interfaces[]` mitigates the loop.
+
+Apply the change in place against the VM object (the example assumes a VM with one pod-network interface named `default` and two Multus-attached secondary interfaces; replace the VM name and namespace as appropriate):
+
+```bash
+kubectl edit vm -n <vm-namespace> <vm-name>
+```
+
+The reordered template looks like this — the `pod`-network entry in `networks[]` is matched by the first entry in `interfaces[]` by `name`, with the Multus-attached secondary entries following:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+  template:
+    spec:
+      domain:
+        devices:
+          interfaces:
+            - name: default
+              masquerade: {}
+            - name: secondary-1
+              bridge: {}
+            - name: secondary-2
+              bridge: {}
+      networks:
+        - name: default
+          pod: {}
+        - name: secondary-1
+          multus:
+            networkName: <nad-namespace>/<nad-name-1>
+        - name: secondary-2
+          multus:
+            networkName: <nad-namespace>/<nad-name-2>
+```
+
+After saving, KubeVirt regenerates the VMI from the updated template; the `Synced vmi` log rate in the new virt-launcher pod and the stability of `.status.interfaces[]` on the new VMI should both confirm whether the workaround applies to this VM's specific interface topology.
+
+## Diagnostic Steps
+
+Confirm the symptom on the virt-launcher side by streaming the pod's logs in the VM's namespace and grepping for the `Synced vmi` message; a healthy VM emits this line at startup and during legitimate reconciles, while a VM caught in the loop emits it many times per second from `pos=server.go:208` with `level:"info"` and the JSON envelope described above:
+
+```bash
+kubectl logs -n <vm-namespace> -l kubevirt.io=virt-launcher,vm.kubevirt.io/name=<vm-name> \
+  --tail=200 -f
+```
+
+Confirm the matching VMI-side symptom by reading the VMI's status block and watching `.status.interfaces[]`; in the loop state, the `ipAddress` / `ipAddresses` / `mac` / `interfaceName` / `podInterfaceName` / `linkState` / `infoSource` fields on the affected entries are rewritten on every reconcile iteration and the IP flips between values rather than stabilising:
+
+```bash
+kubectl get vmi -n <vm-namespace> <vm-name> \
+  -o jsonpath='{.status.interfaces}' | jq .
+```
+
+Cross-check the VM template against the workaround by reading the interface and network lists on the VM object — the first entry of `spec.template.spec.domain.devices.interfaces[]` should have the same `name` as the `pod`-network entry in `spec.template.spec.networks[]`, with any `multus` networks (each referencing a `NetworkAttachmentDefinition` via `networkName`) ordered after it:
+
+```bash
+kubectl get vm -n <vm-namespace> <vm-name> \
+  -o jsonpath='{.spec.template.spec.domain.devices.interfaces}{"\n"}{.spec.template.spec.networks}{"\n"}'
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章。
