### PR TITLE
[observability] Alertmanager 0.27+ UTF-8 matchers parser warning for custom routing rules

### DIFF
--- a/docs/en/solutions/Alertmanager_027_UTF_8_Matcher_Parser_Warnings_for_Existing_Routing_Rules.md
+++ b/docs/en/solutions/Alertmanager_027_UTF_8_Matcher_Parser_Warnings_for_Existing_Routing_Rules.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Alertmanager 0.27+ UTF-8 Matcher Parser Warnings for Existing Routing Rules
 ## Issue
 
 After the platform's monitoring stack rolls Alertmanager to version `0.27` or later, the `alertmanager` container starts logging warnings for routing or inhibit rules that previously worked without complaint:

--- a/docs/en/solutions/Alertmanager_027_UTF_8_Matcher_Parser_Warnings_for_Existing_Routing_Rules.md
+++ b/docs/en/solutions/Alertmanager_027_UTF_8_Matcher_Parser_Warnings_for_Existing_Routing_Rules.md
@@ -1,0 +1,146 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+After the platform's monitoring stack rolls Alertmanager to version `0.27` or later, the `alertmanager` container starts logging warnings for routing or inhibit rules that previously worked without complaint:
+
+```text
+ts=2026-01-08T13:03:19.023Z caller=parse.go:176 level=warn
+msg="Alertmanager is moving to a new parser for labels and matchers, and this
+ input is incompatible. Alertmanager has instead parsed the input using the
+ classic matchers parser as a fallback. To make this input compatible with
+ the UTF-8 matchers parser please make sure all regular expressions and
+ values are double-quoted. If you are still seeing this message please
+ open an issue."
+input="alertname = Optimize- Route existiert nicht"
+origin=config
+err="21:22: unexpected-: expected a comma or close brace"
+suggestion="alertname=\"Optimize- Route existiert nicht\""
+```
+
+Alerts still fire and routes still match — for now — because Alertmanager falls back to the classic parser. The warning is the warning shot: once the classic parser is removed (two releases out per upstream), the same configuration will be a hard parse error and the Alertmanager pod will refuse to start.
+
+Nothing changed in the user's `AlertmanagerConfig` or `Alertmanager` CR, so the signal looks spontaneous and the root cause is not obvious from Alauda Container Platform release notes alone.
+
+## Root Cause
+
+Upstream Alertmanager `0.27` introduced a new matcher grammar that accepts UTF-8 in label values and is stricter about quoting. From the upstream notes:
+
+> *"Alertmanager versions 0.27 and later have a new parser for matchers that has a number of backwards incompatible changes. Alertmanager will make UTF-8 strict mode the default in the next two versions, so it's important to transition as soon as possible."*
+
+The new parser rejects three patterns that the classic parser tolerated:
+
+1. **Unquoted values with special characters.** Spaces, dashes mid-token (`Optimize- Route`), non-ASCII letters (`existiert`, umlauts) — the new parser requires double quotes around the full value.
+2. **Unquoted regex alternations** — values that look like `foo|bar` without quotes.
+3. **Leading / trailing whitespace inside the value** — classic parser trimmed silently, new parser rejects.
+
+In every case the `suggestion=` field of the warning log line shows the exact fixed form: wrap the right-hand side of the matcher in `"..."`.
+
+The platform-managed monitoring rules shipped by Alauda Container Platform already use the quoted form. Warnings surface only for **custom** `AlertmanagerConfig` objects or `Alertmanager` spec entries authored by the cluster operator or by tenant teams. The fix is therefore owned by whoever wrote the custom config — the monitoring stack itself does not need any change.
+
+Alauda Container Platform's monitoring surface (`observability/monitor`) uses the same upstream Prometheus Operator + Alertmanager project, so this behaviour is inherited directly from upstream and the fix is identical regardless of whether the object sits in-core or under the extended monitoring stack.
+
+## Resolution
+
+Walk all custom Alertmanager configuration objects and double-quote every matcher value. Start from the warning log — each `suggestion=` field is the corrected form to paste back in.
+
+### Fix `AlertmanagerConfig` matchers
+
+`AlertmanagerConfig` objects expose matchers as a structured list; the value is the `value` field. Update any entry where the value contains spaces, punctuation, non-ASCII characters, or looks like a regex:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: team-a
+  namespace: team-a
+spec:
+  route:
+    groupBy: ["alertname"]
+    receiver: team-a
+    matchers:
+      - name: alertname
+        value: "Optimize- Route existiert nicht"   # was: Optimize- Route existiert nicht
+        matchType: "="
+      - name: severity
+        value: "warning|critical"                   # was: warning|critical
+        matchType: "=~"
+```
+
+The `value` in YAML is already a string, but Alertmanager parses the rendered string at config-load time — so the **literal** double quotes must be part of the stored value when the config is expressed in Alertmanager's native grammar (e.g. the flat `matchers:` array on the inhibit-rule or mute-time side). When in doubt, use the structured `name / value / matchType` triple rather than the flat string form — the operator renders it into the canonical quoted shape for you.
+
+### Fix flat-string matchers in the `Alertmanager` CR
+
+If the root `Alertmanager` CR uses inhibit rules or mute-time intervals with the flat string form, the quotes must be written explicitly:
+
+```yaml
+inhibitRules:
+  - sourceMatchers:
+      - 'alertname="Watchdog"'
+    targetMatchers:
+      - 'severity="critical"'
+    equal: ["namespace"]
+```
+
+Single quotes around the YAML scalar, double quotes around the matcher value — this survives the two parsers and is forward-compatible with UTF-8 strict mode.
+
+### Fix custom `PrometheusRule` templates that render matchers
+
+A less common but trickier case is `PrometheusRule` entries whose `annotations` or routing hints embed a matcher-formatted string. Those strings are handed to Alertmanager verbatim and follow the same quoting rule.
+
+### Roll out and verify
+
+After the edits, the Prometheus Operator picks up the change on its next reconcile (usually within 30 seconds). No pod restart is required for `AlertmanagerConfig` updates. Confirm the warnings stop by tailing the `alertmanager` container log:
+
+```bash
+kubectl -n <monitoring-namespace> logs -l app.kubernetes.io/name=alertmanager -c alertmanager --tail=200 | grep -i "UTF-8 matchers parser"
+```
+
+An empty result after the reconcile means every matcher now parses cleanly under the new grammar. It is worth running this check once per custom namespace after the upgrade, and once more ahead of the next Alertmanager minor bump.
+
+### Why there was no prior warning
+
+The classic parser accepted the loose syntax silently, so neither `kubectl apply` nor the operator's validation webhook rejected the object at write time. Only after `0.27` ships does Alertmanager emit the deprecation warning at parse time. Treat the absence of warnings today as a regression signal, not as proof of correctness.
+
+## Diagnostic Steps
+
+1. Enumerate Alertmanager pods and pull recent parser warnings:
+
+   ```bash
+   kubectl -n <monitoring-namespace> logs -l app.kubernetes.io/name=alertmanager \
+     -c alertmanager --tail=500 | grep -E "UTF-8 matchers parser|classic matchers parser"
+   ```
+
+2. Extract the `input=` and `suggestion=` fields — these tell you exactly which matcher string is at fault and what the fixed form is:
+
+   ```bash
+   kubectl -n <monitoring-namespace> logs -l app.kubernetes.io/name=alertmanager \
+     -c alertmanager --tail=500 \
+     | grep -oE 'input="[^"]+" origin=[a-z]+ .*suggestion="[^"]+"'
+   ```
+
+3. Find the source configuration for each flagged matcher. The `origin=` field on the warning tells you whether it came from `config` (the Alertmanager CR) or from one of the `AlertmanagerConfig` objects:
+
+   ```bash
+   kubectl get alertmanagerconfig -A
+   kubectl get alertmanager -A -o yaml | grep -A1 -E 'matchers|sourceMatchers|targetMatchers'
+   ```
+
+4. After correcting and re-applying, tail the log again and verify the warning count drops to zero. Track the fix per namespace to avoid missing a custom config under a rarely-touched tenant:
+
+   ```bash
+   for ns in $(kubectl get ns -o name | sed 's|namespace/||'); do
+     count=$(kubectl -n <monitoring-namespace> logs -l app.kubernetes.io/name=alertmanager \
+               -c alertmanager --tail=500 2>/dev/null \
+             | grep "UTF-8 matchers parser" | grep -c "$ns" || true)
+     [ "$count" -gt 0 ] && echo "$ns: $count warnings"
+   done
+   ```
+
+5. For regression prevention, add a pre-merge check on `AlertmanagerConfig` authors: any matcher `value` that contains whitespace, `|`, `-`, or non-ASCII must be wrapped. The `promtool check config` binary (shipped with Prometheus) accepts the same grammar and can be run in CI against rendered config.

--- a/docs/en/solutions/Alertmanager_027_UTF_8_matchers_parser_warning_for_custom_routing_rules.md
+++ b/docs/en/solutions/Alertmanager_027_UTF_8_matchers_parser_warning_for_custom_routing_rules.md
@@ -1,0 +1,83 @@
+---
+kind:
+   - KnownIssue
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Alertmanager 0.27+ UTF-8 matchers parser warning for custom routing rules
+
+## Issue
+
+On Alauda Container Platform the Prometheus monitoring stack ships an Alertmanager binary built from upstream `v0.32.1`, packaged as `registry.alauda.cn:60080/3rdparty/prometheus/alertmanager:v0.32.1-v4.3.4` and run by the `cpaas-system/kube-prometheus` Alertmanager CR. Because this version is well above `0.27`, the binary uses the new UTF-8-capable matchers parser introduced upstream in `0.27`, which has a number of backwards-incompatible changes relative to the classic matchers parser used by earlier versions.
+
+The visible symptom is a warning emitted on Alertmanager configuration load, even when no configuration change has been made on the cluster — the behavior is keyed to the parser version, not to a configuration edit. On the `v0.32.1` build the line is emitted by the alertmanager container in its standard `slog` format with the `source=parse.go:176` field:
+
+```text
+time=2026-05-29T12:59:11.225Z level=WARN source=parse.go:176 msg="Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the classic matchers parser as a fallback. To make this input compatible with the UTF-8 matchers parser please make sure all regular expressions and values are double-quoted and backslashes are escaped. If you are still seeing this message please open an issue." input="alertname = Optimize- Route existiert nicht" origin=config err="22:27: unexpected Route: expected a comma or close brace" suggestion="alertname=\"Optimize- Route existiert nicht\""
+```
+
+Each warning line carries the offending matcher in the `input=` field, a parse-error position in the `err=` field (column and a short reason such as `unexpected Route: expected a comma or close brace`), and a corrected matcher in the `suggestion=` field with the value already double-quoted.
+
+## Root Cause
+
+When the UTF-8 matchers parser receives a matcher string it cannot parse, it does not fail the configuration. Instead it re-parses the string with the classic matchers parser and accepts the result, then logs the `parse.go:176` warning so the operator can fix the input before the next behavior change. The fallback path is announced by an adjacent debug line on the same load: `source=parse.go:154 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input=... origin=config`. The warning itself is the operator-visible signal that the fallback ran.
+
+The warning is scoped to matcher strings that pass through the alertmanager matcher syntax parser. Concretely that is every entry in a `matchers:` list under a route or inhibit rule, plus matchers handed to `amtool`. The deprecated `match:` key/value map form goes through YAML and never reaches the matchers parser, so map-form matchers do not trigger the warning regardless of the value content.
+
+The shipped ACP route tree in `Secret cpaas-system/alertmanager-kube-prometheus` is entirely the `match:` map form (for example `match: {severity: Critical}` and `match: {alert_repeat_interval: 5m}`), and every value is a single alphanumeric token with no spaces or special characters. On the platform cluster the live alertmanager container log therefore contains zero `parse.go` warnings even though the binary contains the strict UTF-8 parser. The warning appears only when an operator (or an integration controller) adds custom matchers in the `matchers:` list form with values that contain whitespace, hyphens that the parser would interpret as token boundaries, or non-ASCII characters — for example `alertname = Optimize- Route existiert nicht`.
+
+## Resolution
+
+Custom routing rules added on top of the shipped configuration must be updated manually to use the double-quoted form for any non-trivial value. The shipped ACP rules already comply and need no changes.
+
+For each non-compliant `matchers:` list entry, wrap the value in double quotes (and escape any embedded backslashes). Using the example from the warning text, the original entry:
+
+```yaml
+route:
+  routes:
+  - matchers:
+    - alertname = Optimize- Route existiert nicht
+    receiver: default
+```
+
+is rewritten to the parser-compliant form:
+
+```yaml
+route:
+  routes:
+  - matchers:
+    - alertname="Optimize- Route existiert nicht"
+    receiver: default
+```
+
+After this change the same `v0.32.1` Alertmanager loads the configuration with no `parse.go` warning and no fallback at all — the configuration parses cleanly on the first pass through the UTF-8 parser.
+
+Two extra notes on scope:
+
+- A matcher whose value is a single alphanumeric token (for example `severity=Critical` or `alert_repeat_interval=5m`) parses cleanly under the UTF-8 parser without quoting; quoting is only required when the value contains whitespace, special characters, or non-ASCII text.
+- A matcher written in the deprecated `match:` map form does not trigger the warning, because YAML already carries the value as a string. Pre-existing map-form entries continue to work as-is and do not need to be migrated to clear the warning.
+
+Applying the double-quoted fix now produces no behavior change for compliant inputs and clears the warning for the non-compliant ones; the same `v0.32.1` binary then loads the route tree without any `parse.go` line or warning at all.
+
+## Diagnostic Steps
+
+Read the live alertmanager container log and filter for the `parse.go` warning to enumerate which matchers are tripping the fallback:
+
+```bash
+kubectl -n cpaas-system logs alertmanager-kube-prometheus-0 -c alertmanager --tail=2000 \
+  | grep 'source=parse.go'
+```
+
+If the grep returns no lines, every matcher currently loaded by Alertmanager is UTF-8-parser-compliant and no action is needed. If lines are returned, each line's `input=` field identifies the exact offending matcher and the `suggestion=` field gives the corrected double-quoted form to copy back into the configuration.
+
+To validate a planned configuration before rolling it out, run `amtool` from inside the Alertmanager container — it ships in the same image at the same version (`amtool, version 0.32.1`) and reproduces the parser warning during `check-config`, so a misshapen matcher can be caught without rotating the pod:
+
+```bash
+kubectl -n cpaas-system exec alertmanager-kube-prometheus-0 -c alertmanager -- \
+  /bin/amtool check-config /etc/alertmanager/config_out/alertmanager.env.yaml
+```
+
+A `SUCCESS` line with no preceding `parse.go:176 WARN` indicates the configuration is fully compliant with the UTF-8 matchers parser; a `SUCCESS` line preceded by one or more `parse.go:176 WARN` lines means the configuration is currently accepted only because of the classic-parser fallback and must be updated before the next Alertmanager upgrade.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
