### PR TITLE
[storage] Prometheus PVC Resize on Ceph RBD Does Not Expand the In-Pod Filesystem

### DIFF
--- a/docs/en/solutions/Prometheus_PVC_Resize_on_Ceph_RBD_Does_Not_Expand_the_In_Pod_Filesystem.md
+++ b/docs/en/solutions/Prometheus_PVC_Resize_on_Ceph_RBD_Does_Not_Expand_the_In_Pod_Filesystem.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Prometheus PVC Resize on Ceph RBD Does Not Expand the In-Pod Filesystem
 ## Issue
 
 A cluster operator bumps the request on the monitoring stack's Prometheus PVC — for example from 100 GiB to 250 GiB — and the object is accepted without error. `kubectl describe pvc` reports the new capacity and the `Bound` condition stays green. Inside the Prometheus pod, however, `df -h /prometheus` still shows the original size:

--- a/docs/en/solutions/Prometheus_PVC_Resize_on_Ceph_RBD_Does_Not_Expand_the_In_Pod_Filesystem.md
+++ b/docs/en/solutions/Prometheus_PVC_Resize_on_Ceph_RBD_Does_Not_Expand_the_In_Pod_Filesystem.md
@@ -1,0 +1,126 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A cluster operator bumps the request on the monitoring stack's Prometheus PVC — for example from 100 GiB to 250 GiB — and the object is accepted without error. `kubectl describe pvc` reports the new capacity and the `Bound` condition stays green. Inside the Prometheus pod, however, `df -h /prometheus` still shows the original size:
+
+```text
+Filesystem      Size  Used Avail Use% Mounted on
+/dev/rbd0       100G   99G    1G  99% /prometheus
+```
+
+The CSI node plugin logs look normal — they even report a successful `resizefs`:
+
+```text
+resizefs_linux.go:74  Device /dev/rbd0 resized successfully
+resizefs_linux.go:156 Volume /dev/rbd0: device size=107374182400 filesystem size=107374182400
+```
+
+Both numbers equal the **old** capacity (100 GiB = 107374182400 bytes), which is the clue. The node-side filesystem grow was attempted but had nothing to grow onto, because the underlying Ceph RBD image was never expanded. Monitoring then fires near-full-disk alerts even though the user already "did the resize".
+
+## Root Cause
+
+Volume expansion on a Ceph RBD-backed PVC is driven by two cooperating controllers:
+
+1. The **CSI external-resizer sidecar** (running alongside the RBD provisioner). It watches the PVC spec, calls `ControllerExpandVolume` against the CSI driver, and the driver in turn asks the Ceph MON/MGR to grow the RBD image.
+2. The **CSI node plugin** on the node where the pod is mounted. Once step 1 reports success, the node plugin issues `NodeExpandVolume` to grow the on-disk filesystem (`xfs_growfs` or `resize2fs`) against the now-larger block device.
+
+The failure pattern seen here is that the PVC object's `.status.capacity` is updated by the controller **before** the RBD image grow actually landed, or the `ControllerExpandVolume` call was dropped by the resizer and never retried. The node plugin then runs `NodeExpandVolume`, sees the block device at its old size, and dutifully "resizes" the filesystem to the size that it already is — hence the matching `device size == filesystem size` line at the old capacity, and no error. No subsequent expansion is scheduled because, from the API's point of view, the resize is done.
+
+This is a RWO, single-replica workload like Prometheus, which makes the mismatch visible in a single pod. The ACP storage stack uses the same upstream `ceph-csi` project (`storage/storagesystem_ceph`), so the expansion contract, the `external-resizer` sidecar, and the `NodeExpandVolume` semantics described here apply directly. RWX volumes on CephFS use a different data path and are not affected.
+
+## Resolution
+
+Re-drive the expansion so that `ControllerExpandVolume` runs again and actually reaches the Ceph cluster. The trick is that the resizer only reconciles when it observes a spec change, so simply "saving" the current value is a no-op — the request size must be **strictly larger** than what is already recorded.
+
+1. Restart the RBD provisioner deployment. This restarts the external-resizer sidecar too, clearing any stuck in-flight reconcile:
+
+   ```bash
+   kubectl -n <ceph-operator-namespace> rollout restart deployment <rbd-provisioner-deployment>
+   ```
+
+2. Bump the PVC request by any positive delta — 1 GiB is enough. PVC requests can only go up, so pick a value slightly above the current request:
+
+   ```bash
+   kubectl -n <monitoring-namespace> edit pvc prometheus-db-prometheus-0
+   ```
+
+   ```yaml
+   spec:
+     resources:
+       requests:
+         storage: 251Gi   # was 250Gi
+   ```
+
+3. Watch the `external-resizer` log on the RBD provisioner pod — it should now call `ControllerExpandVolume` with the new size, the RBD image should grow, and then the node plugin on the Prometheus host should run `NodeExpandVolume` with the new block device size.
+
+4. Verify from inside the pod that `/prometheus` has actually grown:
+
+   ```bash
+   kubectl -n <monitoring-namespace> exec -it prometheus-0 -- df -h /prometheus
+   ```
+
+   The `Size` column should reflect the new value.
+
+Prefer this over deleting and recreating the PVC: Prometheus TSDB blocks are not cheap to rebuild, and the `StatefulSet`'s controller will not automatically rebind to a replacement claim unless the operator managing the stack supports in-place PVC swap.
+
+### When the two-layer expand is not the root cause
+
+If the re-driven expansion still leaves the filesystem at the old size and the node plugin still logs `device size == filesystem size` at the old value, the RBD image itself is not growing. Check Ceph-side first (MON quorum, pool near-full ratio, MGR reachability) before blaming the CSI stack — the CSI driver surfaces cluster-side failures as controller-expand errors, but a MON outage or a pool at `full_ratio` will simply stall the call.
+
+### Prevention / knobs
+
+- Alauda Container Platform's Ceph storage system enables `allowVolumeExpansion: true` on the provided `StorageClass`es by default. If a custom `StorageClass` is in use, confirm this flag is set — otherwise the CSI driver will reject the expand up front, which is a different (and more obvious) failure.
+- For PVCs with high write amplification like Prometheus, expanding *before* the filesystem is ≥ 85 % full avoids the noisy alert storm while the two-layer resize completes.
+
+## Diagnostic Steps
+
+1. Confirm the API-level size is what you expect. An already-expanded PVC metadata record is the signal that the first layer succeeded:
+
+   ```bash
+   kubectl -n <monitoring-namespace> describe pvc prometheus-db-prometheus-0 | grep -E 'Capacity|Status|StorageClass'
+   ```
+
+2. Compare with what the pod actually sees. If these disagree, the node plugin's view of the block device has not been refreshed:
+
+   ```bash
+   kubectl -n <monitoring-namespace> exec -it prometheus-0 -- df -h /prometheus
+   ```
+
+3. Cross-check with kubelet's exported capacity metric. A stale value here tracks the pod view, not the PVC spec:
+
+   ```text
+   kubelet_volume_stats_capacity_bytes{namespace="<monitoring-namespace>", pod=~"prometheus.*"}
+   ```
+
+4. Find the node where the Prometheus pod runs:
+
+   ```bash
+   kubectl -n <monitoring-namespace> get pod prometheus-0 -o wide
+   ```
+
+5. Find the RBD CSI node plugin pod co-located on that node:
+
+   ```bash
+   kubectl -n <ceph-operator-namespace> get pods -o wide | grep csi-rbdplugin
+   ```
+
+6. Read its `csi-rbdplugin` container log and grep for `resize`. The tell-tale signature of this bug is a `resizefs_linux.go` line where `device size` and `filesystem size` are identical **and** both match the old (not requested) capacity:
+
+   ```bash
+   kubectl -n <ceph-operator-namespace> logs <csi-rbdplugin-pod> -c csi-rbdplugin | grep resize
+   ```
+
+7. On the Ceph side, confirm the actual image size. If this still shows the old size, the `ControllerExpandVolume` call never reached Ceph — collect the `external-resizer` sidecar log from the provisioner pod to see why:
+
+   ```bash
+   kubectl -n <ceph-operator-namespace> logs <rbd-provisioner-pod> -c csi-resizer
+   ```
+
+If the resizer log shows repeated errors calling the CSI driver, restart the provisioner before re-bumping the PVC — a stuck gRPC channel will not self-recover until the sidecar is restarted.

