### PR TITLE
[security] Restricting create permissions on TokenReview and SubjectAccessReview APIs on ACP

### DIFF
--- a/docs/en/solutions/Keep_TokenReview_and_SubjectAccessReview_Out_of_Broad_Roles.md
+++ b/docs/en/solutions/Keep_TokenReview_and_SubjectAccessReview_Out_of_Broad_Roles.md
@@ -1,0 +1,92 @@
+---
+kind:
+   - BestPractices
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+Cluster operators sometimes consider granting `create` on `TokenReview`, `SubjectAccessReview` (SAR), or `LocalSubjectAccessReview` (LSAR) to the `system:authenticated` group, or folding those verbs into the built-in `admin` aggregated ClusterRole, so that applications and tenants can self-check their own permissions. The request looks innocuous because the three APIs return "yes/no" answers, not data. They are not innocuous. Broad access to these verbs hands every authenticated identity a cluster-wide introspection surface against the authentication and authorization subsystems.
+
+## Root Cause
+
+`TokenReview`, `SubjectAccessReview`, and `LocalSubjectAccessReview` are the same building blocks the control plane itself uses to decide whether a request should proceed. They were designed for a small population of trusted callers (the aggregation API, webhook integrations, controllers that need to evaluate permissions on behalf of a user). Their inputs and outputs deliberately reveal details about the security posture of the cluster:
+
+- `TokenReview` accepts an arbitrary bearer token and returns whether it authenticates, along with the username and group set the token resolves to. Any identity that can `create` TokenReviews can validate tokens it has obtained through other channels (leaked logs, captured headers, test fixtures) and discover the identities those tokens represent.
+- `SubjectAccessReview` and its namespaced cousin accept a `(user, verb, resource)` triple and return whether the cluster's RBAC graph grants that action. A caller with `create` permission can enumerate the permission surface of any user or ServiceAccount — asking "can `system:serviceaccount:kube-system:attacker` `delete pods` in namespace `X`?" without actually attempting the action.
+
+Taken together, these three verbs are a privilege-enumeration primitive. The built-in `admin` aggregated ClusterRole is namespace-scoped by design and must not confer cluster-wide security introspection either; aggregating review verbs into `admin` effectively promotes every project admin into a limited auditor of the control plane's auth state.
+
+The `system:authenticated` group is similarly the wrong target: it contains every authenticated identity in the cluster — every human user, every ServiceAccount, every workload pod's token. Granting anything to this group is equivalent to granting it to an anonymous attacker who has managed to authenticate at all, which in most cluster environments is not a high bar.
+
+## Resolution
+
+Keep the review APIs restricted to the small set of components that legitimately need them, and use narrower RBAC for everything else.
+
+1. **Do not bind review verbs to `system:authenticated`.** If a workload needs to self-check one specific permission, grant that workload a narrow Role covering only the verb and resource it actually needs. The review APIs are not the tool for "can this app reach its own DB ConfigMap".
+
+2. **Do not aggregate review verbs into the default `admin` / `edit` ClusterRoles.** The aggregation labels (`rbac.authorization.k8s.io/aggregate-to-admin`) were chosen per resource intentionally; adding `tokenreviews` or `subjectaccessreviews` to that set is a platform-wide change with no namespace-scoping escape hatch.
+
+3. **When a workload must issue reviews, give it a dedicated ServiceAccount and a purpose-built Role.** Example: a controller that reconciles per-tenant RBAC and needs to check whether a principal already has a permission before adding a binding.
+
+   ```yaml
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   metadata:
+     name: tenant-rbac-reconciler
+   rules:
+     - apiGroups: ["authorization.k8s.io"]
+       resources: ["subjectaccessreviews"]
+       verbs: ["create"]
+     - apiGroups: ["authorization.k8s.io"]
+       resources: ["localsubjectaccessreviews"]
+       verbs: ["create"]
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: tenant-rbac-reconciler
+   subjects:
+     - kind: ServiceAccount
+       name: tenant-rbac-reconciler
+       namespace: platform-rbac
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: ClusterRole
+     name: tenant-rbac-reconciler
+   ```
+
+   Critically, `tokenreviews.create` is *not* in this example. Most controllers should never need to validate a bearer token out-of-band; that is the job of the API server itself and of authentication webhooks that are configured through the cluster authentication layer.
+
+4. **Keep `tokenreviews.create` to authentication-webhook components only.** If a custom authenticator needs this verb, bind it to that component's ServiceAccount and only to that ServiceAccount. Never to a group.
+
+5. **Prefer `SelfSubjectAccessReview` / `SelfSubjectRulesReview` for the "can I do X myself" case.** These self-scoped variants are intentionally openable to `system:authenticated` and answer the common "can the current caller do X in this namespace" question without exposing anything about other identities. The `kubectl auth can-i` command uses exactly these APIs.
+
+## Diagnostic Steps
+
+Audit who currently holds create-level access to the review APIs. The three commands below cover the common misconfigurations:
+
+```bash
+# Bindings that land on system:authenticated — any match here on a
+# ClusterRole that includes review verbs is a finding to fix.
+kubectl get clusterrolebinding -o json \
+  | jq -r '.items[] | select(.subjects[]? | select(.name=="system:authenticated")) | .metadata.name'
+
+# ClusterRoles that grant create on any of the three review APIs.
+kubectl get clusterrole -o json \
+  | jq -r '
+      .items[] | . as $cr |
+      ($cr.rules // []) |
+      map(select(.verbs | index("create")) |
+          select(.resources[]? | test("^(tokenreviews|subjectaccessreviews|localsubjectaccessreviews)$"))) |
+      select(length > 0) |
+      ($cr.metadata.name)'
+
+# Whether review verbs have been aggregated into the built-in admin role.
+kubectl get clusterrole admin -o yaml \
+  | grep -E 'tokenreviews|subjectaccessreviews|localsubjectaccessreviews' || echo "admin does not aggregate review verbs — good"
+```
+
+Each match produced by the first two commands should be justified against the owning component. Any hit from the third command — `admin` aggregating review verbs — should be reverted immediately; the built-in roles are meant to be treated as immutable policy.

