### PR TITLE
[security] CSR approval denied — granting the signerName-scoped approve permission on the signers resource

### DIFF
--- a/docs/en/solutions/CSR_Approval_Denied_The_signers_Resource_Must_Name_the_signerName_Explicitly.md
+++ b/docs/en/solutions/CSR_Approval_Denied_The_signers_Resource_Must_Name_the_signerName_Explicitly.md
@@ -1,0 +1,157 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# CSR Approval Denied: The `signers` Resource Must Name the signerName Explicitly
+## Issue
+
+A user with a purpose-built `ClusterRole` that was intended to let them approve CertificateSigningRequests still gets a `Forbidden` response when they run `kubectl certificate approve`:
+
+```text
+Error from server (Forbidden):
+  certificatesigningrequests.certificates.k8s.io "csr-xyz" is forbidden:
+  user not permitted to approve requests with signerName
+  "kubernetes.io/kube-apiserver-client-kubelet"
+```
+
+The role is clearly in effect — the user can `get` and `list` CSRs, can read their details, and can even `update` the `/status` subresource. But the approve call is refused with a message that specifically names the `signerName` carried by the request.
+
+## Root Cause
+
+Kubernetes CSR approval is gated by an extra authorization step that does not apply to other resources. In addition to the permission on the CSR object itself (`update` on `certificatesigningrequests/approval`), the API server also requires that the caller have `approve` permission on the virtual resource **`signers`** — *limited to the specific signerName being approved*.
+
+Concretely, the admission flow is:
+
+1. The API server reads the CSR's `spec.signerName` (for kubelet client certificates this is `kubernetes.io/kube-apiserver-client-kubelet`; for kubelet serving certificates it is `kubernetes.io/kubelet-serving`; for user-defined signers it is whatever the CSR creator wrote).
+2. The API server evaluates a SubjectAccessReview: *"Can this subject `approve` on the virtual resource `signers`, with `resourceNames` containing the exact signerName from step 1?"*
+3. Only if that check returns allowed does the approval proceed.
+
+A `ClusterRole` that grants broad permissions on `certificatesigningrequests` without a corresponding rule for `signers` with the right `resourceNames` passes the first authorization check (the CSR object is reachable) and fails the second (the signerName is not whitelisted). The error message names the signer exactly to make that second failure easy to diagnose.
+
+The same mechanism applies to `sign` on `signers` — a signer controller has to have that verb against the signerName it will sign for. Most operators only need `approve`; signers are a smaller set.
+
+## Resolution
+
+### Build a ClusterRole that names every signer the role should cover
+
+The rule set below lets a holder list CSRs, update status for bookkeeping, approve for two built-in signers, and issue SubjectAccessReviews (useful for tooling that checks its own permissions before acting). Adjust `resourceNames` to the exact set of signers the role should cover — add `kubernetes.io/kube-apiserver-client` for generic client certs, or a custom signer name for a cluster-local CA.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csr-approver
+rules:
+  # 1. Read CSR objects.
+  - apiGroups: [certificates.k8s.io]
+    resources: [certificatesigningrequests]
+    verbs: [get, list, watch]
+
+  # 2. Update the approval / status subresources.
+  - apiGroups: [certificates.k8s.io]
+    resources:
+      - certificatesigningrequests/approval
+      - certificatesigningrequests/status
+    verbs: [update]
+
+  # 3. The signer gate — explicitly list every signerName the role may
+  #    approve requests for. Without this rule, the approve call is
+  #    refused even if rule (2) permits the subresource update.
+  - apiGroups: [certificates.k8s.io]
+    resources: [signers]
+    resourceNames:
+      - kubernetes.io/kube-apiserver-client-kubelet
+      - kubernetes.io/kubelet-serving
+      # - kubernetes.io/kube-apiserver-client    # generic client certs
+      # - my.example.com/internal                # custom cluster signer
+    verbs: [approve]
+
+  # 4. Optional: let the role-holder issue SubjectAccessReviews so tooling
+  #    can pre-flight whether it is allowed to approve before attempting.
+  - apiGroups: [authorization.k8s.io]
+    resources: [subjectaccessreviews]
+    verbs: [create]
+```
+
+Apply and bind to the target principal:
+
+```bash
+kubectl apply -f csr-approver.yaml
+
+cat <<'EOF' | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csr-approver-binding
+subjects:
+  - kind: User
+    name: alice@example.com
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: csr-approver
+  apiGroup: rbac.authorization.k8s.io
+EOF
+```
+
+`ServiceAccount` subjects follow the same pattern — change `kind: User` to `kind: ServiceAccount` with a `namespace` field. `Group` subjects (for example, federating to an external IdP group) replace the subject list altogether.
+
+### Verify the signer gate specifically
+
+A generic `kubectl auth can-i approve certificatesigningrequests` does **not** exercise the signer gate — it only checks the CSR object verb. The signer check needs a resource-name-qualified query. `kubectl auth can-i` uses the slash-form `<resource>/<name>` to express resource-name binding (there is no `--resource-name` flag):
+
+```bash
+kubectl auth can-i approve \
+  signers.certificates.k8s.io/kubernetes.io/kube-apiserver-client-kubelet
+```
+
+Return value `yes` means the signer gate will pass for that exact signerName. Repeat for every signerName the role should cover. If a CSR in production carries a signerName not in the role's `resourceNames`, its approval will be rejected regardless of what the other rules say.
+
+(Note: the server reports a warning `signers is not a real resource type` because `signers` is a virtual gate registered for SubjectAccessReview, not a stored CRD. The warning is informational; the `yes` / `no` result is authoritative.)
+
+Separately, some platforms ship ClusterRoleBindings that grant `system:authenticated` broad access (for example a default "view" or "self-readonly" role). Those bindings do not themselves grant the signer-approve verb, but they can obscure test results when probing with `kubectl auth can-i --as=<user>` — the probe sees the aggregate of the user's bindings. Use a narrow `--as=<service-account>` in a test namespace to confirm the `csr-approver` role's effect in isolation.
+
+### Principle of least privilege
+
+List only the signerNames the role actually needs. `resourceNames: ["*"]` would grant approve on every signer in the cluster — including any custom signer added later — and is rarely what is intended. If a role legitimately needs to approve every signer, list them explicitly and update the role when a new signer is introduced.
+
+## Diagnostic Steps
+
+When an approval call is rejected, capture the signerName the CSR carries and compare it against the role's `resourceNames`:
+
+```bash
+kubectl get csr <csr-name> -o jsonpath='{.spec.signerName}{"\n"}'
+```
+
+Common built-in signer names:
+
+| signerName | Used for |
+|---|---|
+| `kubernetes.io/kube-apiserver-client-kubelet` | Kubelet client certificates rotated via CSR |
+| `kubernetes.io/kubelet-serving` | Kubelet serving certificates (metrics / logs endpoint) |
+| `kubernetes.io/kube-apiserver-client` | Generic in-cluster client certs |
+| `kubernetes.io/legacy-unknown` | Any signer not otherwise specified |
+
+Custom signers (namespace-local CAs, external signers) carry whatever signerName the CSR creator wrote; they must be named literally in the approver's `resourceNames`.
+
+Inspect the role actually in effect:
+
+```bash
+kubectl get clusterrole csr-approver -o yaml
+```
+
+Confirm a rule exists with `apiGroups: [certificates.k8s.io]`, `resources: [signers]`, `verbs: [approve]`, and `resourceNames:` listing the needed signerName. A rule that has every part right except `resourceNames` is the exact shape that produces the error message in the issue.
+
+After fixing the role, re-run the approval:
+
+```bash
+kubectl certificate approve <csr-name>
+kubectl get csr <csr-name> -o jsonpath='{.status.conditions}{"\n"}' | jq
+```
+
+A successful approval adds an `Approved` condition; the signer controller then issues the certificate and the `status.certificate` field fills in.

--- a/docs/en/solutions/CSR_approval_denied_granting_the_signerName_scoped_approve_permission_on_the_signers_resource.md
+++ b/docs/en/solutions/CSR_approval_denied_granting_the_signerName_scoped_approve_permission_on_the_signers_resource.md
@@ -1,0 +1,83 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# CSR approval denied — granting the signerName-scoped approve permission on the signers resource
+
+## Issue
+
+On Alauda Container Platform (Kubernetes server v1.34.5), an attempt to approve a `CertificateSigningRequest` (`certificates.k8s.io/v1`, a cluster-scoped resource) fails for a user or service account that otherwise appears to have certificate-related access. The approval is rejected with a `Forbidden` error of the form `certificatesigningrequests.certificates.k8s.io "csr-xxx" is forbidden: user not permitted to approve requests with signerName "<signerName>"`, where `<signerName>` is the signer named on the CSR (for example `kubernetes.io/kube-apiserver-client-kubelet`). The error specifically calls out the signer name rather than a generic access denial.
+
+## Root Cause
+
+CSR approval is gated by a dedicated authorization check on a virtual `signers` resource rather than on the `certificatesigningrequests` resource alone. The `signers` resource lives only in apiGroup `certificates.k8s.io` as an RBAC authorizer construct: it does not appear among the cluster's API resources — only `certificatesigningrequests` is listed there — and exists purely so RBAC can gate approval per signer.
+
+The grant that authorizes approval takes the shape `apiGroups: [certificates.k8s.io]`, `resources: [signers]`, `verbs: [approve]`, with `resourceNames` pinning the signer. The `resourceNames` list must contain the exact, literal `signerName` string of the CSR being approved; approval is authorized only for the signer(s) named there.
+
+A role whose `signers` rule does not list the CSR's `signerName` under `resourceNames` is unauthorized to approve that CSR, which is the mechanism behind the `user not permitted to approve requests with signerName` denial. A wildcard or an omitted `signerName` does not authorize approval of any signer — each `signerName` to be approved must be listed explicitly. Default per-signer approver ClusterRoles ship for the well-known signers, each scoped to a single signer (for example, the kubelet-serving approver role names only `kubernetes.io/kubelet-serving` and is a separate role from the kubelet-client approver).
+
+## Resolution
+
+Grant approval through a custom `ClusterRole` that carries the complete set of rules the approval flow requires. Beyond `approve` on the signer, the role needs `get`/`list`/`watch` on `certificatesigningrequests`, `update` on both the `certificatesigningrequests/approval` and `certificatesigningrequests/status` subresources, and `create` on `subjectaccessreviews` in apiGroup `authorization.k8s.io` (the SubjectAccessReview API, `authorization.k8s.io/v1`, that the signer authorizer issues during approval). Each `signerName` that should be approvable must be listed in the `resourceNames` of the `signers` rule.
+
+The following `ClusterRole` authorizes approval of CSRs for the `kubernetes.io/kube-apiserver-client-kubelet` signer; add further `resourceNames` entries to cover additional signers:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csr-approver
+rules:
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["certificatesigningrequests"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["certificatesigningrequests/approval", "certificatesigningrequests/status"]
+    verbs: ["update"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["signers"]
+    verbs: ["approve"]
+    resourceNames: ["kubernetes.io/kube-apiserver-client-kubelet"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+```
+
+Bind the `ClusterRole` to the user or service account with a `ClusterRoleBinding`, then retry the approval:
+
+```bash
+kubectl certificate approve csr-xxx
+```
+
+The single most common cause of the denial is a `signers` rule whose `resourceNames` omits the CSR's exact `signerName`; correcting that one field — to the literal signer string, with no wildcard — is what authorizes the approval.
+
+## Diagnostic Steps
+
+First read the CSR to obtain the exact `signerName` that the `resourceNames` entry must match:
+
+```bash
+kubectl get csr csr-xxx -o jsonpath='{.spec.signerName}'
+```
+
+Inspect the requesting subject's effective rules and confirm the `signers` rule lists that literal signer string under `resourceNames`. The `update` permission on the approval subresource can be checked directly, and that check is reliable:
+
+```bash
+kubectl auth can-i update certificatesigningrequests/approval
+```
+
+The signer-approval permission is harder to verify mechanically. `kubectl auth can-i approve signers --subresource=<signerName>` runs and returns a yes/no verdict, but its output is unreliable for confirming this grant: it emits a warning that the server has no resource type `signers`, and an impersonation-based check (`--as=<user>`) can return `yes` independent of whether the impersonated subject actually holds the signerName-scoped grant. Treat the `can-i` verdict as inconclusive here and confirm signer approval by reading the ClusterRole's rules directly instead:
+
+```bash
+kubectl auth can-i approve signers --subresource=kubernetes.io/kube-apiserver-client-kubelet
+```
+
+Because the `auth can-i` probe cannot confirm the signer grant, verify it by reading the bound `ClusterRole` directly and checking that the `signers` rule's `resourceNames` contains the CSR's exact `signerName`; a missing or mismatched entry is the authoritative explanation for the `Forbidden` denial:
+
+```bash
+kubectl get clusterrole csr-approver -o jsonpath='{.rules}'
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章。