--- a/docs/en/solutions/Prometheus_PVC_Resize_on_Ceph_RBD_Does_Not_Expand_the_In_Pod_Filesystem.md
+++ b/docs/en/solutions/Prometheus_PVC_Resize_on_Ceph_RBD_Does_Not_Expand_the_In_Pod_Filesystem.md
@@ -1,0 +1,88 @@
+---
+title: Recovering from a PVC online expansion that stalls between spec and status on ACP
+component: storage
+scenario: troubleshooting
+tags: [pvc, storage, csi, topolvm, expansion, resize]
+date_created: 2026-05-30
+date_updated: 2026-05-30
+---
+
+# Recovering from a PVC online expansion that stalls between spec and status on ACP
+
+## Issue
+
+On Alauda Container Platform (kube v1.34.5, default `StorageClass` `topolvm-hdd` provisioned by `topolvm.cybozu.com`, the only Container Storage Interface (CSI) driver registered out of the box), a `PersistentVolumeClaim` (PVC) carries two separately-tracked size fields: `spec.resources.requests.storage` is the size the user is asking for, and `status.capacity.storage` is what the CSI stack has actually delivered down to the underlying volume [ev:c2_a]. After patching the request to a larger value the two fields can disagree for a window — `status.capacity` lags `spec.resources.requests.storage`, and during that window the filesystem mounted inside the pod also still reports the old size [ev:c2_b].
+
+The corollary on the metrics side: kubelet exposes a per-mount `kubelet_volume_stats_capacity_bytes` series labeled by `namespace` and `persistentvolumeclaim`, scraped via the standard `monitoring.coreos.com` `ServiceMonitor` / `PodMonitor` machinery, and the value reported there tracks the live mounted filesystem — not `spec.resources.requests.storage` — so a stalled expansion shows up as a metric value that has not moved even though the PVC object claims the larger size [ev:c4_a].
+
+## Root Cause
+
+In-place expansion of a PVC requires the backing `StorageClass` to carry `allowVolumeExpansion: true`. The ACP default class `topolvm-hdd` does — visible in `kubectl get sc` as the `ALLOWVOLUMEEXPANSION` column reading `true` — so the request is accepted by the API server [ev:c1_a]. From there the CSI flow is the standard upstream two-phase resize: the external resizer calls `ControllerExpandVolume` against the controller plugin to grow the underlying volume, and the node plugin's `NodeExpandVolume` grows the filesystem on the node where the volume is currently mounted [ev:c9_b]. The PVC's `status.conditions` block carries a `Resizing` condition while the volume is being grown by the controller, and a separate `FileSystemResizePending` condition with the message `Waiting for user to (re-)start a pod to finish file system resize of volume on node.` once the controller side has finished but the node-side filesystem grow still needs the mount to be reopened [ev:c2_b].
+
+A stall therefore has two distinct surfaces. Either the controller side never grew the underlying volume (the `Resizing` condition stays True and `status.capacity` never moves), or the controller side completed and the node side is waiting on a pod restart to actually resize the filesystem (`FileSystemResizePending` is True and the in-pod `df -h` still shows the old size while `status.capacity` may have already advanced) [ev:c9_b].
+
+## Resolution
+
+Request expansion by editing the PVC's `spec.resources.requests.storage` to a strictly larger quantity than the current value; never decrease the request [ev:c9_a]:
+
+```bash
+kubectl patch pvc -n <ns> <pvc-name> --type=merge \
+ -p '{"spec":{"resources":{"requests":{"storage":"3Gi"}}}}'
+```
+
+Re-running the patch with the same value as the request currently held is a no-op for the controller — only a strictly larger request re-arms `ControllerExpandVolume`. The same patch shape also drives the recovery path when an earlier expansion stalled: bumping the request a small increment higher (for example 250Gi to 251Gi) is enough to re-trigger the full resize sequence [ev:c9_a].
+
+After the patch, observe the two PVC fields and the condition block to confirm progress [ev:c2_a][ev:c2_b]:
+
+```bash
+kubectl get pvc -n <ns> <pvc-name> \
+ -o jsonpath='{"spec.req="}{.spec.resources.requests.storage}{" status.cap="}{.status.capacity.storage}{" cond="}{.status.conditions}'
+```
+
+If the conditions show `FileSystemResizePending=True` with the message about waiting for a pod restart, the controller side has finished and the only remaining step is to recycle the pod that has the PVC mounted; the next `NodePublishVolume` will trigger the filesystem grow on the node [ev:c9_b]:
+
+```bash
+kubectl rollout restart statefulset -n <ns> <statefulset-name>
+# or, for a bare Pod:
+kubectl delete pod -n <ns> <pod-name>
+```
+
+## Diagnostic Steps
+
+Confirm the StorageClass backing the PVC permits expansion before issuing a patch — a class without `allowVolumeExpansion: true` rejects the request at admission [ev:c1_a]:
+
+```bash
+kubectl get sc
+# Look for ALLOWVOLUMEEXPANSION=true on the class named in pvc.spec.storageClassName.
+```
+
+Read the live `spec` vs `status` divergence and the conditions on the PVC; a non-empty `Resizing` or `FileSystemResizePending` condition pinpoints which side of the two-phase resize is in flight [ev:c2_b]:
+
+```bash
+kubectl get pvc -n <ns> <pvc-name> -o yaml | yq '{
+  "request": .spec.resources.requests.storage,
+  "capacity": .status.capacity.storage,
+  "conditions": .status.conditions
+}'
+```
+
+Locate the CSI node plugin pod on the same node as the workload and inspect its log for a resize event matching the PVC's underlying volume id; on ACP that plugin is the per-node `topolvm-node-<nodeIP>` pod in `nativestor-system` and the relevant container is `csi-topolvm-plugin` [ev:c7]:
+
+```bash
+NODE=$(kubectl get pod -n <ns> <pod-name> -o jsonpath='{.spec.nodeName}')
+PLUGIN=$(kubectl get pods -n nativestor-system \
+  -o jsonpath='{range .items[?(@.spec.nodeName=="'$NODE'")]}{.metadata.name}{"\n"}{end}' \
+  | grep topolvm-node | head -1)
+kubectl logs -n nativestor-system "$PLUGIN" -c csi-topolvm-plugin \
+  | grep -E 'ResizeLV|expanded LV|resized'
+```
+
+A successful controller-side grow appears as a `lvservice request - ResizeLV ... requested=<bytes> current=<bytes>` log line followed by `Logical volume ... successfully resized.` and `expanded LV ... original status.currentSize=<old> status.currentSize=<new>`. If those lines are present but the in-pod filesystem is still small, the controller side is done and the stall is on the node-side `NodeExpandVolume` — restart the consuming pod and the filesystem will catch up to `status.capacity` on the next mount [ev:c9_b].
+
+For the metrics-side cross-check, query the kubelet series scraped by any ACP Prometheus instance that watches the cluster (the `ServiceMonitor` / `PodMonitor` API group `monitoring.coreos.com` is registered on every ACP cluster) [ev:c4_a]:
+
+```text
+kubelet_volume_stats_capacity_bytes{namespace="<ns>", persistentvolumeclaim="<pvc-name>"}
+```
+
+The value of that series reflects the mounted filesystem, so a stall on the node side keeps the series at the pre-expansion byte count even while `kubectl get pvc` shows the larger `status.capacity` — the metric is the most direct signal that the node-side filesystem grow has not yet completed [ev:c4_a].


### PR DESCRIPTION
新增一篇 ACP KB 文章，归入 `storage` 区域。

**⚠️ 自动化验证：无测试计划** — 本篇未登记验证计划，暂不自动合并，请人工确认内容后再合。

## `storage` 区域建议 reviewer

按 `kb/OWNERS.md`（来源：alauda-ai-base operator-list 的产品 owner）该区域候选自动挑选，@ 错了请无视。


没有 GitHub handle 的贡献者（本区域相关请人工 ping）：

- zyfan &lt;zyfan@alauda.io&gt;
- chengli &lt;chengli@alauda.io&gt;
- xdzhang &lt;xdzhang@alauda.io&gt;
- jhshi &lt;jhshi@alauda.io&gt;
- clyi &lt;clyi@alauda.io&gt;
