### PR TITLE
[storage] Default StorageClass Flag on a Ceph-Backed Class Keeps Being Reset to True

### DIFF
--- a/docs/en/solutions/Default_StorageClass_Flag_on_a_Ceph_Backed_Class_Keeps_Being_Reset_to_True.md
+++ b/docs/en/solutions/Default_StorageClass_Flag_on_a_Ceph_Backed_Class_Keeps_Being_Reset_to_True.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Default StorageClass Flag on a Ceph-Backed Class Keeps Being Reset to True
 ## Issue
 
 An operator-managed `StorageClass` (for example a Ceph RBD class provisioned by the ACP `storagesystem_ceph` stack) shows up as the cluster default. Attempts to clear the default flag — patching the `storageclass.kubernetes.io/is-default-class` annotation to `"false"` via `kubectl patch`, editing the object directly, or toggling it from the UI — all appear to succeed momentarily, but within seconds the annotation reverts to `"true"` and the class is again the default.

--- a/docs/en/solutions/Default_StorageClass_Flag_on_a_Ceph_Backed_Class_Keeps_Being_Reset_to_True.md
+++ b/docs/en/solutions/Default_StorageClass_Flag_on_a_Ceph_Backed_Class_Keeps_Being_Reset_to_True.md
@@ -1,0 +1,88 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+An operator-managed `StorageClass` (for example a Ceph RBD class provisioned by the ACP `storagesystem_ceph` stack) shows up as the cluster default. Attempts to clear the default flag — patching the `storageclass.kubernetes.io/is-default-class` annotation to `"false"` via `kubectl patch`, editing the object directly, or toggling it from the UI — all appear to succeed momentarily, but within seconds the annotation reverts to `"true"` and the class is again the default.
+
+## Root Cause
+
+The annotation on the `StorageClass` object is not the source of truth. The class is shipped by a higher-level operator (the one reconciling the Ceph-backed storage system) from a spec field that declares "this class should be the cluster default". On every reconcile tick the operator reads that spec and writes the annotation back. Any edit made directly against the `StorageClass` is therefore transient — the next reconciliation loop overwrites it within the operator's resync interval, which is why the flag "snaps back" no matter how it is flipped.
+
+Fixing this at the annotation layer is structurally wrong; the edit has to happen at the layer the operator actually reads from. Additionally, if a GitOps controller (Argo CD or similar) owns the storage-system CR, direct edits against that CR will also be reverted — in that case the change must be made at the git source of truth, or the controller must be paused while the correction is applied.
+
+## Resolution
+
+### Preferred: update the Ceph storage system CR managed by ACP
+
+Ceph-backed block and filesystem classes in ACP are provisioned by the `storage/storagesystem_ceph` operator from a cluster-scoped CR that describes the Ceph cluster and the pools/classes it should expose. The "is this the default class" decision lives on that CR, not on the `StorageClass` itself.
+
+Edit the managed storage-system resource and set the block-pool entry so that it does not declare itself default. Concretely, locate the `managedResources.cephBlockPools` section (or the pool entry that backs the class being deprecated as default) and remove the `defaultStorageClass: true` line — or set it to `false`, depending on the operator schema in use. After the CR is saved, the operator's next reconcile will rewrite the `StorageClass` annotation to `"false"` and stop reverting it.
+
+```yaml
+# cluster-scoped CR managed by the Ceph storage operator
+spec:
+  managedResources:
+    cephBlockPools: {}        # no default requested, or:
+    # cephBlockPools:
+    #   defaultStorageClass: false
+```
+
+If the cluster uses a different class as the intended default, set that one explicitly — either by flipping `defaultStorageClass: true` on the correct pool entry, or (if the new default is not Ceph-managed at all) by adding the annotation directly on that other `StorageClass` once the Ceph operator has released control of its own class.
+
+If a GitOps controller manages the storage-system CR, make the change in the source repository and let the sync apply it. Do not edit the live CR if sync is enabled — the controller will revert. If a one-off correction must be applied immediately, pause the Argo CD `Application` (or set `syncPolicy.automated: null`), apply the fix, then restore the sync mode after verifying the storage operator has settled.
+
+### Fallback: raw Kubernetes annotation, only when no operator owns the class
+
+If a `StorageClass` is **not** managed by an operator — for example a hand-written class for a CSI driver that no higher-level controller tracks — the standard Kubernetes annotation is authoritative and can be flipped directly:
+
+```bash
+kubectl patch storageclass <name> \
+  -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+```
+
+This path will not stick for operator-managed classes because of the reconcile loop described above; use it only when the class has no owning controller.
+
+## Diagnostic Steps
+
+Confirm which class currently carries the default flag:
+
+```bash
+kubectl get storageclass
+```
+
+The class whose row shows `(default)` is the one carrying the annotation. Then inspect the annotations on that specific object to confirm the flag and see whether it has an owner:
+
+```bash
+kubectl get storageclass <name> -o yaml | \
+  grep -E 'is-default-class|ownerReferences' -A3
+```
+
+If the output contains an `ownerReferences` block pointing at a storage-system CR (or if the object has labels like `app.kubernetes.io/managed-by: ...` naming the Ceph operator), the annotation is operator-controlled — do not fight it at the `StorageClass` level, go to the CR.
+
+Watch the annotation get rewritten to confirm the reconcile loop is the cause:
+
+```bash
+kubectl patch storageclass <name> \
+  -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+kubectl get storageclass <name> \
+  -o jsonpath='{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}'
+# … wait a reconcile interval (typically 30s–5m) …
+kubectl get storageclass <name> \
+  -o jsonpath='{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}'
+```
+
+If the second read shows `true` again, the fix must move up to the storage-system CR as described above.
+
+If a GitOps controller is suspected of reverting changes to the storage-system CR, check the `Application` resource that tracks it:
+
+```bash
+kubectl -n <argocd-ns> get applications.argoproj.io -o wide
+```
+
+Look for an application whose target namespace matches the storage operator and whose sync status was `OutOfSync` briefly after the edit — that confirms the revert came from the GitOps layer, not from the storage operator.

