### PR TITLE
[security] Automating ingress TLS certificate renewal with cert-manager and an internal CA on ACP

### DIFF
--- a/docs/en/solutions/Automating_Ingress_Certificate_Renewal_with_cert_manager_and_an_Internal_CA.md
+++ b/docs/en/solutions/Automating_Ingress_Certificate_Renewal_with_cert_manager_and_an_Internal_CA.md
@@ -1,0 +1,191 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Automating Ingress Certificate Renewal with cert-manager and an Internal CA
+## Issue
+
+The cluster serves workloads over HTTPS using an internal (non-public) Certificate Authority. Manually issuing, rotating, and re-attaching the ingress certificate is error-prone: the wildcard expires, somebody forgets to rotate the private key along with it, or the renewal lands outside a maintenance window. The desired outcome is that the platform bootstraps its own internal CA, issues the wildcard certificate that fronts the ingress layer, and rotates everything on a timer with no manual touch-up.
+
+## Root Cause
+
+There is no bug; this is a configuration exercise. cert-manager is the standard Kubernetes component that manages `Issuer` / `ClusterIssuer` / `Certificate` / `CertificateRequest` objects and reconciles them into valid TLS `Secret` resources. ACP's `security/cert` surface exposes cert-manager in-cluster, so the pieces required for an internal-CA flow are already available; what is needed is a description of the right three CRs and where to attach the resulting secret on the ingress side.
+
+## Resolution
+
+### Preferred: ACP cert-manager + ALB for ingress termination
+
+ACP's ingress layer is delivered by the **ALB Operator** (`networking/operators/alb_operator`). Instead of patching a monolithic ingress-controller spec with a new default certificate, the ALB's Ingress / Frontend resources reference a TLS secret directly. The full flow is:
+
+1. **Bootstrap issuer — self-signed, cluster-scoped.** This issuer exists only to sign the first certificate (the Root CA). Once the Root CA exists, nothing else uses the bootstrap issuer.
+
+   ```yaml
+   apiVersion: cert-manager.io/v1
+   kind: ClusterIssuer
+   metadata:
+     name: bootstrap-issuer
+   spec:
+     selfSigned: {}
+   ```
+
+2. **Root CA certificate.** The Root CA certificate lives in the `cert-manager` namespace so that the follow-up `ClusterIssuer` can reference its secret cluster-wide. `isCA: true` marks the resulting X.509 object as a CA (the `CA:TRUE` basic-constraint is set). `rotationPolicy: Always` forces a fresh private key on every renewal rather than reusing the old one.
+
+   ```yaml
+   apiVersion: cert-manager.io/v1
+   kind: Certificate
+   metadata:
+     name: internal-root-ca
+     namespace: cert-manager
+   spec:
+     commonName: internal-ca.example.com
+     isCA: true
+     secretName: ca-root-secret
+     privateKey:
+       algorithm: ECDSA
+       size: 256
+       rotationPolicy: Always
+     issuerRef:
+       name: bootstrap-issuer
+       kind: ClusterIssuer
+       group: cert-manager.io
+   ```
+
+3. **Internal CA ClusterIssuer.** The `ca:` issuer type wraps the Root CA secret and signs every subsequent certificate request with it.
+
+   ```yaml
+   apiVersion: cert-manager.io/v1
+   kind: ClusterIssuer
+   metadata:
+     name: internal-ca-issuer
+   spec:
+     ca:
+       secretName: ca-root-secret
+   ```
+
+4. **Wildcard certificate for the ingress domain.** The secret produced by this `Certificate` is the one the ALB will actually serve. Put it in a namespace the ALB can read (conventionally a dedicated ingress namespace, for example `cpaas-system` or whatever the ALB frontend's namespace is).
+
+   ```yaml
+   apiVersion: cert-manager.io/v1
+   kind: Certificate
+   metadata:
+     name: ingress-wildcard-cert
+     namespace: cpaas-system
+   spec:
+     isCA: false
+     commonName: "apps.example.com"
+     dnsNames:
+       - "apps.example.com"
+       - "*.apps.example.com"
+     secretName: ingress-wildcard-tls
+     privateKey:
+       algorithm: ECDSA
+       size: 256
+       rotationPolicy: Always
+     issuerRef:
+       name: internal-ca-issuer
+       kind: ClusterIssuer
+       group: cert-manager.io
+   ```
+
+5. **Attach the secret to the ALB.** The ALB's Frontend (for HTTPS listeners) or Ingress (for HTTP-route style) references `ingress-wildcard-tls` by name. Example for a Kubernetes `Ingress` that the ALB is serving:
+
+   ```yaml
+   apiVersion: networking.k8s.io/v1
+   kind: Ingress
+   metadata:
+     name: platform-console
+     namespace: cpaas-system
+     annotations:
+       # project.cpaas.io/alb-name matches the ALB CR that should pick this up;
+       # replace with the actual ALB name in this cluster.
+       project.cpaas.io/alb-name: cpaas-alb
+   spec:
+     tls:
+       - hosts: ["apps.example.com", "*.apps.example.com"]
+         secretName: ingress-wildcard-tls
+     rules:
+       - host: apps.example.com
+         http:
+           paths:
+             - path: /
+               pathType: Prefix
+               backend:
+                 service:
+                   name: console-web
+                   port:
+                     number: 443
+   ```
+
+   On reconcile, the ALB controller loads the secret, programs the listener certificate, and on cert-manager renewals the new secret content is picked up without restarting the ALB pods.
+
+Apply the four CRs in the order above (`kubectl apply -f <file>.yaml`), then wait for each `Certificate` to reach `Ready=True`:
+
+```bash
+kubectl get certificate -A -o wide
+```
+
+The last column shows renewal time. Once `ingress-wildcard-cert` is `Ready=True`, distribute the Root CA (`ca-root-secret` → `ca.crt` key) to clients that need to trust it, either as part of the platform's trust-store distribution or as a one-off out-of-band push.
+
+### Fallback: vanilla in-cluster cert-manager against a generic Kubernetes Ingress
+
+The same four CRs work unchanged against any in-cluster cert-manager installation — the `cert-manager.io` API is a single upstream CRD set. The only thing that changes is step 5: if the cluster uses a non-ALB ingress controller (in-cluster NGINX, Contour, Traefik), attach the secret via that controller's usual knob. For NGINX Ingress with its IngressController object, point the default-SSL-certificate field at the `ingress-wildcard-tls` secret; the cert-manager half of the pipeline is identical.
+
+## Diagnostic Steps
+
+Check the `Certificate` object for its condition and next renewal time:
+
+```bash
+kubectl -n cpaas-system describe certificate ingress-wildcard-cert
+```
+
+A healthy certificate shows:
+
+```text
+Conditions:
+  Type    Status  Reason   Message
+  Ready   True    Ready    Certificate is up to date and has not expired
+Events:
+  Normal  Issuing    ...   The certificate has been successfully issued
+```
+
+Confirm the secret was written and contains the expected keys:
+
+```bash
+kubectl -n cpaas-system get secret ingress-wildcard-tls \
+  -o jsonpath='{.data}' | jq 'keys'
+# -> ["ca.crt","tls.crt","tls.key"]
+```
+
+Inspect the served certificate from inside the cluster, bypassing DNS:
+
+```bash
+kubectl -n cpaas-system get svc
+# pick the ALB service IP, then:
+echo | openssl s_client -connect <alb-svc-ip>:443 \
+  -servername apps.example.com 2>/dev/null | openssl x509 -noout -subject -issuer -dates
+```
+
+The `issuer=` line should reference `internal-ca.example.com` (the Root CA common name). If it still shows a previous default, the ALB has not picked up the secret — check the ALB controller pod logs:
+
+```bash
+kubectl -n cpaas-system logs -l app.kubernetes.io/name=alb
+```
+
+If the ALB never reconciled, confirm the Ingress is labeled or annotated to belong to the correct ALB frontend (the annotation key varies by ALB deployment; `kubectl describe ingress platform-console` shows what the controller matched on).
+
+Force a renewal for a dry-run of the rotation path. The classical form `kubectl cert-manager renew -n cpaas-system ingress-wildcard-cert` requires the [cert-manager kubectl plugin](https://cert-manager.io/docs/reference/cmctl/) (`kubectl-cert_manager` on PATH), which ACP does not ship by default. Without the plugin, the simplest trigger is to delete the issued TLS secret — cert-manager's secret controller detects the missing object on the next reconcile and re-issues the certificate from the same `Certificate` CR:
+
+```bash
+# With the plugin:
+kubectl cert-manager renew -n cpaas-system ingress-wildcard-cert
+
+# Plugin-free equivalent (cert-manager re-issues to refill the secret):
+kubectl delete secret ingress-wildcard-tls -n cpaas-system
+```
+
+A new secret version should appear within seconds and the ALB should serve it without service restart. If the ALB pods still serve the old certificate after a few minutes, capture `kubectl -n cpaas-system describe ingress platform-console` and the ALB controller logs around the renewal time — that is usually an annotation / secret-watch configuration issue rather than a cert-manager one.

--- a/docs/en/solutions/Automating_ingress_TLS_certificate_renewal_with_cert_manager_and_an_internal_CA_on_ACP.md
+++ b/docs/en/solutions/Automating_ingress_TLS_certificate_renewal_with_cert_manager_and_an_internal_CA_on_ACP.md
@@ -1,0 +1,137 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Automating ingress TLS certificate renewal with cert-manager and an internal CA on ACP
+
+## Issue
+
+On Alauda Container Platform, ingress endpoints that terminate TLS need certificates that are issued and rotated without manual intervention. Operators who do not want to depend on an external public CA can stand up an internal CA inside the cluster and have cert-manager mint and auto-renew the leaf certificates that back the ingress TLS secrets. cert-manager is available on ACP: the `certificates`, `clusterissuers`, `issuers`, and `certificaterequests` custom resources in the `cert-manager.io` group are all present, with storage version `v1`, so every resource in this workflow uses `apiVersion: cert-manager.io/v1`. The cert-manager controller runs from image `cert-manager-controller:v1.17.18-v4.3.1` (ACP cert-manager plugin chart `cert-manager-v4.3.1`) in the `cert-manager` namespace.
+
+## Resolution
+
+Bootstrap the trust chain with a self-signed `ClusterIssuer`. A `ClusterIssuer` whose spec carries `selfSigned: {}` acts as a self-signed root that signs a bootstrap certificate without any external CA, which is the standard cert-manager form for seeding an internal chain.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-bootstrap
+spec:
+  selfSigned: {}
+```
+
+Issue the CA certificate from that self-signed issuer. A `Certificate` with `spec.isCA: true` issued by the self-signed `ClusterIssuer` produces a CA key pair, which cert-manager writes to the secret named by `spec.secretName` as a `kubernetes.io/tls` secret holding `tls.crt` and `tls.key`.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: internal-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: internal-ca
+  secretName: ca-root-secret
+  privateKey:
+    rotationPolicy: Always
+  issuerRef:
+    name: selfsigned-bootstrap
+    kind: ClusterIssuer
+    group: cert-manager.io
+```
+
+Set `privateKey.rotationPolicy: Always` on the CA `Certificate` so that a fresh private key matching the configured requirements is generated whenever a re-issuance occurs, rather than the existing key being reused; the field is an enum of `{Never, Always}` and defaults to `Never`.
+
+Promote the CA key pair to a CA-type `ClusterIssuer`. A CA-type `ClusterIssuer` references the existing CA key pair through `spec.ca.secretName` and uses it to sign certificates requested against it; a live CA-type `ClusterIssuer` on the cluster reports status reason `KeyPairVerified` once its signing CA is verified.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: internal-ca-issuer
+spec:
+  ca:
+    secretName: ca-root-secret
+```
+
+Request the leaf ingress certificate from the CA-type issuer. A `Certificate` referencing the CA `ClusterIssuer` through `issuerRef` (`kind: ClusterIssuer`, `group: cert-manager.io`) is issued a leaf certificate that cert-manager writes to a `kubernetes.io/tls` secret named by `spec.secretName`, carrying `tls.crt`, `tls.key`, and `ca.crt`. The leaf `Certificate`'s `spec.dnsNames` and `spec.commonName` populate the SAN and CN entries of the issued certificate.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: custom-ingress-tls
+  namespace: my-app
+spec:
+  secretName: custom-ingress-tls
+  commonName: app.example.com
+  dnsNames:
+    - app.example.com
+  issuerRef:
+    name: internal-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+```
+
+Bind the issued TLS secret to an ingress through the standard Kubernetes `Ingress` resource. The `spec.tls[].secretName` field references the same `kubernetes.io/tls` secret that the leaf `Certificate` produces, so the ingress terminates TLS with the cert-manager-managed certificate for the listed hosts.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-app
+  namespace: my-app
+spec:
+  tls:
+    - hosts:
+        - app.example.com
+      secretName: custom-ingress-tls
+  rules:
+    - host: app.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: my-app
+                port:
+                  number: 80
+```
+
+Renewal is handled by cert-manager without manual reissue: it renews a `Certificate` ahead of expiry and refreshes the contents of the TLS secret in place. On a live leaf certificate cert-manager populates the renewal status fields — `status.renewalTime` is computed from the certificate's `notAfter` minus its `renewBefore` window, and the revision counter is bumped when the secret is refreshed. Because the ingress reads the certificate from the bound secret, the rotated material is served without changing the `Ingress` definition.
+
+## Diagnostic Steps
+
+Confirm the cert-manager CRDs are present and resolve to the expected group and version before applying any of the resources above:
+
+```bash
+kubectl get crd certificates.cert-manager.io clusterissuers.cert-manager.io \
+  issuers.cert-manager.io certificaterequests.cert-manager.io
+```
+
+Check that the CA-type `ClusterIssuer` has verified its signing key pair; a ready issuer reports the `KeyPairVerified` reason in its status conditions:
+
+```bash
+kubectl get clusterissuer internal-ca-issuer -o yaml
+```
+
+Inspect the leaf `Certificate` to confirm its issued SAN/CN inputs and its scheduled renewal. The `spec.dnsNames` and `spec.commonName` are the SAN and CN inputs cert-manager writes into the leaf, and `status.renewalTime` together with the revision counter shows the next scheduled renewal and how many times the secret has been refreshed:
+
+```bash
+kubectl get certificate custom-ingress-tls -n my-app \
+  -o jsonpath='{.spec.dnsNames}{"\n"}{.status.renewalTime}{"\n"}{.status.revision}{"\n"}'
+```
+
+Verify the resulting TLS secret has the expected `kubernetes.io/tls` type and that its data carries the `tls.crt`, `tls.key`, and `ca.crt` keys before binding it into the `Ingress`; the command below prints the secret type followed by the list of key names:
+
+```bash
+kubectl get secret custom-ingress-tls -n my-app \
+  -o json | jq '{type, keys: (.data | keys)}'
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章。
