### PR TITLE
[configure] Per-user API request-count rate limiting is not a kube-apiserver primitive on ACP

### DIFF
--- a/docs/en/solutions/Per_User_API_Rate_Limiting_Is_Not_a_Supported_Capability.md
+++ b/docs/en/solutions/Per_User_API_Rate_Limiting_Is_Not_a_Supported_Capability.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Per-User API Rate Limiting Is Not a Supported Capability
 ## Issue
 
 A common operational question: can the platform enforce a fixed quota of API calls per authenticated user or per client over a time window — for example, "no more than N `kubectl get pods` calls per minute per service account"? The expectation usually comes from external API gateway experience, where per-key rate limits are a standard primitive.

--- a/docs/en/solutions/Per_User_API_Rate_Limiting_Is_Not_a_Supported_Capability.md
+++ b/docs/en/solutions/Per_User_API_Rate_Limiting_Is_Not_a_Supported_Capability.md
@@ -1,0 +1,84 @@
+---
+kind:
+   - Information
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A common operational question: can the platform enforce a fixed quota of API calls per authenticated user or per client over a time window — for example, "no more than N `kubectl get pods` calls per minute per service account"? The expectation usually comes from external API gateway experience, where per-key rate limits are a standard primitive.
+
+ACP inherits the upstream Kubernetes API server model, and that model does not expose a per-user request-count throttle. Operators reaching for this capability should understand what the API server *does* offer, what it does not, and why bolting on external rate limiting in front of the API is strongly discouraged.
+
+## Root Cause
+
+The Kubernetes API server handles overload through two mechanisms, neither of which is a per-user counter:
+
+- **Priority and Fairness (APF)** — classifies incoming requests into FlowSchemas and queues them across PriorityLevels so that a noisy client cannot starve a well-behaved one. APF shapes concurrency and queueing, not request-per-second quotas.
+- **max-in-flight limits** — protect the API server against total concurrent load; again, not per-identity.
+
+There is no control loop that counts requests per user identity over a rolling window and rejects the N+1 call. This is a deliberate design choice: the control-plane API is meant to be available to every authenticated controller, operator, and human operator in the cluster, and a per-user quota would interact badly with bursty reconcile loops that are normal and expected.
+
+## Resolution
+
+Per-user, request-count API rate limiting is not available and is not on the supported configuration surface. Treat this as a settled fact of the platform and redirect effort into the mechanisms that *are* available:
+
+1. **Lean on API Priority and Fairness.** If the problem is that one workload is crowding out the rest, define a dedicated FlowSchema that maps that workload's ServiceAccount (or a label) into a lower PriorityLevel with limited concurrency share. Fairness, not throttling, is the native tool.
+
+   ```yaml
+   apiVersion: flowcontrol.apiserver.k8s.io/v1
+   kind: FlowSchema
+   metadata:
+     name: noisy-workload
+   spec:
+     priorityLevelConfiguration:
+       name: workload-low
+     matchingPrecedence: 1000
+     rules:
+       - subjects:
+           - kind: ServiceAccount
+             serviceAccount:
+               name: noisy-operator
+               namespace: team-x
+         resourceRules:
+           - verbs: ["list", "watch", "get"]
+             apiGroups: ["*"]
+             resources: ["*"]
+   ```
+
+2. **Constrain clients, not the server.** If a specific controller is the source of the pressure, fix it on the client side: raise `--burst` and `--qps` only where justified, fix tight reconcile loops, and adopt informers + caches instead of polling. The kube-apiserver client defaults (`QPS=5, Burst=10`) exist for a reason.
+
+3. **Scope permissions, not quotas.** If the concern is abusive use by a specific identity, RBAC is the correct answer: grant only the verbs and resources that identity needs. A client that cannot `list pods` cluster-wide cannot flood the API server with `list pods` calls.
+
+4. **Do not insert an API gateway in front of the cluster API.** Products aimed at business-facing APIs (3scale-class proxies, external gateways) are the wrong shape for control-plane traffic. They do not understand client-go discovery, watch semantics, `Accept` negotiation, or APF headers, and they will break controllers in subtle ways. Rate limiting implemented at the L4/L7 edge (HAProxy, NGINX, F5) is technically possible but is outside any sane operational envelope — it will drop watch connections, stall leader elections, and turn transient request storms into sustained outages.
+
+5. **Audit instead.** When the goal is accountability (who is making these calls), turn on audit logging and consume it into the platform log pipeline. Audit answers the actual question most of these requests boil down to, which is forensic, not enforcement.
+
+## Diagnostic Steps
+
+Confirm which mechanisms are active and what they are doing:
+
+```bash
+# See APF configuration currently in effect
+kubectl get flowschemas.flowcontrol.apiserver.k8s.io
+kubectl get prioritylevelconfigurations.flowcontrol.apiserver.k8s.io
+
+# Identify which FlowSchema a given request is being classified into
+# (API server exposes this via response headers)
+kubectl get --raw=/apis/flowcontrol.apiserver.k8s.io/v1/flowschemas \
+  -v=8 2>&1 | grep -i 'x-kubernetes-pf-'
+```
+
+Look for which identities are actually heavy on the API server — this is usually more useful than guessing:
+
+```bash
+# apiserver_request_total broken down by user-agent
+kubectl get --raw '/metrics' 2>/dev/null \
+  | grep '^apiserver_request_total' \
+  | sort -t'"' -k2 \
+  | head -n 40
+```
+
+If the output shows a specific controller dominating, the fix is on that controller (cache / informer / backoff), not on an imagined per-user throttle that the API server does not implement.

