### PR TITLE
[service_mesh] Installing istioctl for Diagnostics on a Cluster Running Istio

### DIFF
--- a/docs/en/solutions/Installing_istioctl_for_Diagnostics_on_a_Cluster_Running_Istio.md
+++ b/docs/en/solutions/Installing_istioctl_for_Diagnostics_on_a_Cluster_Running_Istio.md
@@ -1,0 +1,74 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+Operators want to use the `istioctl` command-line utility to inspect proxies, debug routing, and verify the control-plane state on a cluster that has Istio deployed. Unlike the long-lived sidecar binary, `istioctl` is a client tool that must match the **control-plane minor version** in use; running a mismatched client tends to produce confusing output (missing fields, deprecated flags, or "version skew" warnings on every command).
+
+This applies to ACP Service Mesh v2 (and the standalone Service Mesh v2 extension), both of which package upstream Istio without re-skinning the CLI surface.
+
+## Resolution
+
+The preferred path on ACP is to install `istioctl` whose version exactly matches the running Istio control plane. On ACP Service Mesh v2 the control plane is reconciled by the operator and its version is exposed on the `Istio` (or equivalent) custom resource installed in the mesh namespace.
+
+1. **Discover the control-plane version.** The version field on the mesh's CR is the source of truth for what `istioctl` to install:
+
+   ```bash
+   kubectl get istio -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.spec.version}{"\n"}{end}'
+   ```
+
+   On older v1 deployments where the resource is `ServiceMeshControlPlane`, query the status instead:
+
+   ```bash
+   kubectl -n istio-system get smcp -o jsonpath='{.items[*].status.chartVersion}{"\n"}'
+   ```
+
+2. **Download the matching upstream release.** Pin `ISTIO_VERSION` to whatever step 1 returned. The official installer drops a versioned `istio-<version>/` tree into the current directory:
+
+   ```bash
+   ISTIO_VERSION=1.20.3   # substitute the value from step 1
+   curl -sL https://istio.io/downloadIstio | ISTIO_VERSION="$ISTIO_VERSION" sh -
+   ```
+
+3. **Add `istioctl` to `PATH`.** Use a per-shell `PATH` injection rather than copying the binary into a system directory — that way, when the cluster is upgraded and the version changes, swapping the binary is just re-running step 2 in a fresh directory:
+
+   ```bash
+   cd istio-${ISTIO_VERSION}/bin
+   export PATH="$PWD:$PATH"
+   ```
+
+4. **Confirm client/server alignment.** `istioctl version` talks to the in-cluster proxies via the current kubeconfig. Both numbers should match:
+
+   ```bash
+   istioctl version
+   # client version: 1.20.3
+   # control plane version: 1.20.3
+   # data plane version: 1.20.3 (15 proxies)
+   ```
+
+   If `client version` differs from `control plane version` by a full minor release, redo step 2 with the correct `ISTIO_VERSION`. A patch-level skew is generally tolerable but still worth correcting before opening a support ticket.
+
+## Diagnostic Steps
+
+Once `istioctl` is on `PATH`, the most useful first-pass commands are:
+
+```bash
+# Sanity check: every proxy should sync within a few seconds
+istioctl proxy-status
+
+# Pull the live Envoy config of one workload — useful when a route works in
+# the manifest but not at runtime
+istioctl proxy-config all <pod> -n <namespace>
+
+# Run the built-in linter against the cluster
+istioctl analyze -A
+```
+
+If `istioctl proxy-status` reports `STALE` or `NOT SENT` against a pod, the pod's Envoy is not receiving updates from istiod — usually an MTLS/auth or NetworkPolicy problem between the pod and the control plane, not a bug in the configuration that produced the warning.
+
+The kubeconfig in use must already point at the cluster (`kubectl config current-context`). `istioctl` does not perform its own login.

--- a/docs/en/solutions/Installing_istioctl_for_Diagnostics_on_a_Cluster_Running_Istio.md
+++ b/docs/en/solutions/Installing_istioctl_for_Diagnostics_on_a_Cluster_Running_Istio.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Installing istioctl for Diagnostics on a Cluster Running Istio
 ## Issue
 
 Operators want to use the `istioctl` command-line utility to inspect proxies, debug routing, and verify the control-plane state on a cluster that has Istio deployed. Unlike the long-lived sidecar binary, `istioctl` is a client tool that must match the **control-plane minor version** in use; running a mismatched client tends to produce confusing output (missing fields, deprecated flags, or "version skew" warnings on every command).


### PR DESCRIPTION
新增一篇 ACP KB 文章，归入 `service_mesh` 区域。

**⚠️ 自动化验证：无测试计划** — 本篇未登记验证计划，暂不自动合并，请人工确认内容后再合。

## `service_mesh` 区域建议 reviewer

按 `kb/OWNERS.md`（来源：alauda-ai-base operator-list 的产品 owner）该区域候选自动挑选，@ 错了请无视。


没有 GitHub handle 的贡献者（本区域相关请人工 ping）：

- ranwang &lt;ranwang@alauda.io&gt;
