### PR TITLE
[extend] OLM InstallPlan fails with "couldn't find unpacked step" during an operator upgrade on ACP

### DIFF
--- a/docs/en/solutions/OLM_InstallPlan_fails_with_couldnt_find_unpacked_step_during_an_operator_upgrade_on_ACP.md
+++ b/docs/en/solutions/OLM_InstallPlan_fails_with_couldnt_find_unpacked_step_during_an_operator_upgrade_on_ACP.md
@@ -1,0 +1,55 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# OLM InstallPlan fails with "couldn't find unpacked step" during an operator upgrade on ACP
+
+## Issue
+
+On Alauda Container Platform, operators delivered as OperatorBundles are reconciled by the upstream OLM control plane running in the `cpaas-system` namespace (OLM image `registry.alauda.cn:60080/3rdparty/operator-framework/olm:v4.3.1`). During an operator upgrade, the catalog-operator unpacks the resolved bundle into an `InstallPlan` whose `status.plan[]` carries one typed step per resource, each element shaped as `{resolving, resource, status}`. When the catalog-operator cannot unpack or reconcile one of those per-resource steps — for example an RBAC `Role` or `ClusterRole` step — that step's `status` is left in the `Unknown` state rather than reaching the healthy `Present` value.
+
+When a plan step is stuck this way, the `InstallPlan` does not complete: its `status.phase` moves to the `Failed` value instead of the healthy `Complete` value, and the stuck CSV surfaces the failure through its own `status.phase` carrying a `Failed` value with a camelcased reason and a human-readable message. The `InstallPlan` records the outcome in `status.conditions[]`, where each condition carries the standard upstream field shape — `type`, `status`, `reason`, `message`, `lastTransitionTime`, and `lastUpdateTime` — and the `reason` is the camelcased identifier for the state transition.
+
+The condition `message` follows the upstream OLM template `couldn't find unpacked step for <csv-name>: <csv-name>-<short-hash>[<gvr> (<source-name>/<source-namespace>)] (Unknown)`, naming the CSV the step belongs to and the failing step's identifier; on ACP the bracketed source identity resolves to the active catalog source, for example `(platform/cpaas-system)`.
+
+## Root Cause
+
+The bracketed segment in the failure message — `<csv-name>-<hash>[<group>/<version>/<kind> (<source-name>/<source-namespace>)] (Unknown)` — identifies the GVK of the failing bundle step together with the catalog source name and namespace it was resolved from. For an RBAC step, a segment such as `rbac.authorization.k8s.io/v1/Role` means the failing step is a `Role` under the `v1` API of the `rbac.authorization.k8s.io` group; on ACP the trailing source identity reflects the resolved catalog source, for example `platform/cpaas-system`.
+
+The failure surfaces during the CSV replacement that an upgrade triggers. While the new InstallPlan is unresolved, the prior CSV holds the `Replacing` value in its `status.phase` and the incoming CSV holds the `Pending` value; the `csv.spec.replaces` field is the string link from the new CSV back to the name of the CSV it replaces, which is the upgrade replacement edge that the catalog-operator must satisfy before the incoming CSV can progress.
+
+## Resolution
+
+Confirm the replacement relationship between the two CSVs in the operator's namespace. Listing the CSVs shows both rows, with the `REPLACES` column linking the new CSV back to the prior one:
+
+```bash
+kubectl get csv -n <operator-ns>
+```
+
+Inspect the cluster-scoped and namespace-scoped RBAC that carries the operator's name prefix, so that leftover roles from the prior operator version can be identified against the step the message names:
+
+```bash
+kubectl get clusterrole | grep <operator-name>
+kubectl get role -n <operator-ns> | grep <operator-name>
+```
+
+Before driving a fresh resolution, confirm that the intended target version is actually available in the resolved catalog by reading the PackageManifest's `status.channels[].currentCSV`. On ACP this is read from the PackageManifest itself — including the catalog source identity, `catalogSource=platform` in `catalogSourceNamespace=cpaas-system` — rather than assumed:
+
+```bash
+kubectl get packagemanifest <operator> -n cpaas-system -o yaml | grep currentCSV -A3
+```
+
+Recovery is confirmed when the new CSV reaches the `Succeeded` value in its `status.phase`, observable by listing the CSVs in the operator's namespace:
+
+```bash
+kubectl get csv -n <operator-ns>
+```
+
+## Diagnostic Steps
+
+When the upgrade is stalled, listing the CSVs in the operator's namespace shows both the prior CSV in the `Replacing` value and the incoming CSV in the `Pending` value, with the `REPLACES` column linking the new CSV to the one it supersedes — confirming the InstallPlan for the incoming CSV has not yet resolved. Cross-reference the failing GVR named in the InstallPlan condition message (for example `rbac.authorization.k8s.io/v1/Role`) against the roles that carry the operator's name prefix to locate the specific RBAC object involved. Once the incoming CSV advances to the `Succeeded` value, the replacement has completed cleanly.

