### PR TITLE
[gitops] ArgoCD repo-server DNS lookups leak upstream because of pod ndots:5 search expansion

### DIFF
--- a/docs/en/solutions/ArgoCD_repo_server_DNS_lookups_leak_upstream_because_of_pod_ndots5_search_expansion.md
+++ b/docs/en/solutions/ArgoCD_repo_server_DNS_lookups_leak_upstream_because_of_pod_ndots5_search_expansion.md
@@ -1,0 +1,73 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# ArgoCD repo-server DNS lookups leak upstream because of pod ndots:5 search expansion
+
+## Issue
+
+The Alauda Build of Argo CD `argocd-gitops-repo-server` pods in the `argocd` namespace fail to resolve names that should be served by the in-cluster DNS, and the upstream resolver behind CoreDNS starts receiving cluster-internal-looking queries. The repo-server then surfaces repository-fetch or webhook-target lookup failures, and the Argo CD UI may become unreachable.
+
+On a representative cluster (`v1.34.5`), every pod in the `argocd` namespace runs with `dnsPolicy=ClusterFirst` and no `dnsConfig` override, so they all inherit the kubelet-generated `/etc/resolv.conf` defaults. Reading the configuration that drives that file confirms the standard cluster service search list — `<namespace>.svc.cluster.local`, `svc.cluster.local`, `cluster.local` — is appended to every short name.
+
+The diagnostic signature in the CoreDNS query log is a lookup whose name has the cluster domain glued on twice, for example an `AAAA` query for `argocd-gitops-repo-server.argocd.svc.cluster.local.argocd.svc.cluster.local` that returns `NXDOMAIN`.
+
+## Root Cause
+
+A pod whose `dnsPolicy` is `ClusterFirst` and which does not override `spec.dnsConfig.options` receives `options ndots:5` in `/etc/resolv.conf`, alongside the cluster service search list and the in-cluster DNS server address. The same file lists the namespace-scoped, service-wide, and cluster-wide search domains so the libc resolver knows how to expand short service names.
+
+Under `ndots:5`, the libc resolver looks at the input name: when it contains fewer than five dots, the resolver appends each search domain in turn and queries the resulting names BEFORE it attempts the original name as an absolute query. Each search-domain attempt produces a concatenated query name — the input glued onto a cluster suffix — for example `svc.cluster.local.<namespace>.svc.cluster.local` or `svc.cluster.local.svc.cluster.local`.
+
+CoreDNS is authoritative only for the `cluster.local` zone, so a search-expanded name that does not match a real Service or Pod record is returned as `NXDOMAIN`; the same configuration forwards non-`cluster.local` names upstream. The combined effect is that any name in the GitOps pod with fewer than five dots — including names that already end in `.cluster.local` but happen to have only two or three dots in their input form — fans out into several search-domain-appended lookups first, each of which is answered authoritatively as `NXDOMAIN` by CoreDNS and at least one of which can be forwarded upstream, which is the article's reported symptom of internal lookups landing on the external DNS server.
+
+## Resolution
+
+The fix is to lower the `ndots` threshold on the affected pod template so the resolver treats short names as absolute first and only falls back to search expansion when the absolute lookup itself fails. The `spec.dnsConfig.options` field is a generic pod-spec field that takes a list of `name`/`value` pairs and merges into the `dnsPolicy`-generated base.
+
+Patch the repo-server pod template — for the Alauda Build of Argo CD this is the `argocd-gitops-repo-server` Deployment in the `argocd` namespace — to set `ndots:1`:
+
+```yaml
+spec:
+  template:
+    spec:
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+```
+
+Apply the patch with `kubectl`:
+
+```bash
+kubectl -n argocd patch deployment argocd-gitops-repo-server \
+  --type=strategic \
+  -p '{"spec":{"template":{"spec":{"dnsConfig":{"options":[{"name":"ndots","value":"1"}]}}}}}'
+```
+
+After the rollout, every new repo-server pod receives `options ndots:1` in `/etc/resolv.conf` instead of the default `ndots:5`, while the search list and nameserver remain the cluster defaults. With `ndots:1`, any name with at least one dot is queried as absolute first, so the doubled-suffix expansion path stops firing on the workload.
+
+For one-off scripts and external hostnames it is also valid to append a trailing dot to the name. A trailing dot marks the name as fully-qualified, and the resolver skips search-domain expansion and queries the name directly even when `ndots:5` is still in effect.
+
+## Diagnostic Steps
+
+Confirm the pod template still uses the cluster default DNS settings — `dnsPolicy=ClusterFirst` with an empty `dnsConfig` block means the kubelet-default `options ndots:5` and the cluster search list will be written into every new pod:
+
+```bash
+kubectl -n argocd get deployment argocd-gitops-repo-server \
+  -o jsonpath='dnsPolicy={.spec.template.spec.dnsPolicy} dnsConfig={.spec.template.spec.dnsConfig}{"\n"}'
+```
+
+Read the actual file from inside a running repo-server pod to confirm the on-pod resolver configuration — expected default content is `search <namespace>.svc.cluster.local svc.cluster.local cluster.local`, the in-cluster DNS server address on the `nameserver` line, and `options ndots:5`:
+
+```bash
+kubectl -n argocd exec deployment/argocd-gitops-repo-server -- cat /etc/resolv.conf
+```
+
+To observe the search-domain re-expansion the issue describes, trigger a lookup of a short name from inside the pod — for example `kubectl -n argocd exec deployment/argocd-gitops-repo-server -- nslookup <short-name>` — and inspect the cluster DNS query log. With CoreDNS query logging enabled, an input name with fewer than five dots produces a series of search-domain-appended queries before any absolute query, and the doubled-suffix variants return `NXDOMAIN`; this is the same diagnostic signature reported in the issue and is the wire-level evidence that the workload is hitting the `ndots:5` path.
+
+After applying the `ndots:1` patch, the same probe from a new repo-server pod issues a single absolute query for the same input name and no longer generates the doubled-suffix `NXDOMAIN` lookups, which is the expected post-fix behavior.

