### PR TITLE
[networking] Operator manager pod stuck in CrashLoopBackOff when a NetworkPolicy denies egress to the apiserver on ACP

### DIFF
--- a/docs/en/solutions/Operator_Manager_Pod_CrashLoopBackOff_Because_the_Namespace_NetworkPolicy_Blocks_API_Server_Egress.md
+++ b/docs/en/solutions/Operator_Manager_Pod_CrashLoopBackOff_Because_the_Namespace_NetworkPolicy_Blocks_API_Server_Egress.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Operator Manager Pod CrashLoopBackOff Because the Namespace NetworkPolicy Blocks API-Server Egress
 ## Issue
 
 After a default-deny `NetworkPolicy` is applied to a workload namespace, the controller-manager pod for an Operator deployed into that namespace enters `CrashLoopBackOff`. Container logs from the manager pod show a clean startup attempt that times out before the controller can list its watched resources:

--- a/docs/en/solutions/Operator_Manager_Pod_CrashLoopBackOff_Because_the_Namespace_NetworkPolicy_Blocks_API_Server_Egress.md
+++ b/docs/en/solutions/Operator_Manager_Pod_CrashLoopBackOff_Because_the_Namespace_NetworkPolicy_Blocks_API_Server_Egress.md
@@ -1,0 +1,148 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+After a default-deny `NetworkPolicy` is applied to a workload namespace, the controller-manager pod for an Operator deployed into that namespace enters `CrashLoopBackOff`. Container logs from the manager pod show a clean startup attempt that times out before the controller can list its watched resources:
+
+```text
+{"level":"error","ts":"...","logger":"cmd",
+ "msg":"Failed to create a new manager.",
+ "Namespace":"<ns>",
+ "error":"Get \"https://172.30.0.1:443/api?timeout=32s\": dial tcp 172.30.0.1:443: i/o timeout"}
+```
+
+The error is always against the cluster's in-cluster API server VIP (the `kubernetes` Service ClusterIP, typically `10.96.0.1` or `172.30.0.1` depending on the install). Other pods in the same namespace that do not need to talk to the API server (a static frontend, a database, a worker that only listens) appear healthy — only the controller-manager pod, which uses the Kubernetes Go client, fails.
+
+## Root Cause
+
+A `NetworkPolicy` resource scopes egress (and ingress) traffic for any pod whose labels match the policy selector. By default, when a namespace has *any* policy that selects a pod, that pod's allowed ingress and egress are restricted to whatever those policies explicitly permit — everything else is denied.
+
+A controller-manager built with the upstream Operator SDK / controller-runtime stack does the following at start-up:
+
+1. Open a TCP connection to the `kubernetes` Service ClusterIP on port 443.
+2. Establish TLS using the in-cluster CA bundle.
+3. List the cluster's APIs and the resources the manager intends to watch.
+4. Start the leader election lease, then begin reconciling.
+
+If step 1 hits an `i/o timeout`, the manager treats the cluster as unreachable and exits, the kubelet restarts the pod, and the loop repeats. The error message is generic — it does not say "blocked by NetworkPolicy" — which is why the failure is often misdiagnosed as an etcd or API-server outage rather than a namespace policy.
+
+The block is almost always one of:
+
+- The namespace has a default-deny egress policy and **does not explicitly allow** egress to the `kubernetes` Service / its endpoints.
+- The policy that scopes the operator pod allows egress to specific pods (e.g. application backends) but the manager's required egress to the API server was forgotten.
+- The cluster CNI (Kube-OVN, Cilium, OVN-Kubernetes) enforces policies in a slightly different way than expected and the egress to the API server VIP requires either a `to:` block keyed on the cluster's API-server endpoints namespace **or** an explicit egress entry to port 443 with no `to:` restriction.
+
+## Resolution
+
+Allow egress from the operator manager pod to the cluster API server, scoped as tightly as the cluster's policy posture allows. Two patterns are common:
+
+1. **Allow egress to the API-server endpoints by namespace + port** — the most surgical option, only opens 443 toward the actual control-plane endpoints:
+
+   ```yaml
+   apiVersion: networking.k8s.io/v1
+   kind: NetworkPolicy
+   metadata:
+     name: allow-operator-to-apiserver
+     namespace: <operator-ns>
+   spec:
+     podSelector:
+       matchLabels:
+         control-plane: controller-manager
+     policyTypes:
+       - Egress
+     egress:
+       - to:
+           - namespaceSelector:
+               matchLabels:
+                 kubernetes.io/metadata.name: default
+             podSelector:
+               matchLabels:
+                 component: apiserver
+                 provider: kubernetes
+         ports:
+           - protocol: TCP
+             port: 6443
+       - to:
+           - ipBlock:
+               cidr: <api-server-svc-clusterip>/32
+         ports:
+           - protocol: TCP
+             port: 443
+   ```
+
+   Two `to:` blocks are present because some CNIs evaluate policies against the resolved endpoint pods (the kube-apiserver pods in the `default` namespace, or wherever the cluster places them) while others see the traffic as targeting the Service ClusterIP. Including both forms covers either evaluation path. Replace `<api-server-svc-clusterip>` with the value reported by `kubectl get svc kubernetes -n default -o jsonpath='{.spec.clusterIP}'`.
+
+2. **Allow all egress on port 443 from the operator pod** — looser but trivially correct, useful while ramping up policy coverage:
+
+   ```yaml
+   apiVersion: networking.k8s.io/v1
+   kind: NetworkPolicy
+   metadata:
+     name: allow-operator-egress-https
+     namespace: <operator-ns>
+   spec:
+     podSelector:
+       matchLabels:
+         control-plane: controller-manager
+     policyTypes:
+       - Egress
+     egress:
+       - ports:
+           - protocol: TCP
+             port: 443
+       - ports:
+           - protocol: UDP
+             port: 53
+       - ports:
+           - protocol: TCP
+             port: 53
+   ```
+
+   The DNS allowance (`UDP/TCP 53`) is also required if the manager resolves the API server through CoreDNS rather than via the Service ClusterIP directly. Most controller-runtime managers use the in-cluster `KUBERNETES_SERVICE_HOST` env, which is the ClusterIP — but health probes, webhooks, and additional services typically need DNS too.
+
+After applying either policy, restart the manager pod (or wait for the next CrashLoopBackOff retry). The pod should reach `Running` state within one or two reconcile cycles.
+
+## Diagnostic Steps
+
+Confirm the failing pod is the controller-manager and not a different container in the same Deployment:
+
+```bash
+kubectl logs -n <ns> <operator-controller-manager-pod> \
+  -c manager --tail=100 \
+  | grep -E 'Failed to create|i/o timeout|172\.30|10\.96'
+```
+
+The signature is `dial tcp <api-server-svc-ip>:443: i/o timeout` from the controller-runtime / Operator SDK code path.
+
+Verify that an unblocked pod in the same namespace can reach the API server, while the operator pod cannot:
+
+```bash
+kubectl run -n <ns> probe --image=curlimages/curl --restart=Never --rm -it -- \
+  curl -k -m 5 https://kubernetes.default.svc/healthz
+```
+
+If the temporary `probe` pod can reach `200 ok` but the operator manager keeps timing out, the difference is exactly the `NetworkPolicy` selector: the policy applies to the operator pod's labels but not to the `probe` pod (which has no matching labels).
+
+List the policies that select the operator pod and inspect their egress rules:
+
+```bash
+kubectl get networkpolicy -n <ns> -o json \
+  | jq '.items[] | select(.spec.podSelector.matchLabels."control-plane"=="controller-manager")'
+```
+
+Any policy that selects the operator pod must either allow egress to the API server explicitly or be paired with a second policy that does. If no policy in the namespace selects the operator pod and connectivity still fails, the issue is not a namespace `NetworkPolicy` — investigate cluster-wide egress firewall or AdminNetworkPolicy CRs (Kube-OVN supports both).
+
+After applying the fix, confirm the manager makes it past start-up and into the leader election lease:
+
+```bash
+kubectl get lease -n <ns> | grep <operator-name>
+kubectl get pod -n <ns> -l control-plane=controller-manager -o wide
+```
+
+A healthy operator owns its leader-election Lease and the pod stays Ready for several reconcile cycles in a row.

