### PR TITLE
[virtualization] virtctl memory-dump fails with "No space left on device"

### DIFF
--- a/docs/en/solutions/virtctl_memory_dump_Fails_with_No_Space_Left_on_Device_When_the_Auto_Created_PVC_Is_Too_Small.md
+++ b/docs/en/solutions/virtctl_memory_dump_Fails_with_No_Space_Left_on_Device_When_the_Auto_Created_PVC_Is_Too_Small.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# virtctl memory-dump Fails with No Space Left on Device When the Auto-Created PVC Is Too Small
 ## Issue
 
 On an ACP Virtualization cluster (KubeVirt under the hood), requesting an on-demand memory dump of a running VM fails mid-transfer:

--- a/docs/en/solutions/virtctl_memory_dump_Fails_with_No_Space_Left_on_Device_When_the_Auto_Created_PVC_Is_Too_Small.md
+++ b/docs/en/solutions/virtctl_memory_dump_Fails_with_No_Space_Left_on_Device_When_the_Auto_Created_PVC_Is_Too_Small.md
@@ -1,0 +1,135 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+On an ACP Virtualization cluster (KubeVirt under the hood), requesting an on-demand memory dump of a running VM fails mid-transfer:
+
+```text
+Memory dump to pvc testmemorydump failed:
+  Domain memory dump failed:
+    virError(Code=9, Domain=0,
+      Message='operation failed: /usr/libexec/libvirt_iohelper: failure with
+               /var/run/kubevirt/hotplug-disks/<pvc>/<vm>-<pvc>-<ts>.memory.dump:
+               Unable to write ... : No space left on device')
+```
+
+The command is typically invoked with the convenience flag that creates the target PVC for the operator:
+
+```bash
+virtctl memory-dump get <vm-name> --create-claim --claim-name=testmemorydump
+```
+
+When the flag auto-creates the claim, the resulting PVC can be sized below what the dump actually needs, and the dump aborts with `ENOSPC` after libvirt has already begun streaming guest memory into it.
+
+## Root Cause
+
+`virtctl memory-dump ... --create-claim` derives the PVC size from the VM's memory request. When the VMI spec was written without an explicit `.spec.domain.resources.requests.memory` (or was produced from a template that left it empty), the computed size collapses to a small default — far smaller than the guest's actual RAM footprint and the filesystem overhead the CSI driver needs on top of it.
+
+libvirt streams the dump straight into that PVC mounted as a hotplug disk. Once the file reaches the PVC's capacity minus the filesystem overhead, the next write hits `ENOSPC` and libvirt aborts the operation. The KubeVirt-side tracker for this undersizing behaviour is `CNV-82027`.
+
+## Resolution
+
+The durable workaround is to stop relying on `--create-claim` for memory dumps and provision the PVC yourself with a size derived from the VM's configured memory, not from whatever happened to land in the VMI spec.
+
+### Sizing formula
+
+The target PVC must hold the guest's RAM plus libvirt's metadata plus the filesystem overhead the CSI driver charges against the volume:
+
+```text
+PVC size >= (guest_memory + 100 MiB) * (1 + filesystem_overhead)
+```
+
+`filesystem_overhead` defaults to `0.055` (5.5%) for the block-to-filesystem wrapper used by KubeVirt's Containerized Data Importer (CDI); a safer rule of thumb is `0.07` (7%) to give pressure headroom.
+
+For an 8 GiB guest:
+
+```text
+PVC size = (8 GiB + 100 MiB) * 1.07
+        ≈ 8.1 GiB * 1.07
+        ≈ 8.7 GiB
+```
+
+Round up to the nearest size the StorageClass actually provisions (most dynamic provisioners round up to the next GiB anyway).
+
+### Pre-create the PVC
+
+Create the PVC in the same namespace as the VM, with the StorageClass that KubeVirt uses for hotplug disks on this cluster and with `accessModes: [ReadWriteOnce]` (the dump does not need RWX; hotplug attach will work either way).
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: testmemorydump
+  namespace: <vm-namespace>
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 9Gi      # guest_mem + 100Mi + ~7% FS overhead, rounded up
+  storageClassName: <hotplug-capable-sc>
+```
+
+Apply it, then run the dump against the pre-existing claim — notice the absence of `--create-claim`:
+
+```bash
+kubectl apply -f memory-dump-pvc.yaml
+virtctl memory-dump get <vm-name> \
+  --claim-name=testmemorydump \
+  --namespace=<vm-namespace>
+```
+
+The dump streams into the PVC and completes. The resulting file is at `<mount>/memory.dump` inside a pod that mounts the claim, or can be retrieved with:
+
+```bash
+virtctl memory-dump download <vm-name> \
+  --claim-name=testmemorydump \
+  --namespace=<vm-namespace> \
+  --output=./vm-memory.dump
+```
+
+### Preventive fix for new VMs
+
+If dumps on this VM are going to be a recurring activity, patch the VMI spec to always carry an explicit memory request equal to the guest memory. Once the field is populated, `virtctl ... --create-claim` on future invocations will compute a correctly sized PVC on its own, and the workaround is no longer needed.
+
+```yaml
+spec:
+  template:
+    spec:
+      domain:
+        resources:
+          requests:
+            memory: 8Gi
+        memory:
+          guest: 8Gi
+```
+
+## Diagnostic Steps
+
+Before blaming the dump, confirm the failure really is disk-full and not a timeout or a libvirt auth error. The VMI event surface is the single most useful place:
+
+```bash
+kubectl -n <vm-namespace> get vmi <vm-name> -o yaml \
+  | yq '.status.conditions, .status.volumeStatus'
+kubectl -n <vm-namespace> describe vmi <vm-name> | grep -A3 -i dump
+```
+
+`virError(Code=9, ... No space left on device)` on the memory-dump event is the unambiguous signature of this bug. If instead the event reports a libvirt permission error or a hotplug volume-not-ready condition, the root cause is different and the PVC sizing fix will not help.
+
+To confirm the PVC is the bottleneck rather than the underlying PV, inspect the mounted size inside the virt-launcher pod at the moment of failure:
+
+```bash
+POD=$(kubectl -n <vm-namespace> get pod \
+  -l kubevirt.io/vm=<vm-name> \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl -n <vm-namespace> exec "$POD" -c compute -- \
+  df -h /var/run/kubevirt/hotplug-disks/testmemorydump
+```
+
+If the mount's `Avail` is a few hundred MiB at the moment of the crash while the guest has many GiB of RAM, the PVC is undersized — resize the claim (if the StorageClass supports online resize) or recreate it with the formula above.

--- a/docs/en/solutions/virtctl_memory_dump_fails_with_No_space_left_on_device.md
+++ b/docs/en/solutions/virtctl_memory_dump_fails_with_No_space_left_on_device.md
@@ -1,0 +1,122 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# virtctl memory-dump fails with "No space left on device"
+
+## Issue
+
+`virtctl memory-dump <vm> --create-claim` against a running VirtualMachine on Alauda Container Platform Virtualization (KubeVirt) returns with a failure, and the VMI surfaces an event whose payload starts with `Memory dump to pvc <name> failed: Domain memory dump failed: virError(Code=9, ...) ... Unable to write /var/run/kubevirt/hotplug-disks/<pvc>/<...>.memory.dump: No space left on device`. The dump never completes; the PVC that the `--create-claim` flag auto-provisioned has been filled to capacity by the in-progress dump and libvirt's `libvirt_iohelper` aborts the write with `ENOSPC`.
+
+## Root Cause
+
+`virtctl memory-dump --create-claim` records its target on `VirtualMachine.status.memoryDumpRequest`, whose CRD shape on this platform is `{claimName, phase, fileName, message, remove, startTimestamp, endTimestamp}`; `claimName` is the auto-created PVC and `message` carries the failure text quoted above. The PVC is hot-plugged into the VMI and its progress is mirrored on `VirtualMachineInstance.status.volumeStatus[].memoryDumpVolume{claimName, targetFileName, startTimestamp, endTimestamp}` — `targetFileName` is the `.memory.dump` path that the `ENOSPC` event names.
+
+The auto-created PVC is sized off the guest's declared memory. KubeVirt reads that from `VirtualMachine.spec.template.spec.domain.memory.guest`, which itself defaults to `spec.template.spec.domain.resources.requests.memory` when not set explicitly. When the VirtualMachine spec carries neither — i.e. the guest's memory size is not declared — the controller falls back to a value that does not bound the actual RAM the libvirt domain will dump, so the PVC is provisioned smaller than the dump payload and the first write past the PVC's filesystem-usable size hits `ENOSPC`.
+
+A second factor reduces the usable size below what the PVC requests. When the dump PVC is provisioned with `volumeMode: Filesystem` (the default for `topolvm-hdd` and other Filesystem-capable StorageClasses), CDI reserves a fraction of the requested capacity as filesystem overhead. That fraction is `CDI.spec.config.filesystemOverhead` (effective values surfaced on `CDIConfig.status.filesystemOverhead`), defined as a value between 0 and 1; the CDI CRD documents the default as `0.06` (6%) when unset, and on this platform the effective value on the default StorageClass is `0.06`. A PVC asking for exactly the guest memory size therefore has only `requested * (1 - overhead)` available to libvirt, which is short of the dump file by the overhead margin plus the libvirt header bytes.
+
+## Resolution
+
+Do not rely on `--create-claim`. Pre-create the memory-dump PVC at a size that accounts for both the guest memory and the filesystem-overhead reservation, then pass its name to `virtctl memory-dump` so the auto-sizing path is bypassed entirely.
+
+Size the PVC by the following formula. `MEMORY` is the value declared in `spec.template.spec.domain.memory.guest` (or `spec.template.spec.domain.resources.requests.memory` if `memory.guest` is unset); `OVERHEAD` is the effective `CDIConfig.status.filesystemOverhead` for the StorageClass the dump PVC will land on:
+
+```text
+PVC size = (MEMORY + 100 MiB) * (1 + OVERHEAD)
+```
+
+On a cluster whose CDI `filesystemOverhead` is the default `0.06` (6%), an 8 GiB guest needs:
+
+```text
+PVC size = (8 GiB + 100 MiB) * (1 + 0.06)
+        = 8.1 GiB * 1.06
+        ≈ 8.586 GiB   → round up to 8.6 GiB
+```
+
+If the cluster has been customised with a non-default `filesystemOverhead` per-StorageClass — or if the dump PVC will be `volumeMode: Block`, in which case no overhead is reserved — substitute the corresponding value (or `0`) into the same formula.
+
+Create the PVC explicitly, then trigger the dump against it. Replace `<dump-sc>` with the StorageClass to provision against, `<ns>` with the VM's namespace, and `<vm>` with the VirtualMachine name:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vm-memdump
+  namespace: <ns>
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: <dump-sc>
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 8600Mi   # adjust per the formula above
+```
+
+Apply the manifest and then trigger the dump with `--claim-name` instead of `--create-claim` so the controller routes to the pre-created PVC:
+
+```bash
+kubectl apply -f vm-memdump-pvc.yaml
+virtctl memory-dump <vm> -n <ns> --claim-name vm-memdump
+```
+
+`--claim-name` populates `VirtualMachine.status.memoryDumpRequest.claimName` with the pre-existing PVC; the auto-sizing path that `--create-claim` would take is not invoked, so the PVC capacity is whatever the manifest above declared.
+
+While addressing the immediate dump, also fix the underlying VirtualMachine if it was missing a guest-memory declaration: set `spec.template.spec.domain.memory.guest` (or at minimum `spec.template.spec.domain.resources.requests.memory`) so that any future `--create-claim` invocation has a defined RAM size to base auto-sizing on.
+
+## Diagnostic Steps
+
+Confirm that the failure is the `ENOSPC` path described here rather than an unrelated dump error. Inspect the failure message on the VirtualMachine and the corresponding VMI volume status:
+
+```bash
+# Failure text written by the controller after libvirt reports the dump error
+kubectl get vm <vm> -n <ns> \
+  -o jsonpath='{.status.memoryDumpRequest.message}{"\n"}'
+
+# Per-VMI view of the hot-plugged dump volume and its target file name
+kubectl get vmi <vm> -n <ns> \
+  -o jsonpath='{range .status.volumeStatus[?(@.memoryDumpVolume)]}{.name}{"\t"}{.memoryDumpVolume.targetFileName}{"\n"}{end}'
+```
+
+The message should match the article's signature — `Domain memory dump failed: virError(...) ... Unable to write ...memory.dump: No space left on device`. If the message is different (for example, an `AttachHotplugVolume` failure, a CDI populator failure, or a `permission denied`), this article does not apply.
+
+Check whether the VirtualMachine actually declares guest memory, because that determines whether `--create-claim` will pick a sensible auto-size on the next attempt:
+
+```bash
+kubectl get vm <vm> -n <ns> -o jsonpath='\
+guest:    {.spec.template.spec.domain.memory.guest}{"\n"}\
+requests: {.spec.template.spec.domain.resources.requests.memory}{"\n"}'
+```
+
+If both fields are empty, the VM has no declared RAM size and `--create-claim`'s sizing fallback is the root cause; correct the spec before re-running the dump.
+
+Capture the effective filesystem-overhead value the dump PVC will be subject to. This is the constant that goes into the `(1 + OVERHEAD)` term of the sizing formula and is not necessarily `0.07`; the upstream CDI default is `0.06`, and the effective value can be overridden per-StorageClass:
+
+```bash
+# Effective values per StorageClass, plus the global default
+kubectl get cdiconfig config \
+  -o jsonpath='{.status.filesystemOverhead}{"\n"}'
+
+# CRD-level default (documents "if not defined it is 0.06 (6% overhead)")
+kubectl explain cdi.spec.config.filesystemOverhead | sed -n '1,20p'
+```
+
+Sample output on a cluster using the default overhead with a `topolvm-hdd` StorageClass:
+
+```text
+{"global":"0.06","storageClass":{"topolvm-hdd":"0.06"}}
+```
+
+If the dump PVC was provisioned `volumeMode: Block` rather than `Filesystem`, no overhead is reserved and the sizing formula reduces to `MEMORY + 100 MiB`. Inspect the StorageClass's effective volume mode via the StorageProfile to know which case applies:
+
+```bash
+kubectl get storageprofile <dump-sc> \
+  -o jsonpath='{.status.claimPropertySets}{"\n"}'
+```
+
+A `claimPropertySets` entry of `{"accessModes":["ReadWriteOnce"],"volumeMode":"Filesystem"}` confirms the dump PVC takes the overhead path; an entry of `"volumeMode":"Block"` confirms it does not.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