--- a/docs/en/solutions/Default_StorageClass_Flag_on_a_Ceph_Backed_Class_Keeps_Being_Reset_to_True.md
+++ b/docs/en/solutions/Default_StorageClass_Flag_on_a_Ceph_Backed_Class_Keeps_Being_Reset_to_True.md
@@ -1,0 +1,92 @@
+---
+title: Default StorageClass flag keeps reverting after edit
+component: storage
+scenario: troubleshooting
+tags: [storageclass, default-class, annotation, reconcile, gitops]
+date_created: 2026-05-30
+date_updated: 2026-05-30
+---
+
+# Default StorageClass flag keeps reverting after edit
+
+## Issue
+
+On an Alauda Container Platform cluster (kube v1.34.5-1), the cluster-default StorageClass is selected by the `storageclass.kubernetes.io/is-default-class` annotation. When that annotation is `"true"` on a StorageClass, `kubectl get sc` renders the entry with the `(default)` marker in the `NAME` column [ev:c1].
+
+Administrators commonly need to flip this flag — to demote the current default StorageClass before promoting a different one, or to leave the cluster with no default at all. The expected workflow is to edit the annotation directly with `kubectl patch`, `kubectl edit`, or the web console [ev:c2]. On stock ACP this works as expected against a free-standing StorageClass; for example, against the default `topolvm-hdd` StorageClass the apiserver accepts the merge patch verbatim under server-side dry-run [ev:c2]:
+
+```bash
+kubectl patch storageclass topolvm-hdd \
+  --type=merge \
+  -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+```
+
+The reported symptom is different: every attempt to set the annotation to `"false"` succeeds on the apiserver, but the StorageClass's annotation reverts back to `"true"` shortly afterwards, leaving the same StorageClass marked `(default)` in `kubectl get sc` again [ev:c3].
+
+## Root Cause
+
+The reversion is a generic Kubernetes pattern, not a bug in the StorageClass API itself. A StorageClass object can have an external owner — an operator that materialises it from a higher-level custom resource, a GitOps controller that reapplies it from a Git manifest, or an admission webhook that mutates annotations on write. When the live object drifts from what the owner thinks the desired state should be, the owner's next reconcile pass resets the annotation to the desired value, and the user-visible effect is "the flag keeps coming back" [ev:c3].
+
+The diagnostic surface for this is the StorageClass's own metadata. The `metadata.managedFields` array and the `kubectl.kubernetes.io/last-applied-configuration` annotation together show who has most recently written to the object and what value they wrote for `storageclass.kubernetes.io/is-default-class`. On the lab cluster, reading the live default StorageClass shows the annotation `storageclass.kubernetes.io/is-default-class: "true"` carried in `kubectl.kubernetes.io/last-applied-configuration`, recording that an upstream apply call asserted the default flag [ev:c3][ev:c6_a]:
+
+```text
+metadata:
+  annotations:
+    cpaas.io/creator: admin
+    cpaas.io/updated-at: "2026-05-29T10:46:15Z"
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"storage.k8s.io/v1","kind":"StorageClass",
+       "metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"},
+       "name":"topolvm-hdd"},...}
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: topolvm-hdd
+```
+
+When a controller (rather than a one-off `kubectl apply`) holds that manager identity, every drift in the annotation is reconciled back to the controller's desired value [ev:c3].
+
+## Resolution
+
+The fix is to change the desired state at the source — the controller that owns the StorageClass — rather than fighting the reconcile loop by re-patching the live object [ev:c6_a].
+
+Identify the owner first. Inspect the StorageClass's `managedFields` and `kubectl.kubernetes.io/last-applied-configuration` to see which controller or user most recently asserted the annotation [ev:c6_a]:
+
+```bash
+kubectl get sc <name> -o jsonpath='{.metadata.managedFields}' | python3 -m json.tool
+kubectl get sc <name> -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}'
+```
+
+Based on what the manager identity points at, take the appropriate corrective action [ev:c6_a]. If a GitOps controller (for example Argo CD) is the manager, update the StorageClass manifest in the Git repository — flip the `storageclass.kubernetes.io/is-default-class` annotation to `"false"` (or remove the annotation) in source, then let the controller sync the change [ev:c6_a]. Patching the cluster object directly will be reverted on the next sync [ev:c3].
+
+If a storage operator is the manager, the StorageClass is being materialised from a higher-level custom resource the operator owns; flip the default-class flag in that custom resource's spec rather than on the StorageClass itself, so the operator stops re-asserting the annotation on its next reconcile [ev:c3][ev:c6_a].
+
+If `managedFields` records a recent imperative manager (for example a `kubectl apply` invocation from a deployment script or pipeline), update the source manifest used by that pipeline so it stops asserting the annotation; otherwise the next run of the pipeline will reapply the old value [ev:c3][ev:c6_a].
+
+Once the desired state at the source is `is-default-class: "false"` (or the annotation is removed), apply the change there and verify the cluster reaches the desired state [ev:c2][ev:c6_a]:
+
+```bash
+kubectl get sc
+# expect the (default) marker to be gone from <name>
+```
+
+## Diagnostic Steps
+
+Read the live annotation value to confirm what the apiserver currently stores [ev:c1]:
+
+```bash
+kubectl get sc <name> \
+  -o jsonpath='{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}'
+```
+
+Patch the annotation to `"false"` and observe what happens [ev:c2][ev:c3]:
+
+```bash
+kubectl patch storageclass <name> \
+  --type=merge \
+  -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+
+# wait a few seconds, then re-read
+kubectl get sc <name> \
+  -o jsonpath='{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}'
+```
+
+If the value reads back as `"true"` again within seconds of the patch landing, an external owner is reconciling drift on the StorageClass [ev:c3]. Identify the owner from `managedFields` and the `kubectl.kubernetes.io/last-applied-configuration` annotation, then fix the desired state at the source [ev:c6_a].


### PR DESCRIPTION
新增一篇 ACP KB 文章，归入 `storage` 区域。

**⚠️ 自动化验证：无测试计划** — 本篇未登记验证计划，暂不自动合并，请人工确认内容后再合。

## `storage` 区域建议 reviewer

按 `kb/OWNERS.md`（来源：alauda-ai-base operator-list 的产品 owner）该区域候选自动挑选，@ 错了请无视。


没有 GitHub handle 的贡献者（本区域相关请人工 ping）：

- zyfan &lt;zyfan@alauda.io&gt;
- chengli &lt;chengli@alauda.io&gt;
- xdzhang &lt;xdzhang@alauda.io&gt;
- jhshi &lt;jhshi@alauda.io&gt;
- clyi &lt;clyi@alauda.io&gt;
