### PR TITLE
[gitops] ArgoCD redis-ha-haproxy stuck Pending during rollout on a node-count-equal-to-replicas cluster

### DIFF
--- a/docs/en/solutions/ArgoCD_redis_ha_haproxy_stuck_Pending_during_rollout_on_a_node_count_equal_to_replicas_cluster.md
+++ b/docs/en/solutions/ArgoCD_redis_ha_haproxy_stuck_Pending_during_rollout_on_a_node_count_equal_to_replicas_cluster.md
@@ -1,0 +1,80 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# ArgoCD redis-ha-haproxy stuck Pending during rollout on a node-count-equal-to-replicas cluster
+
+## Issue
+
+On Alauda Container Platform, the `argocd` ModulePlugin applies a stock ArgoCD CR named `argocd-gitops` in namespace `argocd` (chart `chart-argocd-installer v4.2.0`). When the CR has `.spec.ha.enabled=true`, the operator materializes an `argocd-gitops-redis-ha-haproxy` Deployment with `replicas: 3`, fronting the `argocd-gitops-redis-ha-server` redis StatefulSet. During a rolling update of this Deployment on a cluster whose worker node count equals the replica count, a freshly created surge pod is observed in `0/1 Pending` alongside the three `Running` replicas, following the upstream `<deployment>-<rs-hash>-<suffix>` naming scheme.
+
+## Root Cause
+
+The `argocd-gitops-redis-ha-haproxy` pod template sets a hard hostname-spread rule: `podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution` with `labelSelector.matchLabels.app.kubernetes.io/name=argocd-gitops-redis-ha-haproxy` at `topologyKey: kubernetes.io/hostname`, plus a soft `preferredDuringSchedulingIgnoredDuringExecution` term at `failure-domain.beta.kubernetes.io/zone` weight 100; the hard hostname term forces every replica onto a distinct node. The same Deployment uses `strategy.type: RollingUpdate` with `rollingUpdate.maxSurge: 25%` and `rollingUpdate.maxUnavailable: 25%`.
+
+The Kubernetes Deployment contract for `maxSurge` calculates the absolute number from the percentage by rounding up, so 25% of 3 replicas allows 1 extra surge pod created before any existing replica is torn down. The contract for required pod anti-affinity is that if the anti-affinity requirements are not met at scheduling time, the pod will not be scheduled onto the node. With three existing replicas already pinned one-per-node by the `kubernetes.io/hostname` term, a 4th surge pod carrying the same `app.kubernetes.io/name` label has no node left that satisfies the required term and therefore remains Pending until the rollout aborts or a fourth node becomes available.
+
+## Resolution
+
+The collision is a property of the Deployment shape rendered when `.spec.ha.enabled=true` interacts with a cluster whose worker count equals the redis-ha-haproxy replica count. Two operator-surface workarounds avoid it; both edit the `argocd-gitops` ArgoCD CR in namespace `argocd` (haproxy container image `build-harbor.alauda.cn/3rdparty/haproxy:2.0.34-alpine-2`, chart `chart-argocd-installer v4.2.0`) and let the operator reconcile the change down into the `argocd-gitops-redis-ha-haproxy` Deployment.
+
+Option A — disable HA on the ArgoCD CR. This collapses the 3-replica redis-ha-haproxy Deployment so the surge-vs-anti-affinity collision cannot recur. Set `.spec.ha.enabled=false` and let the operator tear down the redis-ha-haproxy Deployment and the redis-ha StatefulSet:
+
+```bash
+kubectl patch argocd -n argocd argocd-gitops \
+ --type merge \
+ -p '{"spec":{"ha":{"enabled":false}}}'
+```
+
+Option B — override the redis-ha-haproxy pod template's anti-affinity so the hard hostname term becomes soft. Relaxing the required term to a `preferredDuringSchedulingIgnoredDuringExecution` rule keeps the spread preference but lets the surge pod schedule on a node that already hosts a matching replica, breaking the deadlock. The override must be expressed through the `argocd-gitops` ArgoCD CR's `.spec.ha` block (which owns the redis-ha-haproxy Deployment via the operator reconcile chain) rather than by editing the Deployment directly, because operator-managed Deployments are reverted on the next reconcile loop.
+
+After either change, watch the Deployment until the surge pod clears:
+
+```bash
+kubectl get deploy -n argocd argocd-gitops-redis-ha-haproxy
+kubectl get pod -n argocd -l app.kubernetes.io/name=argocd-gitops-redis-ha-haproxy -o wide
+```
+
+## Diagnostic Steps
+
+Confirm the Deployment shape and replica count that the operator rendered from `argocd-gitops`:
+
+```bash
+kubectl get deploy -n argocd argocd-gitops-redis-ha-haproxy \
+ -o jsonpath='{.spec.replicas}{"\n"}'
+kubectl get deploy -n argocd argocd-gitops-redis-ha-haproxy \
+ -o jsonpath='{.metadata.ownerReferences[0].kind}/{.metadata.ownerReferences[0].name}{"\n"}'
+```
+
+Read the rolling-update strategy on the Deployment — `maxSurge: 25%` plus `maxUnavailable: 25%` is the shape that drives the 1-extra-pod surge math on a 3-replica Deployment:
+
+```bash
+kubectl get deploy -n argocd argocd-gitops-redis-ha-haproxy \
+ -o jsonpath='{.spec.strategy}{"\n"}'
+```
+
+Read the pod template's affinity to confirm the required `kubernetes.io/hostname` term carries `labelSelector.matchLabels.app.kubernetes.io/name=argocd-gitops-redis-ha-haproxy` (the own-ReplicaSet match is what makes the surge pod un-schedulable when every node already hosts a replica):
+
+```bash
+kubectl get deploy -n argocd argocd-gitops-redis-ha-haproxy \
+ -o jsonpath='{.spec.template.spec.affinity.podAntiAffinity}{"\n"}'
+```
+
+List the haproxy pods with node placement; the precondition for the collision is one matching pod per node on every worker — i.e. no node free to host a 4th replica:
+
+```bash
+kubectl get pod -n argocd \
+ -l app.kubernetes.io/name=argocd-gitops-redis-ha-haproxy \
+ -o wide
+```
+
+If a Pending pod is present, `kubectl describe pod` on it surfaces the standard scheduler event for the required term — node count and matching pods enumerated — which matches the contract that an unsatisfied required anti-affinity term keeps the pod off every node:
+
+```bash
+kubectl describe pod -n argocd <pending-haproxy-pod-name>
+```

