### PR TITLE
[networking] TLS passthrough breaks behind an L7 load balancer on ACP ALB ingress

### DIFF
--- a/docs/en/solutions/Passthrough_Ingress_Fails_Behind_a_Layer_7_External_Load_Balancer.md
+++ b/docs/en/solutions/Passthrough_Ingress_Fails_Behind_a_Layer_7_External_Load_Balancer.md
@@ -1,0 +1,132 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A client attempting to reach a workload over an `Ingress` (or equivalent route object) configured for TLS **passthrough** receives connection failures — typically `TLS handshake failed`, `unknown SNI`, or an HTTP `404` from the wrong backend — when the cluster sits behind an external Layer-7 load balancer (cloud ALB/NLB in HTTP/HTTPS mode, F5 in "HTTPS" profile, NGINX in reverse-proxy mode, etc.). The same client succeeds when it bypasses the external LB and hits the cluster ingress directly with a `Host:` override, which tells you the path through the cluster itself is fine.
+
+Indirectly: the workload's own certificate is served on the client's end of the connection, but the SNI extension that reached the cluster proxy either does not match any configured host (hence `404` / `SSL handshake failed`) or was stripped entirely.
+
+## Root Cause
+
+A passthrough route is contractual: the cluster ingress proxy does **not** terminate TLS. It looks at the **SNI** extension of the `ClientHello`, picks the backend, and hands the encrypted bytes straight through. This only works if the client's SNI survives every hop between the client and the cluster ingress proxy intact.
+
+A Layer-7 external load balancer, by definition, terminates TLS at the LB itself: it decrypts, inspects the HTTP layer, and opens a **new** connection toward the backend (the cluster ingress). That new connection carries whatever SNI the LB chooses to set — often the LB's own certificate name, or nothing — and the original client SNI is gone by the time the cluster proxy sees the handshake. The cluster proxy then either routes to a default backend, fails the handshake, or returns `404`.
+
+This is structural: an L7 LB cannot preserve end-to-end TLS with passthrough semantics. Either the LB must run in L4 (TCP) mode, or the cluster-side must switch off passthrough.
+
+## Resolution
+
+ACP's ingress is provided by the **ALB Operator** (`networking/operators/alb_operator`). The same two options apply regardless of the ingress implementation, and the correct choice depends on whether end-to-end TLS is a requirement.
+
+### Preferred (when end-to-end TLS is required): external LB in L4/TCP mode
+
+Keep passthrough on the cluster side, and configure the external LB as a pure TCP forwarder on port `443`. It will not terminate TLS, will not inspect headers, and will not alter SNI — the `ClientHello` reaches the cluster ingress unmodified and the cluster proxy routes it correctly by SNI.
+
+- Cloud NLBs (AWS NLB, GCP TCP LB, Azure Load Balancer) all support a pure L4 listener; use that, not their L7 offering.
+- F5/NGINX: configure a Virtual Server with an `fastL4` profile or a `stream` block, not an HTTP virtual server.
+- Health checks should be TCP to `:443`, not HTTPS, so the LB does not try to do its own TLS handshake against a backend whose certificate may not match the LB's view of the hostname.
+
+The downside of L4 mode is that the external LB cannot do per-path routing, WAF inspection, or HTTP-level metrics; those belong at a different layer.
+
+### Alternative (when L7 external LB is required): switch to edge or reencrypt termination at the cluster
+
+If the external LB must stay in L7 (WAF rules, per-path routing, centralised access logs), change the cluster side so it is also L7 — terminate TLS at the cluster ingress. Two patterns are supported:
+
+- **Edge termination.** The cluster ingress presents its own certificate and speaks plain HTTP to the backend pod. This is the simplest option when the in-cluster network is trusted.
+- **Reencrypt termination.** The cluster ingress terminates the client-side TLS, then opens a new TLS connection to the backend using either the service-CA certificate or one explicitly configured on the Ingress object. This preserves encryption in the pod-to-pod path.
+
+Both modes let the external LB and the cluster ingress independently manage their TLS contexts. Neither needs SNI from the hop upstream, so the original termination happens cleanly.
+
+#### ALB Ingress example: edge termination
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp-edge
+  namespace: myapp
+  annotations:
+    # Bind this Ingress to the named ALB CR.
+    project.cpaas.io/alb-name: cpaas-alb
+spec:
+  tls:
+    - hosts:
+        - myapp.example.com
+      secretName: myapp-tls
+  rules:
+    - host: myapp.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: myapp
+                port:
+                  number: 80
+```
+
+The `tls` block terminates TLS at the ALB using the certificate in `myapp-tls`; the backend is reached as plain HTTP on port 80. Annotations that previously marked the Ingress as passthrough must be removed.
+
+#### ALB Ingress example: reencrypt (backend HTTPS)
+
+When the backend pod speaks HTTPS natively — for instance, a Java service presenting a keystore cert — switch the Ingress to talk TLS to the backend as well. The exact annotation name varies by ALB version; the reference is the ALB CR's annotation documentation. The typical pattern is:
+
+- The Ingress has the same `tls:` block as above (client-side termination).
+- An ALB-specific annotation sets the backend protocol to `https` and optionally pins a trusted-CA certificate for the backend's self-signed cert.
+
+This terminates TLS twice (once at the ALB, once between ALB and backend) but removes the SNI transparency requirement across the external LB hop entirely.
+
+### Fallback: stock Kubernetes Ingress (no ALB)
+
+If the cluster runs a plain Kubernetes Ingress controller (NGINX Ingress, Traefik, etc.), the same two choices apply. NGINX has an `ssl-passthrough` annotation that behaves identically to ALB's passthrough; switching it off and supplying `tls.secretName` puts the controller in edge mode. Traefik has `TLSOption` resources for the same purpose. The external-LB-in-L4 pattern is orthogonal and works for any Ingress controller.
+
+## Diagnostic Steps
+
+Confirm the Ingress is actually in passthrough mode:
+
+```bash
+kubectl get ingress -A -o json \
+  | jq -r '.items[]
+           | select(.metadata.annotations
+                    | to_entries[]?
+                    | select(.key|test("passthrough|ssl-passthrough")))
+           | "\(.metadata.namespace)/\(.metadata.name)"'
+```
+
+Prove the cluster path works in isolation. Bypass the external LB by resolving the hostname directly to the cluster ingress's public IP:
+
+```bash
+curl -vk --resolve myapp.example.com:443:<cluster-ingress-ip> \
+  https://myapp.example.com
+```
+
+A successful response here and a failure through the LB pinpoints the problem to the LB hop.
+
+Confirm what the external LB is doing with TLS. On most clouds this is visible in the LB's listener configuration:
+
+- If the listener uses **HTTPS / HTTP/2** or an L7 product (ALB, Application Gateway, Classic LB `https` listener), the LB is terminating — that matches the failure mode described.
+- If the listener is **TCP / TLS passthrough / L4 NLB**, the LB is forwarding — something else is the problem.
+
+As a quick end-to-end SNI check, capture the `ClientHello` at the cluster ingress (on one of the ingress pod replicas):
+
+```bash
+kubectl exec -it -n <ingress-ns> <ingress-pod> -- \
+  tcpdump -i any -nn -A -s 0 'tcp port 443' | head -n 50
+```
+
+(This requires `tcpdump` in the pod image; otherwise use a debug sidecar or port-forward and capture on the client machine.) If the `SNI=` field in the captured `ClientHello` is empty or matches the external LB's own certificate hostname rather than the client's intended hostname, the diagnosis is confirmed.
+
+Finally, check the cluster-side proxy's own logs for the handshake attempt:
+
+```bash
+kubectl logs -n <ingress-ns> <ingress-pod> --tail=200 | grep -iE "handshake|sni"
+```
+
+Repeated handshake failures correlated with requests from the LB's source IPs make the last mile of evidence: whatever SNI the LB is offering does not match any configured passthrough host in the cluster.

--- a/docs/en/solutions/Passthrough_Ingress_Fails_Behind_a_Layer_7_External_Load_Balancer.md
+++ b/docs/en/solutions/Passthrough_Ingress_Fails_Behind_a_Layer_7_External_Load_Balancer.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Passthrough Ingress Fails Behind a Layer 7 External Load Balancer
 ## Issue
 
 A client attempting to reach a workload over an `Ingress` (or equivalent route object) configured for TLS **passthrough** receives connection failures — typically `TLS handshake failed`, `unknown SNI`, or an HTTP `404` from the wrong backend — when the cluster sits behind an external Layer-7 load balancer (cloud ALB/NLB in HTTP/HTTPS mode, F5 in "HTTPS" profile, NGINX in reverse-proxy mode, etc.). The same client succeeds when it bypasses the external LB and hits the cluster ingress directly with a `Host:` override, which tells you the path through the cluster itself is fine.

--- a/docs/en/solutions/TLS_passthrough_breaks_behind_an_L7_load_balancer_on_ACP_ALB_ingress.md
+++ b/docs/en/solutions/TLS_passthrough_breaks_behind_an_L7_load_balancer_on_ACP_ALB_ingress.md
@@ -1,0 +1,46 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# TLS passthrough breaks behind an L7 load balancer on ACP ALB ingress
+
+## Issue
+
+On Alauda Container Platform the cluster ingress is served by ALB (`alb2`); the running data plane is the `global-alb2` instance in the `cpaas-system` namespace, registered through the `global-alb2` IngressClass with controller `cpaas.io/alb2`, and live Ingresses are fronted by this class. A TLS-passthrough configuration forwards the encrypted TLS connection unchanged to the backend service rather than terminating it at the ingress; on ALB this rides a frontend whose per-port protocol is `tcp` (L4) rather than `https` (L7), so the connection is passed through without being decrypted. When an external HTTP/HTTPS-terminating Layer-7 load balancer sits in front of this ingress, passthrough stops working and client requests fail to reach the intended backend.
+
+## Root Cause
+
+A passthrough frontend on ALB does not terminate TLS; the ALB frontend protocol is what selects L4 versus L7 handling, and on the `alb-nginx` data plane (image `registry.alauda.cn:60080/acp/alb-nginx:v4.3.1`, an nginx/openresty engine) a TCP frontend passes the TLS bytes through untouched. Because the connection is never decrypted at the ingress, the backend is chosen from the TLS Server Name Indication (SNI) value carried in the ClientHello instead of from inspected HTTP headers. ALB binds the backend selection to the requested host: a routing rule (`rules.crd.alauda.io`) matches on `spec.domain` (the hostname), and the matching certificate is keyed to that hostname, so the host/SNI value is what picks the backend and its TLS material.
+
+An external Layer-7 load balancer operating in HTTP/HTTPS mode terminates the incoming TLS connection at the load balancer itself; ALB exhibits the same behavior in its L7 form, where a frontend with `protocol=https` and a bound `certificate_name` terminates TLS at the frontend. When the fronting L7 load balancer terminates TLS and then re-encrypts or forwards the request as a new connection, the original client SNI is lost or altered before traffic reaches the ingress. Since the ingress relies on SNI to select the passthrough backend, a lost or altered SNI leaves the request unmatched and the client request fails.
+
+## Resolution
+
+Keep TLS passthrough end-to-end by ensuring nothing in front of the ingress decrypts the connection. Configure the ALB ingress frontend in TCP/L4 mode so it forwards the encrypted connection unchanged and selects the backend by SNI; the frontend per-port protocol is the knob that determines L4 versus L7 handling, and only the L4/`tcp` form preserves passthrough. Any external load balancer placed in front of the cluster ingress must likewise operate at Layer 4 / TCP so the TLS connection and the client SNI reach ALB intact; a fronting load balancer that terminates and re-encrypts at Layer 7 strips the SNI the ingress needs and breaks passthrough.
+
+The ALB frontend protocol that governs this is observable per port — for example the running `global-alb2` exposes `global-alb2-00080` as `http` and `global-alb2-00443` as `https`; a passthrough port is instead defined with `protocol=tcp` so TLS is forwarded rather than terminated.
+
+Where Layer-7 fronting and TLS termination are an explicit requirement, the alternative is to terminate TLS at the ALB frontend itself rather than passing it through: the per-port frontend protocol is the selector here too — a frontend defined with `protocol=https` and a bound `certificate_name` terminates TLS at the ingress, while a `protocol=tcp` frontend passes it through. The ALB also exposes a configurable SSL strategy field (`alb2.spec.config.defaultSSLStrategy`), but it is the per-port frontend protocol that decides terminate-vs-passthrough. In the L7-terminating mode backend selection no longer depends on an intact end-to-end SNI, because the ingress is the TLS endpoint.
+
+## Diagnostic Steps
+
+Confirm which mode the ingress frontend is in. The ALB frontend's per-port protocol determines whether TLS is terminated (`https`, L7) or passed through (`tcp`, L4); inspect the `global-alb2` frontend definitions in `cpaas-system` to see the protocol bound to the listening port.
+
+```bash
+kubectl get frontend -n cpaas-system -l alb2.cpaas.io/name=global-alb2 \
+  -o custom-columns=NAME:.metadata.name,PORT:.spec.port,PROTOCOL:.spec.protocol
+```
+
+Confirm the routing rule keys backend selection on the hostname. ALB selects the backend by matching the requested host against a rule's `spec.domain`, and the rule's certificate is bound to that same hostname, so a request arriving without the original SNI does not match the host-keyed rule.
+
+```bash
+kubectl get rule.crd.alauda.io -n cpaas-system \
+  -o custom-columns=NAME:.metadata.name,DOMAIN:.spec.domain,CERT:.spec.certificate_name
+```
+
+When the symptom only appears with the external load balancer in the path, the lost or altered SNI introduced by an L7 terminating front is the discriminator: passthrough requires the SNI to survive end to end, and an L7 load balancer that terminates and re-encrypts the connection does not preserve it (kube v1.34.5, ALB data plane `registry.alauda.cn:60080/acp/alb2:v4.3.1`).


### PR DESCRIPTION
新增一篇 ACP KB 文章。