--- a/docs/en/solutions/Operator_manager_pod_stuck_in_CrashLoopBackOff_when_a_NetworkPolicy_denies_egress_to_the_apiserver_on_ACP.md
+++ b/docs/en/solutions/Operator_manager_pod_stuck_in_CrashLoopBackOff_when_a_NetworkPolicy_denies_egress_to_the_apiserver_on_ACP.md
@@ -1,0 +1,109 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Operator manager pod stuck in CrashLoopBackOff when a NetworkPolicy denies egress to the apiserver on ACP
+
+## Issue
+
+On Alauda Container Platform (Kubernetes `v1.34.5`, CNI `kube-ovn v1.15.10` with NetworkPolicy enforcement enabled via `--enable-np=true --np-enforcement=standard --enable-anp=true`), an operator's controller-manager pod enters `CrashLoopBackOff` shortly after a `NetworkPolicy` is applied in its namespace. The container logs from the previous restart show the manager failing to bootstrap with an API-server connection error of the form `Failed to create a new manager.` and `dial tcp <apiserver-ip>:443: i/o timeout`.
+
+A reproduction on the cluster shows the chain end-to-end: a manager-shaped pod (label `control-plane=controller-manager`) starts cleanly and dials the in-cluster apiserver at `https://10.4.0.1:443/api?timeout=32s` while no policy is in place; once a `default-deny-egress` `NetworkPolicy` selecting the pod is applied, the next startup blocks on the same dial and exits with the timeout error, and the kubelet records `state.waiting.reason=CrashLoopBackOff` with `restartCount` climbing and `Warning BackOff` events of `Back-off restarting failed container`.
+
+## Root Cause
+
+`NetworkPolicy` is a core `networking.k8s.io/v1` namespaced resource on ACP (`netpol`), enforced by kube-ovn with upstream semantics. The `policyTypes` field documents that to deny egress, a policy must list `Egress` in `policyTypes` with no `egress` section; the `egress` field doc states that when the egress list is empty the `NetworkPolicy` limits all outgoing traffic from the selected pods. A `NetworkPolicy` of shape `policyTypes:[Egress]` with no `egress` rules, selecting the controller-manager pod, therefore isolates the pod's egress entirely, including its connection to the in-cluster apiserver.
+
+The operator's manager container reaches the apiserver during bootstrap through the in-cluster `kubernetes.default` `Service`. On ACP the service-cluster-ip-range is `10.4.0.0/16`, so the `kubernetes` `Service` in the `default` namespace has `ClusterIP` `10.4.0.1:443/TCP` — distinct from defaults seen on other Kubernetes distributions. When egress to that endpoint is blocked, the bootstrap connection times out, the manager process exits non-zero, and `restartPolicy: Always` makes the kubelet restart the container in a back-off loop, surfacing as `CrashLoopBackOff`.
+
+A subtle point matters when authoring the fix on kube-ovn: traffic to a `Service` `ClusterIP` is DNAT'd to a backend endpoint IP before egress `NetworkPolicy` is enforced, so an `egress` rule that only permits the `kubernetes` `Service` `ClusterIP` (here `10.4.0.1/32:443`) does not unblock the manager. The rule must permit the apiserver's real backend endpoint(s) — the addresses listed in the `EndpointSlice` for the `kubernetes` `Service`, on their secure port (`6443` in the reproduction).
+
+## Resolution
+
+Add a `NetworkPolicy` egress rule in the operator's namespace that permits the controller-manager pod to reach the apiserver backend endpoint(s) on their secure port, then let the kubelet restart the pod through the back-off so the next bootstrap succeeds.
+
+First, discover the apiserver backend endpoints (these are the addresses the rule must permit, not the `kubernetes` `Service` `ClusterIP`):
+
+```bash
+kubectl get endpointslices -n default -l kubernetes.io/service-name=kubernetes
+```
+
+```text
+NAME         ADDRESSTYPE   PORTS   ENDPOINTS         AGE
+kubernetes   IPv4          6443    192.168.136.179   4h1m
+```
+
+Author an egress `NetworkPolicy` that selects the controller-manager pod and permits TCP to each apiserver endpoint IP on the listed port. The `egress.to` peer is a `NetworkPolicyPeer` (`ipBlock | namespaceSelector | podSelector`) and `egress.ports` is a `NetworkPolicyPort` (`port` + `protocol`, default `TCP`); for an apiserver target an `ipBlock` per endpoint IP is the most portable shape:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-apiserver-egress
+  namespace: <operator-namespace>
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 192.168.136.179/32
+      ports:
+        - protocol: TCP
+          port: 6443
+```
+
+Apply the policy alongside (or replacing) the existing default-deny-egress policy; multiple `NetworkPolicy` objects selecting the same pod are OR'd, so adding the allow rule is sufficient as long as no other policy narrows the apiserver path further:
+
+```bash
+kubectl apply -n <operator-namespace> -f allow-apiserver-egress.yaml
+```
+
+After the kubelet next retries the manager container (the back-off interval is bounded; restarts resume on their own), the controller-manager pod transitions out of `CrashLoopBackOff` and the previously failing startup completes — the same probe that failed with `dial tcp 10.4.0.1:443: i/o timeout` returns success on the next bootstrap.
+
+If the cluster has more than one control-plane endpoint, list every address from the `EndpointSlice` as its own `ipBlock` entry under `egress.to`; the rule matches traffic to any one of them. If other in-cluster destinations are also required at startup (for example, CoreDNS for name resolution before connecting to the apiserver), extend the policy with additional `egress` entries — each entry is independently OR'd against the others.
+
+## Diagnostic Steps
+
+When a manager pod is flapping, capture the bootstrap error from the previous container instance — the current container is often mid-retry and its logs are empty or partial:
+
+```bash
+kubectl logs -n <operator-namespace> <manager-pod> --previous
+```
+
+A log line containing `Failed to create a new manager.` together with `dial tcp <ip>:443: i/o timeout` (or an equivalent connection-timeout error against the in-cluster apiserver address) is the diagnostic signature of egress to the apiserver being blocked.
+
+Confirm the container is being restarted by the kubelet and the back-off is in effect:
+
+```bash
+kubectl get pod -n <operator-namespace> <manager-pod> \
+  -o jsonpath='{.status.containerStatuses[0]}'
+kubectl get events -n <operator-namespace> \
+  --field-selector involvedObject.name=<manager-pod> --sort-by=.lastTimestamp
+```
+
+A `state.waiting.reason: CrashLoopBackOff` with a non-zero `lastState.terminated.exitCode` and `Warning BackOff` events of `Back-off restarting failed container` confirm the pattern.
+
+List the `NetworkPolicy` objects in the namespace and inspect any that selects the manager pod to see whether `policyTypes` includes `Egress` without an egress rule that permits the apiserver endpoint(s):
+
+```bash
+kubectl get networkpolicy -n <operator-namespace>
+kubectl describe networkpolicy -n <operator-namespace> <policy-name>
+```
+
+Resolve the apiserver `Service` and its backing endpoints to know which addresses the egress rule must permit; the `ClusterIP` alone is not enough on kube-ovn:
+
+```bash
+kubectl get svc -n default kubernetes
+kubectl get endpointslices -n default -l kubernetes.io/service-name=kubernetes
+```
+
+Once the allow rule is in place, the next bootstrap of the manager container should succeed and the pod should return to `Running` without further restarts.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