--- a/docs/en/solutions/GitOps_Pods_Fail_DNS_Resolution_Because_of_ndots_Search_Path_Re_expansion.md
+++ b/docs/en/solutions/GitOps_Pods_Fail_DNS_Resolution_Because_of_ndots_Search_Path_Re_expansion.md
@@ -1,0 +1,93 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# GitOps Pods Fail DNS Resolution Because of ndots Search Path Re-expansion
+## Issue
+
+The Argo CD console becomes unreachable from inside the cluster, and CoreDNS query logs (or the upstream resolver's logs) show a flood of `NXDOMAIN` answers for hostnames that look doubled up:
+
+```text
+[INFO] 172.22.4.14:41816 - 10265 "AAAA IN argocd-repo-server.argocd.svc.cluster.local.argocd.svc.cluster.local. udp 127 false 1232" NXDOMAIN qr,aa,rd 209 0.000090059s
+```
+
+The cluster service domain (here, `argocd.svc.cluster.local`) is appended a second time to a name that already carried it. Because the doubled name does not exist, every lookup eventually escapes to the configured upstream resolver — which then sees private cluster names it cannot resolve, generating noise and per-query latency on top of the actual failure.
+
+## Root Cause
+
+This is the standard "`ndots` search-path re-expansion" trap, made visible by an in-cluster client that happened to pass a fully qualified service name without a trailing dot.
+
+The kubelet writes a `resolv.conf` into every pod that includes a `search` list of cluster suffixes (typically `<ns>.svc.cluster.local`, `svc.cluster.local`, `cluster.local`, plus any node-level domains) and `options ndots:5` (or similar). The resolver behaves as follows:
+
+- Any hostname with **fewer than `ndots` dots** is considered "relative" and is tried first against every entry in the `search` list, in order, before being tried as an absolute name.
+- A name like `argocd-repo-server.argocd.svc.cluster.local` has exactly four dots — one short of the `ndots:5` threshold — so the resolver re-applies the search list to it. The first try concatenates the namespace's own suffix, producing the double-suffix name in the log.
+
+Because the doubled name does not exist, the resolver only succeeds when it falls back to trying the original name as absolute, after exhausting the search list. Each request therefore costs one or two extra round-trips to CoreDNS plus, in some configurations, an upstream lookup with the wrong domain.
+
+The application code is not technically wrong — passing the full FQDN is a reasonable choice — but combined with the cluster's `ndots` policy it produces this pattern. Until the upstream Argo CD components either set `dnsConfig.options.ndots` lower or always append a trailing dot to internal hostnames, the search-path expansion will keep happening.
+
+## Resolution
+
+Several fixes are available; they are not mutually exclusive.
+
+1. **Lower `ndots` for the affected workload.** This is the cleanest fix and avoids modifying the application. Set `dnsConfig.options.ndots` to `2` (or `1`) on the relevant Deployments — once the value is below the dot count of the FQDN, the resolver will treat the hostname as absolute on the first try:
+
+   ```yaml
+   spec:
+     template:
+       spec:
+         dnsConfig:
+           options:
+             - name: ndots
+               value: "2"
+         dnsPolicy: ClusterFirst   # keep the default; just override ndots
+   ```
+
+   Apply to each Argo CD component that exhibits the symptom (`repo-server`, `application-controller`, `server`). The fix takes effect on the next pod restart.
+
+2. **Make hostnames truly absolute by appending a trailing dot.** If the application is configurable, point it at `argocd-repo-server.argocd.svc.cluster.local.` (note trailing `.`). The libc resolver short-circuits the search-path expansion when it sees a name ending in `.`. This is preferable when the workload is third-party and the resolution behaviour must not be globally relaxed.
+
+3. **Use a short, single-label form within the same namespace.** Inside the Argo CD namespace, the bare service name `argocd-repo-server` will resolve through the search path correctly on the first try. Long FQDNs are only needed when crossing namespaces.
+
+After applying the fix, the doubled-suffix queries should disappear from the CoreDNS log and Argo CD should reach its repo server again.
+
+## Diagnostic Steps
+
+Confirm the cluster's `ndots` setting from inside an affected pod:
+
+```bash
+kubectl -n <ns> exec <pod> -- cat /etc/resolv.conf
+# Look for: options ndots:5
+# And:      search <ns>.svc.cluster.local svc.cluster.local cluster.local ...
+```
+
+Reproduce the doubled lookup deterministically to confirm the pattern is search-path expansion and not application logic.
+
+The classical diagnostic is `kubectl debug -it <pod> --image=<image-with-dig> -- bash` followed by `dig +search +trace argocd-repo-server.argocd.svc.cluster.local`. This requires the debug image to (a) contain `dig` and (b) be pullable on the cluster — on isolated ACP clusters, public registries like `registry.k8s.io` may not be reachable. Use an image you already know is mirrored locally; the operations team can list what `bind-utils` / `dnsutils` images are available.
+
+When no dnsutils image is available, observe the expansion from any in-cluster pod that ships `getent` (the glibc resolver follows the same `resolv.conf` rules):
+
+```bash
+# Pick any running pod in the affected namespace; exec into it and walk the
+# resolution path with getent:
+kubectl -n <ns> exec <pod> -- getent hosts argocd-repo-server.argocd.svc.cluster.local
+kubectl -n <ns> exec <pod> -- cat /etc/resolv.conf
+```
+
+If `getent` is also missing, the third fallback is to read CoreDNS's query log directly. CoreDNS is deployed in `kube-system` on ACP; turn on the `log` plugin briefly and tail one of its pod logs while the application reproduces the failing request — the doubled-name `NXDOMAIN` lines will appear there.
+
+If the trace shows the resolver attempting `<name>.<ns>.svc.cluster.local` first and getting `NXDOMAIN`, then attempting the original name and succeeding, the search-path expansion is confirmed.
+
+Verify the fix took effect after redeploying:
+
+```bash
+kubectl -n <ns> exec <new-pod> -- cat /etc/resolv.conf | grep ndots
+# Expect: options ndots:2
+```
+
+A drop in CoreDNS query rate against the affected service is the practical signal that the workload is no longer paying the search-path cost.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