--- a/docs/en/solutions/Argo_CD_Redis_HAProxy_deployment_stuck_Pending_after_operator_upgrade_on_a_three_worker_cluster.md
+++ b/docs/en/solutions/Argo_CD_Redis_HAProxy_deployment_stuck_Pending_after_operator_upgrade_on_a_three_worker_cluster.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Argo CD Redis HAProxy deployment stuck Pending after operator upgrade on a three-worker cluster
 ## Issue
 
 After upgrading the ACP GitOps component (Argo CD) on a cluster with exactly three schedulable worker nodes, the `redis-ha-haproxy` Deployment that fronts the Argo CD Redis HA tier never completes its rollout. A fourth replica is created alongside the three Running ones and remains `Pending` indefinitely:

--- a/docs/en/solutions/Argo_CD_Redis_HAProxy_deployment_stuck_Pending_after_operator_upgrade_on_a_three_worker_cluster.md
+++ b/docs/en/solutions/Argo_CD_Redis_HAProxy_deployment_stuck_Pending_after_operator_upgrade_on_a_three_worker_cluster.md
@@ -1,0 +1,119 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+After upgrading the ACP GitOps component (Argo CD) on a cluster with exactly three schedulable worker nodes, the `redis-ha-haproxy` Deployment that fronts the Argo CD Redis HA tier never completes its rollout. A fourth replica is created alongside the three Running ones and remains `Pending` indefinitely:
+
+```text
+gitops-redis-ha-haproxy-745cb8db58-8jscz   0/1   Pending   0   32s
+gitops-redis-ha-haproxy-85dbf4d9c-56vjr    1/1   Running   0   9m59s
+gitops-redis-ha-haproxy-85dbf4d9c-wkbwh    1/1   Running   0   9m59s
+gitops-redis-ha-haproxy-85dbf4d9c-zvfjs    1/1   Running   0   9m59s
+```
+
+The Deployment's desired replica count is three, but during the upgrade a surge pod is scheduled before any existing pod is terminated, and no node is available to host it.
+
+## Root Cause
+
+The `redis-ha-haproxy` Deployment combines a hard pod anti-affinity rule with a surging rolling-update strategy. The anti-affinity is `requiredDuringSchedulingIgnoredDuringExecution` keyed on `kubernetes.io/hostname`, so every replica must land on a distinct node:
+
+```yaml
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: gitops-redis-ha-haproxy
+        topologyKey: kubernetes.io/hostname
+```
+
+The upgrade then applies the default surge strategy:
+
+```yaml
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 25%
+    maxSurge: 25%
+```
+
+`maxSurge: 25%` against three replicas rounds up to one, so the controller creates a fourth pod *before* it terminates any of the three existing pods. On a three-worker cluster, every node already hosts a replica of the same Deployment, so the hard anti-affinity rule rejects every candidate node and the new pod stays `Pending`. The rollout never progresses because no existing pod is evicted to make room.
+
+## Resolution
+
+The root fix is to prevent the surge so the rollout has to terminate a pod before creating the replacement. The upstream Argo CD project addressed the same condition in `GITOPS-8033` by shipping patched charts where `maxSurge: 0` on this Deployment; those fixes were picked up in the corresponding Argo CD 1.17.3 / 1.18.2 rebuild. On ACP GitOps, move to a release that carries the fix and re-run the rollout.
+
+Preferred path on ACP — bump the GitOps component to a version that carries the upstream fix, then let the operator reconcile the Deployment:
+
+```bash
+kubectl -n <gitops-namespace> get argocd
+kubectl -n <gitops-namespace> describe argocd <name> | grep -i version
+```
+
+If an immediate upgrade is not possible, patch the Deployment manually. On ACP GitOps the operator owns this field and will reconcile it back, so the patch is a temporary unblock rather than a permanent edit — pair it with scheduling the upgrade.
+
+```bash
+kubectl -n <gitops-namespace> patch deployment gitops-redis-ha-haproxy \
+  --type=strategic \
+  -p '{"spec":{"strategy":{"rollingUpdate":{"maxSurge":0,"maxUnavailable":1}}}}'
+```
+
+With `maxSurge: 0` / `maxUnavailable: 1`, the Deployment drops a pod first, which frees the node, then schedules the replacement onto the now-empty slot. The three-node hard anti-affinity constraint is satisfied at every step.
+
+If using a raw upstream Argo CD Helm chart (no operator), set the same values directly on the HAProxy sub-chart:
+
+```yaml
+redis-ha:
+  haproxy:
+    deploymentStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 0
+        maxUnavailable: 1
+```
+
+A lasting mitigation on any permanent three-worker footprint is to add at least one more worker (or label a dedicated control-plane node as schedulable for this workload). With four nodes available, the surge pod has somewhere to go and the rollout completes even without the strategy tweak.
+
+## Diagnostic Steps
+
+1. Confirm the Pending pod is blocked on scheduling, not on image pull or resource requests:
+
+   ```bash
+   kubectl -n <gitops-namespace> get pod -l app.kubernetes.io/name=gitops-redis-ha-haproxy
+   kubectl -n <gitops-namespace> describe pod <pending-pod>
+   ```
+
+   Look at the `Events` section. A scheduler message such as `0/6 nodes are available: 3 node(s) didn't match pod anti-affinity rules, 3 node(s) had untolerated taints` confirms the diagnosis — three workers are already occupied, the other three are control-plane or tainted.
+
+2. Check the anti-affinity rule on the Deployment:
+
+   ```bash
+   kubectl -n <gitops-namespace> get deploy gitops-redis-ha-haproxy \
+     -o jsonpath='{.spec.template.spec.affinity.podAntiAffinity}' | jq .
+   ```
+
+   A `requiredDuringSchedulingIgnoredDuringExecution` entry on `topologyKey: kubernetes.io/hostname` with a matching `labelSelector` is the hard constraint driving the stall.
+
+3. Check the current rolling update strategy and compare against your worker count:
+
+   ```bash
+   kubectl -n <gitops-namespace> get deploy gitops-redis-ha-haproxy \
+     -o jsonpath='{.spec.strategy}' | jq .
+   kubectl get nodes -l node-role.kubernetes.io/worker= -o name | wc -l
+   ```
+
+   If `replicas == workers` and `maxSurge > 0`, every rollout will hit this exact symptom until the Deployment is patched or another worker is added.
+
+4. Watch the rollout progress after applying the patch or upgrade:
+
+   ```bash
+   kubectl -n <gitops-namespace> rollout status deploy/gitops-redis-ha-haproxy --timeout=5m
+   ```
+
+   A clean rollout returns `deployment "gitops-redis-ha-haproxy" successfully rolled out` without any intermediate Pending pod.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
