### PR TITLE
[virtualization] Diagnosing ImagePullBackOff on CDI image-import pods on ACP Virtualization

### DIFF
--- a/docs/en/solutions/Common_Image_Poller_Pods_Stuck_in_ImagePullBackOff_on_a_Fresh_Virtualization_Install.md
+++ b/docs/en/solutions/Common_Image_Poller_Pods_Stuck_in_ImagePullBackOff_on_a_Fresh_Virtualization_Install.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Common-Image Poller Pods Stuck in ImagePullBackOff on a Fresh Virtualization Install
 ## Issue
 
 On a freshly installed cluster running ACP Virtualization, a set of "poller" pods in the boot-source images namespace stay in `ImagePullBackOff` indefinitely instead of cleaning themselves up after the pull fails:

--- a/docs/en/solutions/Common_Image_Poller_Pods_Stuck_in_ImagePullBackOff_on_a_Fresh_Virtualization_Install.md
+++ b/docs/en/solutions/Common_Image_Poller_Pods_Stuck_in_ImagePullBackOff_on_a_Fresh_Virtualization_Install.md
@@ -1,0 +1,88 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+On a freshly installed cluster running ACP Virtualization, a set of "poller" pods in the boot-source images namespace stay in `ImagePullBackOff` indefinitely instead of cleaning themselves up after the pull fails:
+
+```text
+NAMESPACE              NAME                                          READY   STATUS             AGE
+<os-images-ns>         poller-centos-stream10-image-cron-xxxxx       0/1     ImagePullBackOff   8m
+<os-images-ns>         poller-centos-stream9-image-cron-xxxxx        0/1     ImagePullBackOff   8m
+<os-images-ns>         poller-fedora-image-cron-xxxxx                0/1     ImagePullBackOff   8m
+```
+
+(`<os-images-ns>` is the virtualization images namespace, named after the operator that manages boot sources.)
+
+The pods are owned by `CronJob` resources that drive the **common boot-source import** feature: they poll public image registries on a schedule, pull canonical OS images (Fedora, CentOS Stream, and so on), and surface them in the virtualization console as one-click sources for new VMs. When the cluster has no outbound path to those registries — typical on a disconnected install, or behind an egress proxy that has not yet been configured for the virtualization namespace — the pull fails on every retry and the pods accumulate in `ImagePullBackOff`.
+
+## Root Cause
+
+A new install of the virtualization stack enables common boot-source import by default, on the assumption that the cluster has internet egress and that operators want a turnkey VM-creation experience. The flag that drives this is `spec.enableCommonBootImageImport` on the `HyperConverged` custom resource owned by the HyperConverged Cluster Operator. While the flag is `true`, the operator reconciles a set of `CronJob`s — one per maintained OS — that pull the canonical images and stage them as `DataImportCron`/`DataSource` objects.
+
+In a disconnected or restricted-egress cluster, none of those pulls succeed, but the `CronJob`-spawned pods keep being recreated on the next schedule tick, so the failed pods never drain.
+
+## Resolution
+
+### ACP-preferred path: turn off the boot-source poller in the HyperConverged CR
+
+The cleanest fix on a cluster that does not need (or cannot reach) the public boot-source images is to disable the feature outright. Patch the `HyperConverged` CR to set `enableCommonBootImageImport` to `false`:
+
+```bash
+kubectl -n <virt-namespace> patch hyperconverged kubevirt-hyperconverged \
+  --type=json \
+  -p '[{"op":"replace","path":"/spec/enableCommonBootImageImport","value":false}]'
+```
+
+Within the next reconcile pass, the HCO removes the poller `CronJob`s and the failed pods. Verify:
+
+```bash
+kubectl -n <os-images-ns> get pods
+kubectl -n <os-images-ns> get cronjobs
+```
+
+Existing `DataSource`/`DataVolume` objects already populated from earlier pulls (or imported manually) are not touched — only the automatic refresh stops.
+
+### Alternative: keep the feature on, but point it at a reachable mirror
+
+If common boot images **are** wanted but the public registry is unreachable, a better option than disabling the feature is to mirror the upstream image repositories into a registry the cluster can reach (an in-cluster registry, an air-gapped artifact store, or a corporate mirror) and point the boot-source registry list at the mirror. This is configured per OS through the `dataImportCronTemplates` block of the same `HyperConverged` CR — overlay an entry that overrides the upstream URL with the mirrored URL. Once the next cron tick runs against the mirror successfully, the pollers complete and the `DataSources` go ready.
+
+### OSS fallback: bare KubeVirt + HCO
+
+On a cluster that runs upstream KubeVirt with the community HyperConverged Cluster Operator (no ACP wrapper), the field name and behavior are identical — the `HyperConverged` CRD is the same upstream object, and the same `enableCommonBootImageImport` toggle exists. The patch command above works unchanged.
+
+If the cluster does not deploy HCO at all (a bare `kubevirt-operator` install), there are no cluster-managed boot-source `CronJob`s in the first place, and any image-pull errors come from explicit `DataVolume`/`DataImportCron` objects the operator created — those need to be diagnosed individually rather than disabled wholesale.
+
+## Diagnostic Steps
+
+- Confirm the failing pods belong to the boot-source poller, not to a user-created `DataVolume`. Poller pods carry the `cdi.kubevirt.io/dataImportCron` ownership chain and are spawned by `CronJob`s with names of the form `poller-<os>-image-cron`:
+
+  ```bash
+  kubectl -n <os-images-ns> get cronjobs
+  kubectl -n <os-images-ns> get pods \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.ownerReferences[0].kind}{"\n"}{end}'
+  ```
+
+- Read the current value of the toggle to confirm the feature is in fact on (the default on a new install is `true` even if it is not present in the CR — absence means default):
+
+  ```bash
+  kubectl -n <virt-namespace> get hyperconverged kubevirt-hyperconverged \
+    -o jsonpath='{.spec.enableCommonBootImageImport}{"\n"}'
+  ```
+
+- Inspect one failing pod to confirm the failure is `ImagePullBackOff` against an external registry, not `ErrImagePull` because of an in-cluster pull-secret problem:
+
+  ```bash
+  kubectl -n <os-images-ns> describe pod <poller-pod>
+  ```
+
+  The pull URL in the events line shows the upstream registry the cron is trying to reach.
+
+- After applying the disable patch, confirm the operator has reconciled — the `CronJob`s should disappear and `kubectl -n <os-images-ns> get pods` should return empty (or contain only pods unrelated to boot-source polling).
+
+- If the goal is to keep the feature but use a mirror, generate a small VM from a manually imported `DataSource` to confirm end-to-end VM creation still works without the auto-import path.

