### PR TITLE
[networking] Diagnosing HTTP 504 timeouts behind an external load balancer on ACP

### DIFF
--- a/docs/en/solutions/504_Timeouts_Behind_an_External_Cloud_Load_Balancer.md
+++ b/docs/en/solutions/504_Timeouts_Behind_an_External_Cloud_Load_Balancer.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# 504 Timeouts Behind an External Cloud Load Balancer
 ## Issue
 
 Workloads exposed through an external cloud load balancer (for example a GCP TCP/HTTPS load balancer fronting the cluster ingress) periodically return HTTP 504 to the caller, even though the backend pod is healthy. A latency probe shows the time-to-first-byte (`starttransfer`) hovering close to 30 seconds before the request is cut off, while DNS lookup, TCP connect, and TLS handshake all complete in milliseconds. Sample probe line:

--- a/docs/en/solutions/504_Timeouts_Behind_an_External_Cloud_Load_Balancer.md
+++ b/docs/en/solutions/504_Timeouts_Behind_an_External_Cloud_Load_Balancer.md
@@ -1,0 +1,113 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+Workloads exposed through an external cloud load balancer (for example a GCP TCP/HTTPS load balancer fronting the cluster ingress) periodically return HTTP 504 to the caller, even though the backend pod is healthy. A latency probe shows the time-to-first-byte (`starttransfer`) hovering close to 30 seconds before the request is cut off, while DNS lookup, TCP connect, and TLS handshake all complete in milliseconds. Sample probe line:
+
+```text
+local_port: 43886 | dnslookup: 0.000338 | connect: 0.014501 |
+appconnect: 0.035137 | pretransfer: 0.035208 |
+starttransfer: 32.182811 | total: 30.182911 |
+size: 14 | response: 504
+```
+
+## Root Cause
+
+Two timers govern the request path and a 504 fires the moment the *shorter* one expires before the backend responds:
+
+1. The in-cluster ingress proxy (the platform's HAProxy-based router on ACP ALB) has a per-route response timeout that defaults to 30 seconds. Once the upstream pod takes longer than that to start sending bytes, the proxy aborts the connection and synthesises a 504 to the client.
+2. The external cloud load balancer in front of the cluster has its own backend timeout. When that timer is shorter than (or close to) the in-cluster timer, the cloud LB also returns 504 before the proxy has a chance to.
+
+Whichever timer is reached first wins. A slow application or a chain of intermediaries (firewall, WAF, NAT) only makes the gap worse, but the 504 itself is always a timer expiring on the network path, not a kernel error.
+
+## Resolution
+
+Treat the timeouts as a chain that must be ordered from outermost to innermost: external LB > ingress > backend. Each hop must wait at least as long as the next hop downstream, otherwise the outer hop will give up early.
+
+### 1. Raise the ingress timeout for the affected route
+
+On ACP, the ALB operator (`networking/operators/alb_operator`) provides the platform-preferred entry point. Adjust the response timeout on the Ingress resource using the ALB-specific annotation; the value applies only to that Ingress and does not change the cluster default.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: slow-app
+  namespace: prod
+  annotations:
+    alb.cpaas.io/timeout: "120s"
+spec:
+  rules:
+    - host: slow-app.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: slow-app
+                port:
+                  number: 8080
+```
+
+If the cluster's Ingress controller is HAProxy-based (NGINX Ingress is the more common ACP default), the equivalent timeout knob is exposed through the controller's own annotation set; ALB users should rely on the annotation above.
+
+### 2. Raise the external load balancer's backend timeout
+
+Set the cloud-side backend timeout to a value strictly larger than the ingress timeout configured in step 1. As a rule of thumb keep at least a 30-second margin so the cluster has a chance to surface a clean 504 (with route headers and request id) before the cloud LB times the connection out and hides those signals.
+
+For a GCP backend service this is the `--timeout` flag (in seconds). Whatever the cloud, the order must be:
+
+```text
+client timeout  >  external LB backend timeout  >  cluster ingress timeout  >  app server timeout
+```
+
+### 3. Address the slow backend
+
+Increasing timers buys time but does not fix the underlying latency. Track down the slow backend in parallel:
+
+- Profile the application — pure CPU, blocking I/O, or downstream dependency calls?
+- Confirm the pod's CPU/memory requests are not being throttled.
+- Check that the Service has healthy endpoints for the entire 30-second window (a rolling restart can leave a single endpoint serving while others come up).
+
+## Diagnostic Steps
+
+Reproduce the latency from inside the cluster, bypassing the external LB, to confirm the bottleneck is in the application and not on the public path:
+
+```bash
+kubectl run latency-probe --rm -it --restart=Never \
+  --image=curlimages/curl:8.10.1 -- sh -c '
+  while true; do
+    printf "%s | " "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    curl -o /dev/null -s -w \
+      "dns:%{time_namelookup} connect:%{time_connect} \
+tls:%{time_appconnect} ttfb:%{time_starttransfer} \
+total:%{time_total} code:%{http_code}\n" \
+      http://slow-app.prod.svc.cluster.local:8080/health
+    sleep 1
+  done'
+```
+
+If `ttfb` already exceeds the ingress timeout from inside the cluster, the application is the slow hop. If it is fast in-cluster but slow when called through the external LB, the additional latency is on the public path or in the LB itself.
+
+Inspect the effective timeout the ALB negotiated for the route:
+
+```bash
+kubectl get ingress slow-app -n prod \
+  -o jsonpath='{.metadata.annotations}' | jq .
+```
+
+Look at the ingress controller pod logs around the time of the 504 — the log line includes the upstream address and the duration the proxy waited before cutting the connection:
+
+```bash
+kubectl -n cpaas-system logs -l app=alb -c alb --tail=200 \
+  | grep -E '504|timeout|slow-app'
+```
+
+If the timeout is happening on the cloud LB instead of the cluster, the cluster logs will not show a 504 at all — the request never reaches the backend. In that case the fix lives entirely on the cloud-side configuration (step 2).

--- a/docs/en/solutions/Diagnosing_HTTP_504_timeouts_behind_an_external_load_balancer_on_ACP.md
+++ b/docs/en/solutions/Diagnosing_HTTP_504_timeouts_behind_an_external_load_balancer_on_ACP.md
@@ -1,0 +1,73 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Diagnosing HTTP 504 timeouts behind an external load balancer on ACP
+
+## Issue
+
+On Alauda Container Platform (ACP install package v4.3.13, Kubernetes v1.34.5, ALB2 `v4.3.1` data plane `registry.alauda.cn:60080/acp/alb-nginx:v4.3.1` in the `cpaas-system` namespace fronted by `ingressclass/global-alb2`), an HTTP client receives an HTTP `504 Gateway Timeout` for a request that traverses an external cloud load balancer in front of the cluster ingress before reaching a backend Pod. The user-facing request path layers an external L4/L7 load balancer, the in-cluster ALB2 data plane, and the workload Pod, and any one of these hops can close a slow response before the next hop has a chance to return it.
+
+The end-to-end shape of the path is the standard Kubernetes `Service` of type `LoadBalancer` topology — the upstream `Service.spec.type` enum (`ClusterIP / ExternalName / LoadBalancer / NodePort`) is identical on ACP, and an external cloud LB attaches in front of a `LoadBalancer`-typed Service exactly the same way it does on any conformant cluster. On the customer cluster the symptom appears as the `504` returned to the browser/client whenever the backend takes longer to produce the first response byte than the lowest-timeout hop on that path allows.
+
+## Root Cause
+
+A request that crosses multiple network hops is governed by each hop's independent timeout, and the connection is terminated by whichever hop has the lowest configured timeout — not by the slowest hop nor the backend itself. When a slow upstream causes the response's time-to-first-byte to exceed the configured timeout on any intermediate hop, that hop closes the connection and the client observes the closure as an HTTP `504 Gateway Timeout`; this is distribution-independent because the status code is read by `libcurl` (or any HTTP client) from whichever upstream closed or responded, and the same code surfaces on ACP exactly as on any other Kubernetes platform.
+
+For the external-load-balancer-in-front topology specifically, when the cloud LB's own request timeout is configured lower than the cluster ingress's timeout, the external LB terminates a slow-but-otherwise-valid request before the in-cluster ingress data plane can return the backend's response, and the client sees `504` from the LB rather than the backend.
+
+## Resolution
+
+The remediation principle is "outer timeout must be greater than inner timeout for every hop on the request path". Concretely, when a user-managed external load balancer fronts an ACP cluster, the external LB's request timeout must be configured higher than the cluster ingress's timeout so that the LB does not close a connection the ingress would still serve. The external LB's timeout is a property of the external device and is configured outside the cluster on the LB itself (cloud-provider console, on-prem appliance, etc.) — this configuration is generic to the LB product and is not a Kubernetes object.
+
+On the ACP side, the in-cluster ingress data plane is ALB2 (`alaudaloadbalancer2.crd.alauda.io`, ingressclass `global-alb2`, controller `cpaas.io/alb2`, data plane image `registry.alauda.cn:60080/acp/alb-nginx:v4.3.1` in the `cpaas-system` namespace). ALB2 exposes per-frontend timeout knobs through the `Frontend` CRD (`frontends.crd.alauda.io/v1`) under `.spec.config.timeout`, where `proxy_connect_timeout_ms`, `proxy_read_timeout_ms`, and `proxy_send_timeout_ms` set the upstream connect / read / send budgets the data plane applies to traffic for that frontend. The ALB2 Frontend timeout is the ACP-side instance of the inner-hop timeout in the outer-must-exceed-inner ordering: raise it to match the application's expected time-to-first-byte before raising the external LB timeout to a value strictly greater than the ALB2 timeout, so the external LB never closes a connection the ALB2 data plane would still serve:
+
+```yaml
+apiVersion: crd.alauda.io/v1
+kind: Frontend
+metadata:
+  name: <frontend-name>
+  namespace: cpaas-system
+spec:
+  config:
+    timeout:
+      proxy_connect_timeout_ms: 60000
+      proxy_read_timeout_ms: 60000
+      proxy_send_timeout_ms: 60000
+```
+
+After updating the ALB2 `Frontend` and the external LB timeout (with the LB value strictly greater than the ALB2 value, which in turn is greater than the observed `time_starttransfer`), re-run the curl diagnostic against the user-facing URL and confirm the request now completes with `http_code: 200` (or the backend's real status) instead of `504`.
+
+## Diagnostic Steps
+
+Capture per-request timing plus HTTP status from an external vantage point using `curl --write-out`. The libcurl `--write-out` variables (`%{time_namelookup}`, `%{time_connect}`, `%{time_appconnect}`, `%{time_pretransfer}`, `%{time_starttransfer}`, `%{time_total}`, `%{size_download}`, `%{http_code}`) are rendered verbatim by `curl` 8.5.0 / libcurl and work the same way against any ACP-fronted URL — the format string below produces one labelled line per request and is safe to run in a sustained loop from a client outside the cluster:
+
+```bash
+while true; do
+  curl -s -o /dev/null \
+    --write-out 'dnslookup: %{time_namelookup} | connect: %{time_connect} | appconnect: %{time_appconnect} | pretransfer: %{time_pretransfer} | starttransfer: %{time_starttransfer} | total: %{time_total} | size: %{size_download} | response: %{http_code}\n' \
+    "https://<user-facing-url>/<path>"
+  sleep 1
+done
+```
+
+Inspect the per-request output and compare `time_starttransfer` against the configured upstream timeouts. When `time_starttransfer` (the elapsed time from request start to the first response byte) exceeds the lowest configured timeout on the request path, the request is terminated upstream and the `%{http_code}` field renders `504` for that sample; this is the canonical signal that "the backend was too slow for the hop that closed the connection" and identifies which timeout needs to be raised.
+
+```text
+dnslookup: 0.004 | connect: 0.012 | appconnect: 0.045 | pretransfer: 0.046 | starttransfer: 30.001 | total: 30.002 | size: 0 | response: 504
+```
+
+Confirm the external-LB-in-front topology by listing `LoadBalancer`-typed Services and inspecting the front-door binding. `Service.spec.type` accepts the upstream enum (`ClusterIP / ExternalName / LoadBalancer / NodePort`) unchanged on ACP, and an external cloud LB attaches in front of a Service of `type: LoadBalancer` the same way it does on any conformant cluster:
+
+```bash
+kubectl get svc -A --field-selector spec.type=LoadBalancer
+kubectl get alaudaloadbalancer2 -n cpaas-system global-alb2 \
+  -o jsonpath='{.status.allocatedAddress}{"\n"}'
+```
+
+When the LB timeout is the closing hop, raising only the ALB2 `Frontend` timeout does not resolve the symptom — the external LB will still close the connection at its own (lower) limit. The rule "outer ≥ inner" must hold for every hop on the path, so apply the timeout increase to whichever hop the curl `time_starttransfer` sample shows is closing first.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