--- a/docs/en/solutions/Per_user_API_request_count_rate_limiting_is_not_a_kube_apiserver_primitive_on_ACP.md
+++ b/docs/en/solutions/Per_user_API_request_count_rate_limiting_is_not_a_kube_apiserver_primitive_on_ACP.md
@@ -1,0 +1,78 @@
+---
+kind:
+   - Information
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Per-user API request-count rate limiting is not a kube-apiserver primitive on ACP
+
+## Issue
+
+Cluster administrators on Alauda Container Platform (ACP install package v4.3.13, server `v1.34.5`, kube-apiserver image `registry.alauda.cn:60080/tkestack/kube-apiserver:v1.34.5`) sometimes ask for a built-in way to cap "N requests per user per second/minute" at the API server — for example, to stop a runaway client from issuing `kubectl get pods` at high rate. The kube-apiserver ACP runs is the upstream Kubernetes API server, and that server does not expose a request-count-based throttle per authenticated user or client; there is no field, flag, or admission resource that implements such a quota. The same gap applies in any equivalent distribution because the apiserver inherits the upstream design.
+
+## Root Cause
+
+What the upstream kube-apiserver does ship is API Priority and Fairness (APF), served at GA at `flowcontrol.apiserver.k8s.io/v1` on this cluster, with `FlowSchema` and `PriorityLevelConfiguration` as built-in cluster-scoped kinds. APF is a concurrency-and-fairness mechanism: a `FlowSchema` selects which authenticated subjects a rule applies to and points the matching requests at a `PriorityLevelConfiguration`, whose tunables (`nominalConcurrencyShares`, `queues`, `handSize`, `queueLengthLimit`, plus `type: Limited|Exempt`) shape in-flight concurrency — not requests-per-time-window. The `FlowSchema.spec` exposes only `distinguisherMethod`, `matchingPrecedence`, `priorityLevelConfiguration`, and `rules`; there is no `maxRequestsPerSecond` or `requestsPerMinute` style field anywhere in the schema, and `distinguisherMethod` (e.g. `ByUser`, `ByNamespace`) merely groups requests into fair-share queues inside a priority level rather than imposing a per-subject rate cap.
+
+The native Kubernetes APIs themselves carry no user-level request-count throttle. The `FlowSchema` subject selector is a *matching* construct, and no other built-in API group provides a per-user-per-time-window quota; the apiserver's own command-line surface confirms the same — no `--rate-limit`, no `--per-user-*`, no `--max-requests` flag is configured, and APF being GA upstream since Kubernetes 1.29 means it is unconditionally on without a feature-gate toggle.
+
+## Resolution
+
+Treat APF as the supported control-plane stability mechanism and configure it through the standard built-in objects. The cluster already ships the upstream default set of FlowSchemas — `exempt`, `probes`, `system-leader-election`, `system-node-high`, `system-nodes`, `kube-controller-manager`, `kube-scheduler`, `kube-system-service-accounts`, `service-accounts`, `global-default`, and `catch-all` — bound to the upstream default PriorityLevelConfigurations (`exempt`, `system`, `node-high`, `leader-election`, `workload-high`, `workload-low`, `global-default`, `catch-all`) with concurrency shapes such as `Limited` + `nominalConcurrencyShares` + `queues` + `handSize` + `queueLengthLimit`:
+
+```bash
+kubectl get flowschemas.flowcontrol.apiserver.k8s.io
+kubectl get prioritylevelconfigurations.flowcontrol.apiserver.k8s.io
+```
+
+To carve out a separate concurrency lane for a specific authenticated subject, define a `FlowSchema` that selects that subject and routes it to a `PriorityLevelConfiguration` with the desired concurrency shape — this is the only in-cluster knob that targets a particular user, and it acts on parallel in-flight load, not requests-per-window:
+
+```yaml
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  name: noisy-client
+spec:
+  matchingPrecedence: 9000
+  priorityLevelConfiguration:
+    name: workload-low
+  distinguisherMethod:
+    type: ByUser
+  rules:
+    - subjects:
+        - kind: User
+          user:
+            name: alice
+      resourceRules:
+        - verbs: ["*"]
+          apiGroups: ["*"]
+          resources: ["*"]
+```
+
+If the requirement is genuinely a per-user request-count quota over a time window, place that policy *outside* the cluster — at the front-door load balancer or firewall that fronts the API server (HAProxy, F5, NGINX, etc.). That layer is customer-managed network infrastructure and is outside the cluster's API surface; the kube-apiserver itself will not implement the policy.
+
+## Diagnostic Steps
+
+Confirm that the admission machinery in the cluster does not implement a per-user throttle either. Listing the admission-registration kinds returns only the four upstream resources — `MutatingWebhookConfiguration`, `ValidatingWebhookConfiguration`, `ValidatingAdmissionPolicy`, and `ValidatingAdmissionPolicyBinding`, all under `admissionregistration.k8s.io/v1` — and none of them is a request-count throttle resource:
+
+```bash
+kubectl api-resources | grep -i admission
+```
+
+Inspect the kube-apiserver static-pod manifest to confirm the running flag set does not include a per-user or request-count rate limiter. On ACP the kube-apiserver runs as a static pod in the `kube-system` namespace; describe it and review the `Command:` section — the configured flags cover authentication mode (`Node,RBAC`), etcd endpoints and TLS, audit, admission plugins (such as `NodeRestriction`, `OwnerReferencesPermissionEnforcement`, `DenyServiceExternalIPs`), and token handling, with no `--rate-limit`, no `--per-user-*`, and no `--max-requests-inflight`-style per-subject quota flag present:
+
+```bash
+kubectl get pods -n kube-system -l component=kube-apiserver
+kubectl describe pod -n kube-system kube-apiserver-<control-plane-node>
+```
+
+Confirm the APF API surface itself is live on the cluster — both kinds are served at GA `flowcontrol.apiserver.k8s.io/v1` and the default FlowSchemas and PriorityLevelConfigurations are present, which is the in-cluster surface to use when concurrency or fairness needs tuning:
+
+```bash
+kubectl api-resources --api-group=flowcontrol.apiserver.k8s.io
+kubectl get flowschema catch-all -o yaml
+kubectl get prioritylevelconfiguration global-default -o yaml
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章。
