### PR TITLE
[observability] Recovering Prometheus from TSDB head-chunk and WAL corruption on ACP

### DIFF
--- a/docs/en/solutions/Recover_Prometheus_from_TSDB_head_chunk_corruption.md
+++ b/docs/en/solutions/Recover_Prometheus_from_TSDB_head_chunk_corruption.md
@@ -1,0 +1,122 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+The platform monitoring stack starts emitting `KubeAPIDown` (and other rule-based) alerts even though `kubectl get --raw=/healthz` and the API server pods themselves are healthy. The Prometheus pods log repeated rule-evaluation failures of the form:
+
+```text
+ts=YYYY-MM-DDTHH:MM:SS.XXXZ caller=group.go:NNN level=warn
+  component="rule manager" file=/etc/prometheus/rules/...rules.yaml
+  group=kube-prometheus-node-recording.rules
+  msg="Evaluating rule failed"
+  rule="record: instance:node_cpu:rate:sum
+        expr: sum by (instance) (rate(node_cpu_seconds_total{...}[3m]))"
+  err="corruption in head chunk file /prometheus/chunks_head/00xxx4:
+       checksum mismatch expected:0, actual:dxxxxx6"
+```
+
+Recording- and alerting-rule queries return errors instead of values, so any alert whose expression depends on those rules fires spuriously.
+
+## Root Cause
+
+Prometheus persists the most recent (still-mutable) two-hour window of samples as **head chunks** plus a **write-ahead log (WAL)** under `/prometheus/`. Head chunks are written with a per-chunk checksum so that a partial or torn write can be detected on the next read.
+
+A checksum mismatch in `/prometheus/chunks_head/...` means the head chunk file on disk is no longer self-consistent. Common triggers:
+
+- The Prometheus pod was killed ungracefully (OOM, node power loss, forced eviction) before the in-memory head was flushed.
+- The PV / underlying storage acknowledged a write that was not actually durable (storage latency spike, controller failover, kernel page-cache loss on a host crash).
+- A node-level failure interrupted an in-flight write to a head chunk.
+
+Once a head chunk is corrupt, the rule manager that tries to read it surfaces the error on every evaluation tick, which is what produces the `KubeAPIDown`-style false positives — the alert is not really about the API server, it is about the recording rule that feeds it.
+
+## Resolution
+
+ACP exposes the platform Prometheus through `observability/monitor` (Prometheus Operator + Thanos). The recovery procedure is the same as for any open-source Prometheus deployment: stop the operator from reconciling the StatefulSet, delete the corrupted head and WAL files inside the affected pod, and let Prometheus rebuild from the persisted blocks.
+
+> Important: deleting `chunks_head/` and `wal/` discards the most recent (typically up to two hours) of samples for that replica. Long-term blocks already flushed to disk — and any data already shipped to Thanos / object storage — are preserved. If two Prometheus replicas are running and only one is corrupt, the surviving replica still serves the recent window.
+
+1. **Pause the operator** so it does not fight the manual cleanup. Substitute the namespace where the platform monitoring stack lives (`cpaas-system` for the in-core ACP `observability/monitor` install).
+
+   ```bash
+   NS=cpaas-system          # adjust for your install
+   kubectl -n "$NS" scale deploy prometheus-operator --replicas=0
+   ```
+
+2. **Identify the affected Prometheus pod** and confirm the corruption error on it (do not blindly clean every replica):
+
+   ```bash
+   kubectl -n "$NS" get pods -l app.kubernetes.io/name=prometheus
+   kubectl -n "$NS" logs <prom-pod> -c prometheus --tail=200 \
+     | grep -i "corruption in head chunk"
+   ```
+
+3. **Remove only the corrupted head chunks and WAL** inside the failing pod. The Prometheus container runs as a non-root user; the data directory is `/prometheus`.
+
+   ```bash
+   kubectl -n "$NS" exec -it <prom-pod> -c prometheus -- \
+     sh -c 'rm -rf /prometheus/chunks_head/* /prometheus/wal/*'
+   ```
+
+4. **Restart the Prometheus pod** so the TSDB re-opens cleanly:
+
+   ```bash
+   kubectl -n "$NS" delete pod <prom-pod>
+   ```
+
+5. **Resume the operator** to restore normal reconciliation:
+
+   ```bash
+   kubectl -n "$NS" scale deploy prometheus-operator --replicas=1
+   ```
+
+6. **Verify**. The pod should reach `Ready`, the corruption log line should stop, and rule evaluation should succeed:
+
+   ```bash
+   kubectl -n "$NS" get pod <prom-pod> -w
+   kubectl -n "$NS" logs <prom-pod> -c prometheus --tail=200 \
+     | grep -E 'level=err|head chunk|"Evaluating rule failed"' || echo "clean"
+   ```
+
+If the original `KubeAPIDown` alert was a false positive caused by a broken recording rule, it should resolve on the next evaluation cycle once the rule starts producing values again.
+
+### Prevention
+
+- Provision the Prometheus PV on storage that honors `fsync` and survives node reboots without losing committed pages.
+- Run **two** Prometheus replicas (the operator's default) so a single-replica TSDB corruption does not cause a monitoring outage.
+- Keep Thanos / remote-write export to long-term object storage enabled — the recent-window loss during this recovery is then bounded to whatever has not yet been shipped.
+- Avoid hard-killing Prometheus pods. When draining a node, let the kubelet's graceful termination flush the head.
+
+## Diagnostic Steps
+
+```bash
+# 1. Confirm the alert really comes from a broken recording rule, not the API server.
+kubectl get --raw=/healthz       # API server should answer "ok"
+kubectl get --raw=/readyz?verbose
+
+# 2. Find which Prometheus replicas are logging the corruption.
+NS=cpaas-system
+for p in $(kubectl -n "$NS" get pod -l app.kubernetes.io/name=prometheus \
+             -o name); do
+  echo "==== $p ===="
+  kubectl -n "$NS" logs "$p" -c prometheus --tail=300 \
+    | grep -E 'corruption in head chunk|"Evaluating rule failed"' | tail -5
+done
+
+# 3. Inspect the on-disk layout (sanity check before deleting anything).
+kubectl -n "$NS" exec <prom-pod> -c prometheus -- ls -lh /prometheus
+kubectl -n "$NS" exec <prom-pod> -c prometheus -- ls -lh /prometheus/chunks_head | head
+kubectl -n "$NS" exec <prom-pod> -c prometheus -- ls -lh /prometheus/wal | head
+
+# 4. After recovery, confirm rule evaluation is healthy.
+kubectl -n "$NS" exec <prom-pod> -c prometheus -- \
+  wget -qO- http://localhost:9090/api/v1/rules | \
+  jq '.data.groups[].rules[] | select(.health!="ok")'
+```
+
+If `chunks_head/` keeps growing back into corruption after recovery, the root cause is upstream of Prometheus — investigate the underlying storage class, node stability, and the pod's recent termination history (`kubectl -n "$NS" describe pod <prom-pod>` for `Last State: Terminated` reasons).

--- a/docs/en/solutions/Recover_Prometheus_from_TSDB_head_chunk_corruption.md
+++ b/docs/en/solutions/Recover_Prometheus_from_TSDB_head_chunk_corruption.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Recover Prometheus from TSDB head chunk corruption
 ## Issue
 
 The platform monitoring stack starts emitting `KubeAPIDown` (and other rule-based) alerts even though `kubectl get --raw=/healthz` and the API server pods themselves are healthy. The Prometheus pods log repeated rule-evaluation failures of the form:

--- a/docs/en/solutions/Recovering_Prometheus_from_TSDB_head_chunk_and_WAL_corruption_on_ACP.md
+++ b/docs/en/solutions/Recovering_Prometheus_from_TSDB_head_chunk_and_WAL_corruption_on_ACP.md
@@ -1,0 +1,77 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Recovering Prometheus from TSDB head-chunk and WAL corruption on ACP
+
+## Issue
+
+On Alauda Container Platform, the monitoring stack ships kube-prometheus through the prometheus ModulePlugin in the `cpaas-system` namespace, where the Prometheus CR `kube-prometheus-0` owns the single-replica StatefulSet `prometheus-kube-prometheus-0`. The container runs upstream Prometheus 3.11.3 (image tag `prometheus:v3.11.3-v4.3.4`), so its on-disk TSDB head-chunk and Write-Ahead Log (WAL) format — and the corruption behavior described below — match the generic Prometheus mechanism. When Prometheus reads a TSDB head-chunk file whose recorded checksum does not match the data on disk, it reports a line of the form `corruption in head chunk file <path>: checksum mismatch`, and the affected instance cannot complete startup.
+
+With the head chunk unreadable, the rule manager component inside the prometheus container fails to evaluate its recording and alerting rules and logs `Evaluating rule failed`. Because the failed instance also stops scraping its targets, freshness-based alerts such as the apiserver-health and `up`-style availability rules can fire while scraping is interrupted, even though the scraped components themselves remain healthy.
+
+## Root Cause
+
+The corruption typically follows an ungraceful shutdown of the Prometheus pod, elevated latency on the underlying storage, or a node failure — any of which can leave a head-chunk file partially written so its stored checksum no longer matches its contents. On ACP the TSDB data PVC `prometheus-kube-prometheus-0-db-prometheus-kube-prometheus-0-0` (a `topolvm-hdd` volume) is mounted at `/prometheus`, the path passed as `--storage.tsdb.path`, so the live head-chunk directory `/prometheus/chunks_head/` and the WAL directory `/prometheus/wal/` are the on-disk structures that get damaged. With a 7-day local retention, the persisted TSDB blocks under `/prometheus` are the long-term store, while the head chunk and WAL hold only the most recent, not-yet-flushed samples.
+
+## Resolution
+
+Recovery is to remove the corrupted head-chunk files under `/prometheus/chunks_head/` and the WAL files under `/prometheus/wal/` on the TSDB volume, then bring Prometheus back up so it replays a clean head. The `prometheus` container image is distroless and carries no shell or coreutils, so the deletion cannot be performed with a plain `kubectl exec ... rm`; instead, stop the running Prometheus so the volume is released, then mount the same PVC into a short-lived debug or init container that does have a shell to remove the two directories before Prometheus is brought back up.
+
+The StatefulSet `prometheus-kube-prometheus-0` is not managed directly — it is owned by the prometheus-operator (ownerRef Prometheus/`kube-prometheus-0`, controller), which continuously reconciles its replica count from the Prometheus CR's `spec.replicas`. Scaling the StatefulSet with `kubectl scale statefulset ... --replicas=0` is therefore reverted back up by the operator, which re-attaches the RWO PVC and races the repair. Stop Prometheus by operating on the **Prometheus CR** instead: either set `spec.paused: true` (a valid field on the Prometheus CR) or set its `spec.replicas: 0`. This tears down the running pod and releases the PVC without the operator fighting back.
+
+```bash
+# Stop Prometheus via the operator-managed Prometheus CR (not the StatefulSet).
+kubectl -n cpaas-system patch prometheus kube-prometheus-0 \
+  --type=merge -p '{"spec":{"paused":true,"replicas":0}}'
+```
+
+```yaml
+# Mount the released PVC into a throwaway pod that has a shell, then
+# delete the corrupt head-chunk and WAL directories under /prometheus.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tsdb-repair
+  namespace: cpaas-system
+spec:
+  restartPolicy: Never
+  containers:
+    - name: repair
+      # Any shell-capable image available from your cluster's registry.
+      image: <a-shell-capable-image-from-your-registry>
+      command: ["sh", "-c", "rm -rf /prometheus/chunks_head/* /prometheus/wal/* && echo done"]
+      volumeMounts:
+        - name: db
+          mountPath: /prometheus
+  volumes:
+    - name: db
+      persistentVolumeClaim:
+        # volumeClaimTemplate-generated PVC name for the StatefulSet's data volume.
+        claimName: prometheus-kube-prometheus-0-db-prometheus-kube-prometheus-0-0
+```
+
+After the corrupt files are removed, re-enable Prometheus through the same CR by clearing the pause and restoring the replica count; the operator then recreates the pod, and on startup Prometheus replays a clean head and resumes scraping and rule evaluation.
+
+```bash
+kubectl -n cpaas-system patch prometheus kube-prometheus-0 \
+  --type=merge -p '{"spec":{"paused":false,"replicas":1}}'
+```
+
+Removing the head-chunk and WAL files discards the most recent in-memory samples that had not yet been flushed to a persisted TSDB block, so a gap of recent metrics around the time of the corruption is expected. The long-term data already written to TSDB blocks under `/prometheus` is unaffected and remains queryable after recovery.
+
+## Diagnostic Steps
+
+Confirm the corruption by inspecting the prometheus container logs for the checksum-mismatch line; the presence of `corruption in head chunk` identifies a damaged head chunk as the reason the instance will not start.
+
+```bash
+kubectl -n cpaas-system logs prometheus-kube-prometheus-0-0 -c prometheus \
+  | grep -i "corruption in head chunk"
+```
+
+A matching log line, together with the `Evaluating rule failed` entry from the rule manager, confirms that the failure is TSDB head-chunk corruption rather than a configuration or scheduling problem, and that the file-removal recovery above is the appropriate remediation.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
