### PR TITLE
[virtualization] VMI and virt-launcher pod not removed when a runStrategy:Manual VirtualMachine is shut down from the guest OS (CNV-71224) on ACP

### DIFF
--- a/docs/en/solutions/Guest_Initiated_Shutdown_Leaves_VMI_virt_launcher_Behind_When_runStrategy_Manual.md
+++ b/docs/en/solutions/Guest_Initiated_Shutdown_Leaves_VMI_virt_launcher_Behind_When_runStrategy_Manual.md
@@ -1,0 +1,162 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A VirtualMachine configured with `spec.runStrategy: Manual` is shut down from **inside the guest OS** (a `shutdown -h now`, a Windows Start-menu shutdown, or a power-button event from the guest). The `VirtualMachine` object correctly transitions to `Stopped`, but the companion `VirtualMachineInstance` and the `virt-launcher` pod are **not** cleaned up — they linger in `Succeeded` / `Completed` state indefinitely, holding node resources (memory allocations, disk attachments) and occupying pod slots:
+
+```text
+$ kubectl get vm
+NAME             STATUS     READY
+vm-1-example     Stopped    False
+
+$ kubectl get vmi
+NAME             PHASE
+vm-1-example     Succeeded     # <-- should have disappeared
+
+$ kubectl get pod -l kubevirt.io/domain=vm-1-example
+NAME                            STATUS
+virt-launcher-vm-1-...-jtx45    Completed     # <-- same
+```
+
+External shutdown (`virtctl stop`, deleting the VMI) does clean everything up. The issue is specifically with the **guest-initiated** path combined with `runStrategy: Manual`.
+
+## Root Cause
+
+A VM's lifecycle in KubeVirt is coordinated by the controller watching the `runStrategy`:
+
+- `Always` / `RerunOnFailure`: the controller keeps a VMI alive; after guest shutdown, it reaps the `Succeeded` VMI and launches a new one (or stops, depending on the strategy).
+- `Halted`: the controller keeps the VMI torn down; any attempt to start it is reverted.
+- **`Manual`**: the controller leaves the decision to operator actions (`virtctl start/stop`). It does **not** reap a `Succeeded` VMI on its own, because doing so would conflict with the "only the operator decides" contract implicit in `Manual`.
+
+The bug is in the reconciliation of `Manual`: when the guest shuts itself down, the VMI transitions to `Succeeded` through kubelet's normal pod-phase reporting, but neither the VM controller nor the VMI controller deletes the VMI object. The `VirtualMachine`'s `status.ready: False` and `STATUS: Stopped` reflects that the guest is no longer running, but the underlying VMI / virt-launcher sits around — no one has the authority (or the code path) to remove it.
+
+Engineering has a fix tracked in KubeVirt; until it lands, the VMI can be deleted manually to release the resources, or the `runStrategy` can be changed to one that does reap automatically.
+
+## Resolution
+
+### Workaround 1 — delete the VMI manually after each guest shutdown
+
+After any in-guest shutdown of a `runStrategy: Manual` VM, the operator (or a tool on their behalf) must delete the stale VMI:
+
+```bash
+kubectl -n <ns> delete vmi <vm-name>
+```
+
+Deleting the VMI also reaps the `virt-launcher` pod. The `VirtualMachine` object's status stays `Stopped`, which is correct.
+
+Subsequent `virtctl start <vm>` creates a fresh VMI without interference.
+
+### Workaround 2 — use a different runStrategy
+
+If the operational model does not require `Manual`-level control, switch to one of the auto-reaping strategies:
+
+- `RerunOnFailure` — the VM restarts only after a **failure** exit, not after a clean shutdown. A clean guest shutdown leaves the VM `Stopped`, and the controller cleans up the VMI as part of the transition.
+
+  ```yaml
+  spec:
+    runStrategy: RerunOnFailure
+  ```
+
+- `Always` — the VM always has a running VMI; an in-guest shutdown triggers a fresh restart. Not appropriate if the workload expects "stay down until operator starts me".
+
+- `Halted` — the VM is forcibly kept off until an operator action changes the strategy back. Not usually what `Manual` users want, but viable if "stay down" is the normal state.
+
+Pick the strategy that matches the intended VM lifecycle. `Manual` is the most permissive but carries this cleanup gap.
+
+### Workaround 3 — script the cleanup
+
+If the organisation needs `runStrategy: Manual` semantics but does not want operators to hand-delete VMIs every time a guest shuts down, a small controller / CronJob can do the job:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: vmi-succeeded-reaper
+  namespace: cluster-virt
+spec:
+  schedule: "*/5 * * * *"
+  successfulJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: vmi-reaper
+          restartPolicy: OnFailure
+          containers:
+            - name: reap
+              image: bitnami/kubectl:latest
+              command: ["sh","-c"]
+              args:
+                - |
+                  # Delete any VMI whose phase is Succeeded and whose parent
+                  # VM has runStrategy=Manual with status.ready=false.
+                  kubectl get vmi -A -o json | \
+                    jq -r '.items[]
+                           | select(.status.phase=="Succeeded")
+                           | "\(.metadata.namespace) \(.metadata.name)"' | \
+                  while read -r ns name; do
+                    rs=$(kubectl -n "$ns" get vm "$name" \
+                           -o jsonpath='{.spec.runStrategy}' 2>/dev/null || true)
+                    if [ "$rs" = "Manual" ]; then
+                      echo "Deleting stale VMI $ns/$name"
+                      kubectl -n "$ns" delete vmi "$name" --wait=false
+                    fi
+                  done
+```
+
+Give the `vmi-reaper` ServiceAccount the RBAC needed for the listed operations, then schedule. Five minutes is a reasonable cadence — frequent enough to release resources before a second VM lifecycle collision, infrequent enough that the job does not add load.
+
+### Stop using this workaround once the fix lands
+
+Track the KubeVirt / VM-operator release notes and, once a version with the fix is available, upgrade and remove the CronJob / reaper. The upgraded controller will reap automatically.
+
+## Diagnostic Steps
+
+Confirm the symptom:
+
+```bash
+NS=<vm-ns>; VM=<vm-name>
+kubectl -n "$NS" get vm "$VM" \
+  -o jsonpath='{.spec.runStrategy}{"\t"}{.status.ready}{"\t"}{.status.printableStatus}{"\n"}'
+# Manual	false	Stopped
+
+kubectl -n "$NS" get vmi "$VM" -o jsonpath='{.status.phase}{"\n"}'
+# Succeeded      <-- leaked
+
+kubectl -n "$NS" get pod -l kubevirt.io/domain="$VM" \
+  -o jsonpath='{.items[*].status.phase}{"\n"}'
+# Completed      <-- same
+```
+
+`Stopped` on the VM plus `Succeeded`/`Completed` on the VMI/pod plus `runStrategy: Manual` is this bug.
+
+Check for guest shutdown events in the VMI's conditions to distinguish from an infrastructure-side failure:
+
+```bash
+kubectl -n "$NS" get vmi "$VM" -o json | \
+  jq '.status.conditions[] | {type, status, reason, message}'
+```
+
+A condition reasons of `GuestPowerRequestReceived` or similar (depending on the agent's reporting) confirms the shutdown originated from inside the guest. Infrastructure-initiated shutdowns (node failure, live-migration failure) produce different reasons and are not this note.
+
+After applying the workaround (manual delete or CronJob reaper), re-check:
+
+```bash
+kubectl -n "$NS" get vmi "$VM" 2>&1 | grep -c "not found"
+# 1 = the VMI is gone
+```
+
+And confirm the VM can be restarted cleanly:
+
+```bash
+virtctl -n "$NS" start "$VM"
+kubectl -n "$NS" get vmi "$VM" -w
+```
+
+A fresh VMI reaches `Running` as expected. Without the workaround, the start command would have to contend with the stale VMI left over from the last shutdown.

--- a/docs/en/solutions/Guest_Initiated_Shutdown_Leaves_VMI_virt_launcher_Behind_When_runStrategy_Manual.md
+++ b/docs/en/solutions/Guest_Initiated_Shutdown_Leaves_VMI_virt_launcher_Behind_When_runStrategy_Manual.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Guest-Initiated Shutdown Leaves VMI / virt-launcher Behind When `runStrategy: Manual`
 ## Issue
 
 A VirtualMachine configured with `spec.runStrategy: Manual` is shut down from **inside the guest OS** (a `shutdown -h now`, a Windows Start-menu shutdown, or a power-button event from the guest). The `VirtualMachine` object correctly transitions to `Stopped`, but the companion `VirtualMachineInstance` and the `virt-launcher` pod are **not** cleaned up — they linger in `Succeeded` / `Completed` state indefinitely, holding node resources (memory allocations, disk attachments) and occupying pod slots:

--- a/docs/en/solutions/VMI_and_virt_launcher_pod_not_removed_when_a_runStrategyManual_VirtualMachine_is_shut_down_from_the_guest_OS_CNV_71224_on_ACP.md
+++ b/docs/en/solutions/VMI_and_virt_launcher_pod_not_removed_when_a_runStrategyManual_VirtualMachine_is_shut_down_from_the_guest_OS_CNV_71224_on_ACP.md
@@ -1,0 +1,101 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# VMI and virt-launcher pod not removed when a runStrategy:Manual VirtualMachine is shut down from the guest OS (CNV-71224) on ACP
+
+## Issue
+
+On Alauda Container Platform with KubeVirt installed via the HCO operator (`kubevirt-hyperconverged-operator.v4.3.6` CSV, `kubevirts.kubevirt.io/kubevirt-kubevirt-hyperconverged` reporting `observedKubeVirtVersion=v1.7.0-alauda.2`, virt-controller image `build-harbor.alauda.cn/3rdparty/kubevirt/virt-controller:v1.7.0-alauda.2`), a `VirtualMachine` configured with `.spec.runStrategy: Manual` is started and stopped via the `virtualmachines/start` and `virtualmachines/stop` subresources on `subresources.kubevirt.io/v1` rather than by an auto-restart policy — virt-controller logs the explicit action as `Starting VM due to start request and runStrategy: Manual` and creates the `VirtualMachineInstance` only when the `/start` subresource is invoked.
+
+Symptom: when the guest OS of such a `runStrategy: Manual` VM is shut down from inside the guest (for example by running `poweroff` in the guest session), the `VirtualMachine` object correctly reports `STATUS=Stopped` / `READY=False`, but the associated `VirtualMachineInstance` is not deleted and remains with `PHASE=Succeeded`, and the matching `virt-launcher-<vmi>-<hash>` pod is not deleted either and remains with `STATUS=Completed`. The VM's reported state and its actual runtime objects are inconsistent at the same point in time, exactly as the upstream bug CNV-71224 describes:
+
+```
+NAME                AGE     STATUS    READY
+vm-manual-demo   5m15s   Stopped   False
+
+NAME                                    READY   STATUS      RESTARTS   AGE
+virt-launcher-vm-manual-demo-6jxpk   0/3     Completed   0          4m7s
+
+NAME                AGE    PHASE       IP         NODENAME          READY
+vm-manual-demo   4m8s   Succeeded   10.0.2.2   192.168.136.179   False
+```
+
+## Root Cause
+
+This is an upstream KubeVirt defect tracked as CNV-71224: under `.spec.runStrategy: Manual`, when the guest itself initiates the shutdown (rather than a `stop` subresource call from outside), the virt-controller transitions the `VirtualMachineInstance` to `PHASE=Succeeded` and emits the `Stopped: The VirtualMachineInstance was shut down` event, but does not subsequently delete the VMI. Because the `virt-launcher` pod's `metadata.ownerReferences[0]` points at the VMI (`apiVersion: kubevirt.io/v1, kind: VirtualMachineInstance, controller: true, blockOwnerDeletion: true`), the launcher pod cannot be garbage-collected while the VMI persists, so it lingers as `Completed`. The VM-level `printableStatus` is reconciled from the absence of a Running VMI and correctly reports `Stopped`, which produces the visible state inconsistency.
+
+ACP ships this code path unchanged — the virt-controller image on the cluster is a v1.7.0-alauda.2 rebuild of upstream KubeVirt 1.7.0, so the same reconcile path applies and the behavior reproduces with a CentOS 7.9 containerDisk VM that runs `/sbin/poweroff` via the qemu-guest-agent. Across a 90-second observation window after the in-guest poweroff, the VMI stayed at `PHASE=Succeeded` and the virt-launcher pod stayed at `STATUS=Completed`; the virt-controller logs contain no delete/gc/restart entries for that VMI between the `Stopped` event and the end of the window. The Manual run strategy itself is working correctly here — virt-controller takes no action on a Manual VM after its VMI Succeeded, which is the intended "manual" semantics; the defect is the missing cleanup of the runtime objects, not unwanted auto-restart.
+
+## Resolution
+
+There is no in-cluster configuration that disables the orphan-on-guest-shutdown behavior — the fix has to land in the KubeVirt virt-controller code (CNV-71224). Until that fix is included in the deployed KubeVirt build, clean up the leftover `VirtualMachineInstance` after a guest-initiated shutdown so the `virt-launcher` pod can be garbage-collected and so the VM can be started again. Because the launcher pod has the VMI as its controller `ownerReference`, deleting the VMI is sufficient — Kubernetes garbage collection will then remove the pod automatically:
+
+```bash
+kubectl -n <vm-namespace> delete vmi <vm-name>
+```
+
+To start the same `runStrategy: Manual` VM again after cleanup, issue the start subresource (the VM's normal Manual lifecycle entry point; on this build the start endpoint accepts a PUT against the `subresources.kubevirt.io/v1` aggregated API):
+
+```bash
+# via virtctl when available:
+virtctl start <vm-name> -n <vm-namespace>
+
+# or directly against the aggregated API:
+curl -sk -X PUT -H "Authorization: Bearer <token>" -H "Content-Type: application/json" -d '{}' \
+  "https://<apiserver>/apis/subresources.kubevirt.io/v1/namespaces/<vm-namespace>/virtualmachines/<vm-name>/start"
+```
+
+When CNV-71224 is resolved in a future KubeVirt build (in upstream KubeVirt or in a later `v1.7.0-alauda.*` rebuild shipped with a newer ACP virtualization CSV), the VMI and virt-launcher pod will be removed automatically on guest-initiated shutdown and the manual `delete vmi` step will not be required.
+
+## Diagnostic Steps
+
+Confirm the KubeVirt build and the virt-controller image that actually owns this lifecycle. On ACP, KubeVirt lives in the `kubevirt` namespace, and the CSV name is `kubevirt-hyperconverged-operator.v4.3.*`:
+
+```bash
+kubectl get kubevirt -n kubevirt \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"  operatorVersion="}{.status.operatorVersion}{"  observed="}{.status.observedKubeVirtVersion}{"\n"}{end}'
+kubectl get csv -n kubevirt | grep hyperconverged
+kubectl get deployment -n kubevirt virt-controller \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+```
+
+Confirm the VM's effective run strategy. Under `.spec.runStrategy: Manual` the VM should only start in response to an explicit `start` subresource call, never on its own; this is what makes the post-shutdown orphan persist instead of being recycled by an auto-restart:
+
+```bash
+kubectl -n <vm-namespace> get vm <vm-name> \
+  -o jsonpath='{"runStrategy="}{.spec.runStrategy}{"  status="}{.status.printableStatus}{"  ready="}{.status.ready}{"\n"}'
+```
+
+Inspect the symptom triad after the guest has been shut down from inside (for example by running `poweroff` in the guest OS or via the qemu-guest-agent). The VirtualMachine status, VMI phase, and virt-launcher pod status are the three diagnostic surfaces the article calls out:
+
+```bash
+kubectl -n <vm-namespace> get vm <vm-name>
+kubectl -n <vm-namespace> get vmi <vm-name>
+kubectl -n <vm-namespace> get pod -l kubevirt.io=virt-launcher
+```
+
+A reproduction shows the VM at `STATUS=Stopped READY=False`, the VMI still present at `PHASE=Succeeded` with `Ready=False(reason=PodTerminating)` in `.status.conditions`, and the launcher pod still present at `STATUS=Completed`. The `kubectl get events` stream for the namespace contains the matching `Normal Stopped The VirtualMachineInstance was shut down` and `Normal Deleted Signaled Deletion` entries from the VMI controller, despite the VMI object remaining.
+
+Confirm that the launcher pod's persistence is a consequence of the VMI orphan (not an independent pod-GC issue) by inspecting its `ownerReferences` — the pod is owned by the VMI as `controller: true`, so it cannot be garbage-collected while the VMI exists:
+
+```bash
+kubectl -n <vm-namespace> get pod -l kubevirt.io=virt-launcher \
+  -o jsonpath='{.items[0].metadata.ownerReferences}{"\n"}'
+```
+
+Confirm that the virt-controller is not attempting (and failing) some cleanup, which would point at a different problem. With CNV-71224, the controller's logs contain the `Stopped` / `Signaled Deletion` entries for the VMI but no subsequent `delete` / `garbage` / `restart` actions on that VMI — the absence of those lines is the observable signature on this build:
+
+```bash
+kubectl logs -n kubevirt deployment/virt-controller --tail=500 \
+  | grep <vm-name>
+```
+
+## References
+
+- Upstream defect tracker: CNV-71224 — Guest-initiated shutdown does not remove VMI and virt-launcher pod when runStrategy is set to Manual.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
