### PR TITLE
[virtualization] Console-only namespace access to KubeVirt VirtualMachines via RBAC

### DIFF
--- a/docs/en/solutions/Console_only_namespace_access_to_KubeVirt_VirtualMachines_via_RBAC.md
+++ b/docs/en/solutions/Console_only_namespace_access_to_KubeVirt_VirtualMachines_via_RBAC.md
@@ -1,0 +1,149 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Console-only namespace access to KubeVirt VirtualMachines via RBAC
+
+## Issue
+
+A non-admin user needs to open the serial console or VNC display of `VirtualMachine` objects in one namespace, list those VMs and their backing `VirtualMachineInstance` pods, and see the supporting workload resources — but must not be able to start, stop, edit, or delete any VM, and must have no access in any other namespace.
+
+The built-in aggregated role `kubevirt.io:view` grants `get`/`list`/`watch` on `virtualmachines` and `virtualmachineinstances` in the `kubevirt.io` API group, but it deliberately omits the console and VNC subresources, so a user bound to it can see VM objects yet cannot open their console. A custom namespace-scoped `Role` that adds those two subresources solves the problem without granting any mutating verb.
+
+## Resolution
+
+Apply two objects in the target namespace: a `Role` that defines the console-only permission set, and a `RoleBinding` that grants it to a single user (or service account). Both are standard `rbac.authorization.k8s.io/v1` resources; the underlying authorizer is the upstream Kubernetes RBAC mechanism, where each `PolicyRule` is an additive allow-list — verbs not listed are denied.
+
+Optionally bind the stock cluster-scoped `view` role first, so the user has the usual namespace-wide baseline visibility (configmaps, pods, services, events, and so on with `get`/`list`/`watch`). The `view` ClusterRole is present on Alauda Container Platform and covers `pods`, `pods/log`, `services`, `endpoints`, `events` in the core API group:
+
+```bash
+kubectl create rolebinding view-baseline \
+  --clusterrole=view \
+  --user=<username> \
+  -n <namespace>
+```
+
+Then create the console-only `Role` and `RoleBinding`. The first rule grants the read verbs on the VM and VMI objects themselves. The second rule grants the two console subresources from the aggregated `subresources.kubevirt.io` group — `virtualmachineinstances/console` (serial console) and `virtualmachineinstances/vnc` (VNC). The third rule grants the read verbs on the supporting core resources:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubevirt-console-access
+  namespace: <namespace>
+rules:
+- apiGroups: ["kubevirt.io"]
+  resources: ["virtualmachines", "virtualmachineinstances"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["subresources.kubevirt.io"]
+  resources:
+  - virtualmachineinstances/console
+  - virtualmachineinstances/vnc
+  verbs: ["get", "update"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log", "services", "endpoints", "events"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubevirt-console-access-binding
+  namespace: <namespace>
+subjects:
+- kind: User
+  name: <username>
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: kubevirt-console-access
+  apiGroup: rbac.authorization.k8s.io
+```
+
+To bind to a `ServiceAccount` instead of a user, replace the `subjects` entry with `{kind: ServiceAccount, name: <sa>, namespace: <namespace>}` (drop `apiGroup`).
+
+Two properties of this configuration are worth highlighting. First, the second rule's `apiGroups: ["subresources.kubevirt.io"]` is required — `virtualmachineinstances/console` and `virtualmachineinstances/vnc` are served by the KubeVirt aggregated API server under that group, not under `kubevirt.io`; a rule that lists those subresource paths under `kubevirt.io` will not authorize them. Second, because the `Role` lists only `get`/`list`/`watch` on `virtualmachines`/`virtualmachineinstances` and `get`/`update` on the two console subresources, every other verb — `create`, `update`, `patch`, `delete` on the VM/VMI objects, and the mutating subresources `virtualmachines/start`, `virtualmachines/stop`, `virtualmachineinstances/pause`, `virtualmachineinstances/addvolume`, and so on — is denied by default.
+
+## Diagnostic Steps
+
+Confirm that the bound subject actually has the granted permissions and is denied the omitted ones. The reliable way to ask the authorizer "is this verb allowed for that subject" is to authenticate as the subject (real token) and run `kubectl auth can-i`, which issues a `SelfSubjectAccessReview`. Impersonated `SubjectAccessReview` via `--as=<user>` from an admin context is not a reliable probe on this platform — it can return `yes` for verbs the target subject does not actually have.
+
+Bind the `Role` to a `ServiceAccount` (or rewrite the existing `RoleBinding`'s `subjects` to point at one), then mint a token for it and run the checks against the API server with that token. The expected outcome is the matrix that the article's `Role` defines:
+
+```bash
+NS=<namespace>
+TOK=$(kubectl -n $NS create token <sa-name>)
+SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+
+# Granted reads — expect 'yes' for each
+for v in get list watch; do
+  echo -n "$v vm: "
+  kubectl --token=$TOK --server=$SERVER --insecure-skip-tls-verify \
+    -n $NS auth can-i $v virtualmachines.kubevirt.io
+done
+
+# Omitted verbs — expect 'no' for each
+for v in create update patch delete; do
+  echo -n "$v vm: "
+  kubectl --token=$TOK --server=$SERVER --insecure-skip-tls-verify \
+    -n $NS auth can-i $v virtualmachines.kubevirt.io
+done
+
+# Mutating VM subresources — expect 'no'
+kubectl --token=$TOK --server=$SERVER --insecure-skip-tls-verify \
+  -n $NS auth can-i update virtualmachines --subresource=start
+
+# Cross-namespace — expect 'no'
+kubectl --token=$TOK --server=$SERVER --insecure-skip-tls-verify \
+  -n default auth can-i get virtualmachines.kubevirt.io
+```
+
+The `console` and `vnc` subresources live under `subresources.kubevirt.io`, not `kubevirt.io`, so `kubectl auth can-i` with the resource-shortname form may probe the wrong API group. Issue the `SelfSubjectAccessReview` directly via the raw API to pin the group explicitly:
+
+```bash
+for sub in console vnc; do
+  echo -n "get vmi/$sub in $NS: "
+  cat <<EOF | kubectl --token=$TOK --server=$SERVER --insecure-skip-tls-verify \
+    create -f - --validate=false -o jsonpath='{.status.allowed}'
+apiVersion: authorization.k8s.io/v1
+kind: SelfSubjectAccessReview
+spec:
+  resourceAttributes:
+    namespace: $NS
+    group: subresources.kubevirt.io
+    resource: virtualmachineinstances
+    subresource: $sub
+    verb: get
+EOF
+  echo
+done
+```
+
+Expected output on a correctly bound subject:
+
+```text
+get vmi/console in <namespace>: true
+get vmi/vnc in <namespace>: true
+```
+
+For an end-to-end check, hit the live VNC subresource endpoint with the subject's token. The distinction between RBAC denial and a missing object is visible in the HTTP status: `403 Forbidden` is the authorizer rejecting the request, `404 NotFound` means the request was authorized and the `VirtualMachineInstance` simply does not exist:
+
+```bash
+curl -k -o /dev/null -w "%{http_code}\n" \
+  -H "Authorization: Bearer $TOK" \
+  "$SERVER/apis/subresources.kubevirt.io/v1/namespaces/$NS/virtualmachineinstances/<vmi>/console"
+```
+
+A `403` response with the message `virtualmachineinstances.subresources.kubevirt.io ".." is forbidden: User ".." cannot get resource "virtualmachineinstances/console"` indicates the binding is missing (or the request is being made in the wrong namespace); a `404` with `virtualmachineinstance.kubevirt.io ".." not found` confirms the RBAC path is clear and only the VMI name needs attention.
+
+The same probe in a different namespace will return `403` even for the bound subject, confirming the `RoleBinding` is namespace-scoped:
+
+```bash
+curl -k -o /dev/null -w "%{http_code}\n" \
+  -H "Authorization: Bearer $TOK" \
+  "$SERVER/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/<vmi>/console"
+```

--- a/docs/en/solutions/Grant_Console_Only_Access_to_VirtualMachines_for_Non_Admin_Users_in_a_Single_Namespace.md
+++ b/docs/en/solutions/Grant_Console_Only_Access_to_VirtualMachines_for_Non_Admin_Users_in_a_Single_Namespace.md
@@ -1,0 +1,116 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A common multi-tenant requirement on ACP Virtualization is to let an end user **open a VM's serial console or VNC session** — for day-to-day operations like logging into the guest OS, running `systemd` checks, or observing boot messages — without granting them enough authority to start, stop, reconfigure, or delete the VM itself.
+
+The default cluster roles err on the coarse side. `view` lets a user see the objects but not reach the `/console` and `/vnc` subresources; `edit` or `admin` reach the console but also permit mutating the VM spec, live-migrating it, or deleting it entirely. Neither is a fit for the "support person who needs to SSH into the VM through the platform" persona.
+
+## Resolution
+
+Combine the built-in `view` ClusterRole (for visibility) with a small custom `Role` that grants only the two subresources KubeVirt exposes for interactive console access. Bind both in the target namespace.
+
+This approach works uniformly on ACP Virtualization (in-core `virtualization`, based on upstream KubeVirt) and on any plain-Kubernetes cluster running KubeVirt — the subresource paths are identical.
+
+1. **Grant `view` in the target namespace.** This lets the user list and describe VMs and VMIs, which the web console needs to render the VM page:
+
+   ```bash
+   kubectl create rolebinding vm-console-view \
+     --clusterrole=view \
+     --user=<user-name> \
+     -n <namespace>
+   ```
+
+   Use `--group=<group-name>` instead of `--user=...` to grant to an OIDC/LDAP group rather than an individual.
+
+2. **Define the console-only Role.** The two KubeVirt subresources for interactive console access are `virtualmachineinstances/console` (serial console) and `virtualmachineinstances/vnc` (VNC framebuffer). The verb for opening a session is `get`, but the way the websocket is established also requires `update`. The rest of the rules (`pods`, `pods/log`, `services`, `endpoints`, `events`) cover the incidental reads the console UI performs while rendering:
+
+   ```yaml
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: Role
+   metadata:
+     name: kubevirt-console-access
+     namespace: <namespace>
+   rules:
+     - apiGroups: ["kubevirt.io"]
+       resources:
+         - virtualmachines
+         - virtualmachineinstances
+       verbs: ["get", "list", "watch"]
+     - apiGroups: ["subresources.kubevirt.io"]
+       resources:
+         - virtualmachineinstances/console
+         - virtualmachineinstances/vnc
+       verbs: ["get", "update"]
+     - apiGroups: [""]
+       resources:
+         - pods
+         - pods/log
+         - services
+         - endpoints
+         - events
+       verbs: ["get", "list", "watch"]
+   ```
+
+   Note what is **absent**: no `create`/`update`/`patch`/`delete` on `virtualmachines` (the user cannot change the spec), no verbs on `virtualmachineinstancemigrations` (cannot live-migrate), no verbs on `virtualmachineinstances` beyond `get/list/watch` (cannot stop or restart). The user's only write capability is to establish a console session.
+
+3. **Bind the custom Role.**
+
+   ```yaml
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: RoleBinding
+   metadata:
+     name: kubevirt-console-access-binding
+     namespace: <namespace>
+   subjects:
+     - kind: User
+       name: <user-name>
+       apiGroup: rbac.authorization.k8s.io
+   roleRef:
+     kind: Role
+     name: kubevirt-console-access
+     apiGroup: rbac.authorization.k8s.io
+   ```
+
+   Bind a group instead by substituting `kind: Group` and `name: <group-name>`.
+
+4. **Hand the user the access URL.** On ACP Virtualization the web console exposes the VM page and a built-in console tab; the user will land on an authenticated view of the VM list for the namespace only. Outside the web console, the same permissions are enough to drive `virtctl console <vm>` / `virtctl vnc <vm>` from the command line.
+
+## Diagnostic Steps
+
+Use `kubectl auth can-i` to verify the bindings end-to-end before handing them off:
+
+```bash
+# Should return "yes" — user can list VMs in the namespace.
+kubectl auth can-i list virtualmachines.kubevirt.io \
+  --as=<user-name> -n <namespace>
+
+# Should return "yes" — user can open a serial console session.
+kubectl auth can-i get virtualmachineinstances.subresources.kubevirt.io/console \
+  --as=<user-name> -n <namespace>
+
+# Should return "no" — user cannot stop or reconfigure the VM.
+kubectl auth can-i patch virtualmachines.kubevirt.io \
+  --as=<user-name> -n <namespace>
+
+kubectl auth can-i delete virtualmachines.kubevirt.io \
+  --as=<user-name> -n <namespace>
+```
+
+If the `list virtualmachines` check returns `no`, the `view` RoleBinding from step 1 did not land — check that the namespace and subject match.
+
+If the `get .../console` check returns `yes` but the console session still refuses to open ("permission denied" from the UI), inspect the websocket handshake:
+
+```bash
+kubectl -n <namespace> logs deploy/virt-api --tail=50 | grep -i forbidden
+```
+
+The most common cause at that point is the user being bound in a different namespace than the VM lives in — Role and RoleBinding are namespace-scoped; cross-namespace bindings do not work. Re-create the binding in the same namespace as the VM.
+
+If the user should get the same permission in more than one namespace, create one `RoleBinding` per namespace (preferred — keeps the blast radius tight), or convert the `Role` into a `ClusterRole` and bind it per-namespace with separate `RoleBinding` objects.

--- a/docs/en/solutions/Grant_Console_Only_Access_to_VirtualMachines_for_Non_Admin_Users_in_a_Single_Namespace.md
+++ b/docs/en/solutions/Grant_Console_Only_Access_to_VirtualMachines_for_Non_Admin_Users_in_a_Single_Namespace.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Grant Console-Only Access to VirtualMachines for Non-Admin Users in a Single Namespace
 ## Issue
 
 A common multi-tenant requirement on ACP Virtualization is to let an end user **open a VM's serial console or VNC session** — for day-to-day operations like logging into the guest OS, running `systemd` checks, or observing boot messages — without granting them enough authority to start, stop, reconfigure, or delete the VM itself.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