--- a/docs/en/solutions/Operator_InstallPlan_Fails_to_Unpack_RBAC_Step_from_Previous_CSV.md
+++ b/docs/en/solutions/Operator_InstallPlan_Fails_to_Unpack_RBAC_Step_from_Previous_CSV.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Operator InstallPlan Fails to Unpack RBAC Step from Previous CSV
 ## Issue
 
 An OLM-managed operator — in this case the local-storage provider that backs the TopoLVM storage system on ACP — is being upgraded to a new catalog revision. The `Subscription` produces an `InstallPlan` as expected, but the plan stalls with condition `Installed=False` and a message of the form:

--- a/docs/en/solutions/Operator_InstallPlan_Fails_to_Unpack_RBAC_Step_from_Previous_CSV.md
+++ b/docs/en/solutions/Operator_InstallPlan_Fails_to_Unpack_RBAC_Step_from_Previous_CSV.md
@@ -1,0 +1,122 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+An OLM-managed operator — in this case the local-storage provider that backs the TopoLVM storage system on ACP — is being upgraded to a new catalog revision. The `Subscription` produces an `InstallPlan` as expected, but the plan stalls with condition `Installed=False` and a message of the form:
+
+```text
+couldn't find unpacked step for local-storage-operator.v4.14.0-XXXXXXXXXXXX:
+local-storage-operator.v4.14.0-XXXXXXXXXXXX-local-st-<hash>
+[rbac.authorization.k8s.io/v1/Role (<catalog-ns>/<marketplace-ns>)] (Unknown)
+```
+
+The cluster-service version (CSV) for the new revision stays in `Pending`, the in-flight `InstallPlan` is `Failed`, and no pods ever roll over to the new image. User-facing symptom: the operator keeps running on the previous revision and never advances.
+
+## Root Cause
+
+OLM's catalog operator produces an `InstallPlan` as a DAG of "steps" — one step per resource that needs to be created or updated as part of the upgrade, with dependencies between them. When the plan is executed, each step's declared resource is "unpacked" from the bundle image into a cached per-step record. The plan watches for those cached records and refuses to proceed until every step reports `Created` or `Present`.
+
+The message `couldn't find unpacked step for ... [rbac.authorization.k8s.io/v1/Role (...)]` means the catalog operator could not reconcile the RBAC step — typically a `Role` or `ClusterRole` that the new bundle declares — against the cluster state. The usual cause is a lingering `Role`/`ClusterRole` from the **previous** revision whose metadata or owner references no longer match what the new bundle expects; the unpacker sees an object at that name but cannot reconcile it to the new step, so it marks the step `Unknown` and the plan stalls indefinitely.
+
+Other contributing factors that produce the same surface error:
+
+- The `Role` step is generated correctly by the bundle, but the catalog cache has gone stale and the bundle image re-pull did not refresh the unpacked step record for that particular resource.
+- The previous CSV was force-deleted leaving orphaned RBAC behind (without OLM getting to reconcile the owner references), and the new CSV cannot adopt those objects.
+
+The common thread: old RBAC from the replaced CSV is blocking the unpack step of the new RBAC, and the `InstallPlan` needs those stale objects cleared before it can make progress.
+
+## Resolution
+
+### Preferred: clean up stale RBAC and let the extend-managed subscription regenerate the plan
+
+Operator lifecycle on ACP is handled by the `extend` capability (the in-core OLM-based machinery for installing and upgrading extension operators). The correct recovery is to identify the specific stale RBAC objects that the new bundle cannot reconcile, remove them, and let the `Subscription` generate a fresh `InstallPlan` that can unpack cleanly.
+
+1. Find the leftover `Role`/`ClusterRole` objects from the previous revision. Match by the name fragment that appeared in the failure message — typically the operator name prefix — or by labels the old CSV stamped on them:
+
+   ```bash
+   kubectl get clusterrole | grep <operator-name-prefix>
+   kubectl get role -n <operator-namespace> | grep <operator-name-prefix>
+   ```
+
+2. Delete **only** the objects that are no longer referenced by any live CSV. Objects owned by a `Succeeded` CSV should be left alone:
+
+   ```bash
+   kubectl delete clusterrole <stale-name>
+   kubectl delete role -n <operator-namespace> <stale-name>
+   ```
+
+3. Verify the target CSV exists in the catalog at the version the `Subscription` is asking for:
+
+   ```bash
+   kubectl get packagemanifest <operator-package> \
+     -n <marketplace-namespace> -o yaml | \
+     grep -E 'currentCSV|name:' -A1
+   ```
+
+4. If the current CSV and the failing `InstallPlan` need to be rebuilt from scratch (because partial state has accumulated through repeated failed attempts), delete the stuck lifecycle objects and let the `Subscription` regenerate a clean set:
+
+   ```bash
+   kubectl delete csv <pending-csv-name> -n <operator-namespace>
+   kubectl delete subscription <subscription-name> -n <operator-namespace>
+   kubectl delete installplan <failed-installplan-name> -n <operator-namespace>
+   ```
+
+5. Recreate the `Subscription` targeting the desired channel/version. OLM will generate a fresh `InstallPlan`; with the conflicting RBAC cleared, the unpack step succeeds and the CSV progresses to `Succeeded`.
+
+6. Confirm end-state: the new CSV is `Succeeded`, the associated operator `Deployment` is at the new image, and for TopoLVM specifically, the topology-aware volume provisioner Pods are all running on the new revision:
+
+   ```bash
+   kubectl get csv -n <operator-namespace>
+   kubectl get deploy -n <operator-namespace>
+   kubectl get pods -n <operator-namespace> -o wide
+   ```
+
+The storage system backed by this operator — `storage/storagesystem_topolvm` in ACP — keeps serving existing `PersistentVolumes` throughout this procedure. Only the operator-level control plane pauses while the `InstallPlan` is being rebuilt; data-path CSI pods keep running.
+
+### Fallback: self-assembled OLM deployment (not via ACP's extend surface)
+
+If the cluster uses a raw upstream OLM installation (for example a direct `olm.yaml` deployment outside the ACP `extend` surface), the same failure mode can appear for any OLM-managed operator whose bundle RBAC conflicts with leftover RBAC from a previous version. The cleanup sequence is identical: delete the stale `Role`/`ClusterRole`, delete the stuck `InstallPlan` and CSV, recreate the `Subscription`. The relevant OLM CRDs (`Subscription`, `InstallPlan`, `ClusterServiceVersion`) are the same.
+
+## Diagnostic Steps
+
+Inspect the failing `InstallPlan` to see which exact step is stuck and what resource it refers to:
+
+```bash
+kubectl get installplan -n <operator-namespace> \
+  <installplan-name> -o yaml | \
+  yq '.status.conditions, .status.plan'
+```
+
+The relevant pieces are:
+
+- A condition `type: Installed, status: "False", reason: InstallComponentFailed` with the `couldn't find unpacked step for ...` message.
+- A plan entry whose `resource.kind` is `Role` or `ClusterRole` and whose `status` is `Unknown` — that is the step the unpacker could not reconcile.
+
+Compare that RBAC name to the objects currently on the cluster:
+
+```bash
+kubectl get clusterrole,role -A | grep <name-from-installplan>
+```
+
+If an object exists but its `ownerReferences` point at the previous CSV (or no CSV at all), it is the stale object blocking the unpack step.
+
+Check the catalog operator's own logs for the rebuild of the unpacked cache; repeated errors about the same step name confirm the stall is not transient:
+
+```bash
+kubectl -n <olm-namespace> logs deploy/catalog-operator | \
+  grep -E 'unpacked|<installplan-name>'
+```
+
+After the cleanup and `Subscription` recreate, watch the new `InstallPlan` walk through its steps:
+
+```bash
+kubectl -n <operator-namespace> get installplan -w
+```
+
+The healthy sequence is `Phase: Planning` → `Phase: RequiresApproval` (if manual approval is enabled) → `Phase: Installing` → `Phase: Complete`. The CSV then advances `Pending` → `Installing` → `Succeeded` over roughly the same window.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