--- a/docs/en/solutions/Keep_TokenReview_and_SubjectAccessReview_Out_of_Broad_Roles.md
+++ b/docs/en/solutions/Keep_TokenReview_and_SubjectAccessReview_Out_of_Broad_Roles.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Keep TokenReview and SubjectAccessReview Out of Broad Roles
 ## Issue
 
 Cluster operators sometimes consider granting `create` on `TokenReview`, `SubjectAccessReview` (SAR), or `LocalSubjectAccessReview` (LSAR) to the `system:authenticated` group, or folding those verbs into the built-in `admin` aggregated ClusterRole, so that applications and tenants can self-check their own permissions. The request looks innocuous because the three APIs return "yes/no" answers, not data. They are not innocuous. Broad access to these verbs hands every authenticated identity a cluster-wide introspection surface against the authentication and authorization subsystems.

--- a/docs/en/solutions/Restricting_create_permissions_on_TokenReview_and_SubjectAccessReview_APIs_on_ACP.md
+++ b/docs/en/solutions/Restricting_create_permissions_on_TokenReview_and_SubjectAccessReview_APIs_on_ACP.md
@@ -1,0 +1,56 @@
+---
+kind:
+   - BestPractices
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Restricting create permissions on TokenReview and SubjectAccessReview APIs on ACP
+
+## Issue
+
+On Alauda Container Platform v4.3.13 (Kubernetes v1.34.5), the three Kubernetes review APIs — `tokenreviews.authentication.k8s.io`, `subjectaccessreviews.authorization.k8s.io`, and `localsubjectaccessreviews.authorization.k8s.io` — are shipped verbatim by kube-apiserver. `TokenReview` is the cluster-scoped, create-only API that validates an arbitrary bearer token against the cluster's authenticators; it is the only API in `authentication.k8s.io/v1` that performs arbitrary-token validation (the sibling `SelfSubjectReview` only reflects the caller's own identity). `SubjectAccessReview` is cluster-scoped and `LocalSubjectAccessReview` is namespaced; both let the caller ask "can subject U perform verb V on resource R?" and both ship alongside the safer `selfsubjectaccessreviews` / `selfsubjectrulesreviews` self-only variants.
+
+The `system:authenticated` virtual group is attached by kube-apiserver to every successfully authenticated request, so every human user, every ServiceAccount, and every system component that authenticates against the cluster is a member of that group. Any ClusterRoleBinding that grants `create` on a review API to `system:authenticated` therefore grants that capability to every identity the cluster trusts at all, which is the security posture this article addresses.
+
+## Root Cause
+
+Granting `create` on `tokenreviews` to `system:authenticated` lets any authenticated identity validate arbitrary bearer tokens via the TokenReview API, which is the sole arbitrary-token validator in the cluster. Granting `create` on `subjectaccessreviews` to `system:authenticated` lets any authenticated identity probe authorization decisions for arbitrary subjects cluster-wide, and granting `create` on `localsubjectaccessreviews` extends the same probing into individual namespaces. Either grant exposes the cluster's authorization boundaries by letting any authenticated identity enumerate which subjects can perform which actions, and the same reconnaissance surface lets an attacker identify ServiceAccounts or users with elevated privileges and plan lateral movement or privilege escalation accordingly.
+
+The same exposure can arrive by a second route: aggregation into the default `admin` ClusterRole. The `admin` ClusterRole is shipped by kube-apiserver bootstrap (label `kubernetes.io/bootstrapping=rbac-defaults`) and carries an `aggregationRule` whose `clusterRoleSelectors` match the label `rbac.authorization.k8s.io/aggregate-to-admin=true`; any ClusterRole that bears that label has its rules folded into `admin` automatically. The `admin` ClusterRole is designed for namespace-scoped resource management and is not intended as a cluster-wide security-introspection role, so aggregating review APIs into it would grant those capabilities to every subject holding `admin` in any namespace.
+
+## Resolution
+
+Restrict `create` on `tokenreviews` / `subjectaccessreviews` / `localsubjectaccessreviews` to system-level components and trusted controllers; do not bind those verbs to `system:authenticated`, and do not aggregate them into the default `admin` ClusterRole. On ACP v4.3.13 the default posture already conforms: none of the 11 ClusterRoleBindings bound to `system:authenticated` grant `create` on `tokenreviews`, `subjectaccessreviews`, or `localsubjectaccessreviews`; the only review-API verb reaching `system:authenticated` is `create` on `selfsubjectaccessreviews` and `selfsubjectrulesreviews` (via `system:basic-user`), which are self-only and reveal nothing about other subjects.
+
+On the same cluster the default `admin` ClusterRole already aggregates `create` on `localsubjectaccessreviews` (via the bootstrap ClusterRole `system:aggregate-to-admin`, which bears the `aggregate-to-admin=true` label), while `tokenreviews` (cluster-scoped) and `subjectaccessreviews` (cluster-scoped) are not aggregated into `admin`. The LSAR aggregation matches the upstream Kubernetes default and is namespace-scoped by design — a holder of `admin` in namespace N can only ask LSAR questions whose `spec.resourceAttributes.namespace` equals N — so it does not provide cluster-wide reconnaissance the way an `admin`-aggregated SAR or TokenReview rule would.
+
+The 28 ClusterRoles on the cluster that carry review-API rules are all either bootstrap roles (`system:*` and the aggregation-fed `admin`) or scoped operator roles (for example `capi-*`, `cdi-*`, `cert-manager-*`, `kubevirt-*`); none of them are bound to `system:authenticated`, which keeps the recommended posture in place by default. Preserve this posture by refusing to add new ClusterRoleBindings that grant `create` on the three review APIs to `system:authenticated`, and by refusing to attach the `rbac.authorization.k8s.io/aggregate-to-admin=true` label to any ClusterRole whose rules include `tokenreviews/create` or `subjectaccessreviews/create`.
+
+## Diagnostic Steps
+
+Enumerate which ClusterRoleBindings reference the `system:authenticated` group so an operator can see every ClusterRole bound cluster-wide to every authenticated identity:
+
+```bash
+kubectl get clusterrolebinding -o wide | grep system:authenticated
+```
+
+On ACP v4.3.13 the command returns 11 default ClusterRoleBindings — the upstream Kubernetes set (`system:basic-user`, `system:discovery`, `system:public-info-viewer`) plus ACP, KubeVirt, and CDI add-ons (`cpaas-*`, `productentry`, `cdi.kubevirt.io:config-reader`, `kubevirt.io:*`); the diagnostic is generic Kubernetes and runs against ACP unchanged.
+
+Inspect whether the review APIs have been aggregated into the default `admin` ClusterRole:
+
+```bash
+kubectl get clusterrole admin -o yaml | grep -E 'tokenreviews|subjectaccessreviews'
+```
+
+On ACP v4.3.13 the effective rules of `admin` include `{authorization.k8s.io, [localsubjectaccessreviews], [create]}` only — `tokenreviews` and `subjectaccessreviews` are not aggregated into `admin`, which matches the recommended posture.
+
+List every ClusterRole whose rules grant access to the review resources so any role that allows their creation surfaces in one pass:
+
+```bash
+kubectl get clusterroles -o yaml | grep -E 'TokenReview|SubjectAccessReview|LocalSubjectAccessReview'
+```
+
+On ACP v4.3.13 the enumerated form of this grep returns 28 ClusterRoles that carry review-API rules; all 28 are bootstrap roles or scoped operator roles, and none are bound to `system:authenticated`, so the diagnostic shape is portable to ACP and confirms the cluster's default conformance with the recommended posture.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