--- a/docs/en/solutions/Diagnosing_ImagePullBackOff_on_CDI_image_import_pods_on_ACP_Virtualization.md
+++ b/docs/en/solutions/Diagnosing_ImagePullBackOff_on_CDI_image_import_pods_on_ACP_Virtualization.md
@@ -1,0 +1,61 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Diagnosing ImagePullBackOff on CDI image-import pods on ACP Virtualization
+
+## Issue
+
+On Alauda Container Platform Virtualization, an image-import pod can become stuck in the `ImagePullBackOff` state and remain there in `kubectl get pods` long after it was created — observed on a node debug pod that stayed `ImagePullBackOff` for roughly 38 hours rather than being cleaned up. When a kubelet cannot successfully pull a pod's container or disk image, the pod does not proceed to `Running`; it stays in `ImagePullBackOff` while the kubelet retries the pull with exponential backoff, and the pod's phase remains `Pending` with the container's `waiting.reason` set to `ImagePullBackOff`. A pod whose image pull keeps failing is not garbage-collected on failure — it persists in the `ImagePullBackOff` state in pod listings rather than disappearing, so the stuck pod stays visible until the underlying pull problem is resolved.
+
+The affected pods in this scenario are CDI image-import pods belonging to a `DataImportCron`, which periodically attempt to download OS base disk images (such as community Linux base images) from a source image registry. Two facts hold on the platform: the `dataimportcrons.cdi.kubevirt.io` CRD is present, and a `kubevirt-hyperconverged` HyperConverged instance exists in the `kubevirt` namespace.
+
+## Root Cause
+
+`ImagePullBackOff` arises when the image cannot be obtained — the source image registry is unreachable or unconfigured, or the pull is unauthorized or denied. An import pod whose `DataImportCron` source points at a registry that the node cannot reach therefore remains stuck in that state; in the observed case the pull failed with a `dial tcp ... i/o timeout` against the registry, the kubelet recorded a `BackOff` event with `Back-off pulling image`, and the pod never advanced past the pull. Because the kubelet keeps retrying the same unreachable target with backoff, the pod neither succeeds nor terminates.
+
+## Resolution
+
+First confirm the pod really is blocked on the image pull and identify the image it is trying to fetch. Import pods run in the namespace of the configured `DataImportCron`'s target DataSource/DataVolume — not necessarily `kubevirt` — so locate the failing pod across namespaces (or in the specific `DataImportCron` namespace) and inspect it; the `STATUS` column shows `ImagePullBackOff` and the container's `waiting.reason` matches, and the events on the pod carry the kubelet `BackOff` message naming the image being pulled. Import pods appear only where `DataImportCron` resources are actually configured, and since no common-boot-image set is delivered by default, a default install may list none.
+
+```bash
+kubectl get pods -A
+kubectl describe pod -n <dataimportcron-namespace> <import-pod-name>
+```
+
+Resolving the condition means making the source image registry reachable and the pull authorized from the cluster nodes — for example by configuring network reachability or a registry mirror, and supplying valid pull credentials — so that the kubelet's next backoff retry can complete the pull and the import pod advances out of `ImagePullBackOff`. The stuck pod clears once the pull succeeds; it persists only while the pull keeps failing.
+
+The set of OS base disk images that `DataImportCron` resources import is governed at the platform level. On this platform the `kubevirt-hyperconverged` HyperConverged instance in the `kubevirt` namespace (HyperConverged operator version 1.17.0, `hco.kubevirt.io/v1beta1`) carries a `spec.enableCommonBootImageImport` field that defaults to `true`, and its `dataImportCronTemplates` are shipped empty in both spec and status — no common-boot-image set is delivered by default — so the import pods present on a given cluster reflect the `DataImportCron` resources actually configured there.
+
+Read the current value of the toggle from the HyperConverged instance:
+
+```bash
+kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt \
+  -o jsonpath='{.spec.enableCommonBootImageImport}'
+```
+
+Set the field to control whether the common boot-image import is enabled on the instance:
+
+```bash
+kubectl patch hyperconverged kubevirt-hyperconverged -n kubevirt --type=json \
+  -p '[{"op":"replace","path":"/spec/enableCommonBootImageImport","value":false}]'
+```
+
+## Diagnostic Steps
+
+Enumerate the `DataImportCron` resources to map an `ImagePullBackOff` import pod back to the cron that spawned it and the OS base disk image it targets; the CRD `dataimportcrons.cdi.kubevirt.io` is served on the platform.
+
+```bash
+kubectl get dataimportcrons.cdi.kubevirt.io -A
+```
+
+For a stuck pod, the kubelet's recorded events are the authoritative signal: a `Failed to pull` entry with a `dial tcp ... i/o timeout` points at an unreachable registry, while an unauthorized or denied pull points instead at missing or invalid credentials; either way the kubelet falls back to `ImagePullBackOff` and keeps retrying with backoff rather than failing the pod outright.
+
+```bash
+kubectl describe pod -n <dataimportcron-namespace> <import-pod-name>
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章。
