### PR TITLE
[observability] Configure a Custom CA Certificate for Alertmanager's SMTP Email Receiver on ACP

### DIFF
--- a/docs/en/solutions/Configure_a_Custom_CA_Certificate_for_Alertmanagers_SMTP_Email_Receiver.md
+++ b/docs/en/solutions/Configure_a_Custom_CA_Certificate_for_Alertmanagers_SMTP_Email_Receiver.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Configure a Custom CA Certificate for Alertmanager's SMTP Email Receiver
 ## Issue
 
 Alertmanager is configured to send notifications through an internal SMTP relay that presents a TLS certificate signed by a private (in-house) Certificate Authority. Notifications never arrive at their inbox; the Alertmanager pod log shows a TLS handshake failure against the SMTP server:

--- a/docs/en/solutions/Configure_a_Custom_CA_Certificate_for_Alertmanagers_SMTP_Email_Receiver.md
+++ b/docs/en/solutions/Configure_a_Custom_CA_Certificate_for_Alertmanagers_SMTP_Email_Receiver.md
@@ -1,0 +1,177 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+Alertmanager is configured to send notifications through an internal SMTP relay that presents a TLS certificate signed by a private (in-house) Certificate Authority. Notifications never arrive at their inbox; the Alertmanager pod log shows a TLS handshake failure against the SMTP server:
+
+```text
+level=error ts=... caller=dispatch.go... component=dispatcher
+  msg="Notify for alerts failed"
+  ... err="... x509: certificate signed by unknown authority"
+```
+
+The SMTP server is reachable (TCP connects succeed), the credentials are correct, and the same mail server works for other clients that trust the in-house CA. What Alertmanager is missing is a path from its container's CA-trust store to the certificate chain the SMTP server presents.
+
+## Root Cause
+
+The Alertmanager container image ships with the default public CA bundle. Private CAs — including whatever the organisation uses to sign internal service certificates — are not in that bundle. When Alertmanager opens a TLS connection to the SMTP server, its standard library's verifier walks up the presented chain, does not find the private root in its trust store, and aborts with `x509: certificate signed by unknown authority`.
+
+Fixing this needs two steps working together:
+
+1. The private CA bundle has to be **available to the pod**. It is delivered as a `Secret` mounted into the Alertmanager container by the monitoring stack's operator.
+2. The SMTP receiver in Alertmanager's own configuration has to **point at the mounted path** as its `ca_file`.
+
+Either step alone is not enough. If the Secret is mounted but the receiver does not reference it, Alertmanager keeps using the default bundle. If the receiver references a path but no Secret mounts there, the connection fails earlier (file not found) rather than with the cleaner `unknown authority` error.
+
+## Resolution
+
+Three objects, applied in order.
+
+### Step 1 — create the CA Secret in the monitoring namespace
+
+Gather the full private-CA certificate (the root, and any intermediate certificates needed to chain up to the SMTP server's leaf) into a single `ca.crt` file and create a Secret in the monitoring namespace:
+
+```bash
+# Validate the file chain before creating the Secret.
+openssl crl2pkcs7 -nocrl -certfile /path/to/internal-ca.crt | \
+  openssl pkcs7 -print_certs -noout | head -20
+
+kubectl -n cpaas-monitoring create secret generic custom-email-ca \
+  --from-file=ca.crt=/path/to/internal-ca.crt
+```
+
+The Secret name (`custom-email-ca`) is what the monitoring stack's configuration references in Step 2.
+
+### Step 2 — tell the monitoring stack to mount the Secret into Alertmanager
+
+The monitoring stack's central config (`cluster-monitoring-config` ConfigMap or the platform's equivalent CR) accepts a list of additional Secrets to mount. Add the Secret from Step 1:
+
+```bash
+kubectl -n cpaas-monitoring edit configmap cluster-monitoring-config
+```
+
+Modify (or add) the `alertmanagerMain` block so it includes:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: cpaas-monitoring
+data:
+  config.yaml: |
+    alertmanagerMain:
+      secrets:
+        - custom-email-ca
+```
+
+The monitoring operator reconciles the change and rolls the Alertmanager pods. After the roll, each pod mounts the Secret's contents at a predictable path:
+
+```text
+/etc/alertmanager/secrets/<secret-name>/<key-in-secret>
+```
+
+So the `ca.crt` key of the `custom-email-ca` Secret appears inside the pod at:
+
+```text
+/etc/alertmanager/secrets/custom-email-ca/ca.crt
+```
+
+Verify the mount before moving on:
+
+```bash
+POD=$(kubectl -n cpaas-monitoring get pod -l app.kubernetes.io/name=alertmanager \
+        -o jsonpath='{.items[0].metadata.name}')
+kubectl -n cpaas-monitoring exec "$POD" -c alertmanager -- \
+  ls -l /etc/alertmanager/secrets/custom-email-ca/
+# -rw-------  1  nobody  nobody  2100 ... ca.crt
+```
+
+### Step 3 — point the email receiver at the mounted CA
+
+Alertmanager's own configuration lives in a Secret (conventionally named `alertmanager-main` or `alertmanager-<name>` depending on the operator). The email receiver's `tls_config.ca_file` must point at the Step-2 mount path:
+
+```yaml
+# Inside the alertmanager.yaml that the alertmanager Secret holds.
+receivers:
+  - name: email-receiver
+    email_configs:
+      - to:   admin@example.com
+        from: alertmanager@example.com
+        smarthost: smtp.example.com:587
+        auth_username: alertmanager
+        auth_password: <smtp-password>
+        require_tls: true
+        tls_config:
+          ca_file: /etc/alertmanager/secrets/custom-email-ca/ca.crt
+          insecure_skip_verify: false
+```
+
+`require_tls: true` forces the TLS handshake. `insecure_skip_verify: false` (or leaving the key out entirely, which defaults to `false`) makes sure the handshake actually verifies against `ca_file`.
+
+Depending on how the monitoring stack exposes Alertmanager configuration, update `alertmanager.yaml` through the operator's config surface rather than editing the Secret directly (the operator will reconcile direct edits back). Typical path is:
+
+```bash
+# Via the monitoring stack's user-workload configuration ConfigMap / CR.
+kubectl -n cpaas-monitoring edit configmap alertmanager-config
+```
+
+After the update reconciles, send a test alert (silence and unsilence a low-severity rule, or use Alertmanager's API to fire a dummy notification) and confirm the SMTP relay now receives the message.
+
+### TLS-level pitfalls to avoid
+
+- **Do not rely on `insecure_skip_verify: true`**. It makes the error disappear but also disables authentication of the SMTP server — a private network SMTP compromise can then impersonate the relay.
+- **Do include the full chain**, not just the root. If the SMTP server's leaf is signed by an intermediate, include the intermediate in the `ca.crt` file — the verifier walks only from the presented chain upward, so the intermediate needs to be present somewhere.
+- **Watch the file mode on the mount**. If the operator mounts the Secret with a mode the Alertmanager user cannot read, the `ca_file` read fails silently. The monitoring operator handles this automatically on most builds; if not, verify with `ls -l` inside the pod.
+
+## Diagnostic Steps
+
+Confirm the error is the TLS trust failure specifically (not a different email issue):
+
+```bash
+POD=$(kubectl -n cpaas-monitoring get pod -l app.kubernetes.io/name=alertmanager \
+        -o jsonpath='{.items[0].metadata.name}')
+kubectl -n cpaas-monitoring logs "$POD" -c alertmanager --tail=500 | \
+  grep -E 'Notify for alerts failed|unknown authority|x509'
+```
+
+`unknown authority` confirms this note. A different error (authentication failure, timeouts, connection refused) points elsewhere and needs a different fix.
+
+Check that Step 1 and Step 2 are both in place:
+
+```bash
+# Secret exists in the monitoring ns.
+kubectl -n cpaas-monitoring get secret custom-email-ca -o jsonpath='{.data}{"\n"}' | jq 'keys'
+# ["ca.crt"]
+
+# Mounted in the Alertmanager pod.
+kubectl -n cpaas-monitoring exec "$POD" -c alertmanager -- \
+  ls /etc/alertmanager/secrets/custom-email-ca/
+```
+
+After Step 3, verify the Alertmanager config inside the pod reflects the change:
+
+```bash
+kubectl -n cpaas-monitoring exec "$POD" -c alertmanager -- \
+  cat /etc/alertmanager/config/alertmanager.yaml | grep -A3 'email_configs'
+```
+
+The `ca_file` line should name the full `/etc/alertmanager/secrets/custom-email-ca/ca.crt` path.
+
+Test the TLS handshake directly from inside the pod to rule out any network or certificate issue independent of Alertmanager:
+
+```bash
+kubectl -n cpaas-monitoring exec "$POD" -c alertmanager -- \
+  openssl s_client -connect smtp.example.com:587 \
+                   -starttls smtp \
+                   -CAfile /etc/alertmanager/secrets/custom-email-ca/ca.crt \
+                   -verify_return_error < /dev/null
+```
+
+`Verify return code: 0 (ok)` confirms the CA file is correct and the SMTP server's certificate chains up to it. Once the handshake verifies at this level, Alertmanager's next notification attempt succeeds.

--- a/docs/en/solutions/Configure_a_Custom_CA_Certificate_for_Alertmanagers_SMTP_Email_Receiver_on_ACP.md
+++ b/docs/en/solutions/Configure_a_Custom_CA_Certificate_for_Alertmanagers_SMTP_Email_Receiver_on_ACP.md
@@ -1,0 +1,102 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Configure a Custom CA Certificate for Alertmanager's SMTP Email Receiver on ACP
+
+## Issue
+
+On Alauda Container Platform with the `prometheus` ModulePlugin installed (chart `ait/chart-kube-prometheus` v4.3.3, image `3rdparty/prometheus/alertmanager:v0.32.1-v4.3.4`), Alertmanager's SMTP email receiver must validate the smarthost's TLS certificate against the in-container trust store. When the smarthost certificate is signed by a private or internal CA that is not present in that trust store, the TLS handshake to the SMTP server fails with `x509: certificate signed by unknown authority` and the configured email notifications are never delivered.
+
+## Root Cause
+
+The Alertmanager binary shipped in `cpaas-system` is upstream Alertmanager v0.32.1, which honors the upstream `email_configs[].tls_config.ca_file` field. That field takes a filesystem path inside the Alertmanager container pointing at a PEM-encoded CA bundle used to verify the smarthost certificate. If `ca_file` is not set (or does not reference the issuer of the smarthost certificate), the connection is verified against the container's default trust store only — which does not include arbitrary internal or private CAs — and the receiver logs the x509 verification failure rather than sending mail.
+
+## Resolution
+
+Provide the private CA bundle to the Alertmanager pod by creating a Kubernetes Secret in `cpaas-system` and listing it on the platform's Alertmanager CR. The supported mount surface is the upstream prometheus-operator `Alertmanager.spec.secrets[]` field — the same field the platform already exercises on `Alertmanager` `cpaas-system/kube-prometheus`, whose live `spec.secrets` includes `callback-secret` mounted by the operator.
+
+Create the Secret holding the PEM-encoded CA bundle (replace the file path with the actual CA bundle on disk):
+
+```bash
+kubectl -n cpaas-system create secret generic smtp-ca-bundle \
+  --from-file=ca.crt=/path/to/smtp-ca.pem
+```
+
+Add the secret name to the Alertmanager CR's `spec.secrets[]`. The prometheus-operator reconciles `spec.secrets[]` and mounts each entry into the Alertmanager pod at `/etc/alertmanager/secrets/<secret-name>/` (read-only), the same way `callback-secret` is currently mounted at `/etc/alertmanager/secrets/callback-secret/` on the running pod:
+
+```bash
+kubectl -n cpaas-system patch alertmanager kube-prometheus \
+  --type merge \
+  -p '{"spec":{"secrets":["smtp-ca-bundle"]}}'
+```
+
+When multiple secrets are required, pass the full list (the patch replaces `spec.secrets` rather than appending) so existing entries such as `callback-secret` are preserved.
+
+Reference the mounted bundle from the email receiver via the operator-produced path `/etc/alertmanager/secrets/<secret-name>/<key-in-secret>`. The same path pattern is already used in the live rendered `alertmanager.yaml`, where `bearer_token_file: /etc/alertmanager/secrets/callback-secret/token` resolves the `callback-secret` mount — the CA bundle uses the identical shape:
+
+```yaml
+receivers:
+  - name: email-receiver
+    email_configs:
+      - to: ops@example.com
+        from: alertmanager@example.com
+        smarthost: smtp.example.internal:587
+        auth_username: alertmanager@example.com
+        auth_identity: alertmanager@example.com
+        auth_password: <smtp-password>
+        require_tls: true
+        tls_config:
+          ca_file: /etc/alertmanager/secrets/smtp-ca-bundle/ca.crt
+```
+
+Keep `require_tls: true` (or omit it and rely on the upstream default) on the receiver, and do not set `insecure_skip_verify: true` — enabling skip-verify bypasses the custom CA mount entirely and silently disables certificate validation, defeating the purpose of supplying the bundle.
+
+As an alternative to hand-editing the rendered alertmanager configuration, the AlertmanagerConfig CRD (`alertmanagerconfigs.monitoring.coreos.com/v1alpha1`) exposes the same custom-CA capability as a typed field. `spec.receivers[].emailConfigs[].tlsConfig.ca` is an object with `{configMap, secret}` selectors — a `SecretKeySelector` referencing a Secret + key holding the PEM CA bundle, rather than a raw filesystem path:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: email-with-ca
+  namespace: cpaas-system
+spec:
+  receivers:
+    - name: email-receiver
+      emailConfigs:
+        - to: ops@example.com
+          from: alertmanager@example.com
+          smarthost: smtp.example.internal:587
+          requireTLS: true
+          tlsConfig:
+            ca:
+              secret:
+                name: smtp-ca-bundle
+                key: ca.crt
+```
+
+## Diagnostic Steps
+
+Confirm the symptom by tailing the Alertmanager container log; the upstream Notify path emits the x509 verification failure verbatim from the alertmanager container:
+
+```bash
+kubectl -n cpaas-system logs statefulset/alertmanager-kube-prometheus \
+  -c alertmanager --tail=200 | grep -i 'x509\|certificate'
+```
+
+A log line containing `x509: certificate signed by unknown authority` from the dispatcher / notify path confirms the SMTP smarthost certificate's issuer is not present in the container trust store and that a custom `ca_file` mount is required.
+
+After applying the Secret and patching `spec.secrets[]`, verify the operator has wired the mount into the Alertmanager pod at the expected path:
+
+```bash
+kubectl -n cpaas-system get pod -l app.kubernetes.io/name=alertmanager \
+  -o jsonpath='{range .items[*].spec.containers[?(@.name=="alertmanager")].volumeMounts[*]}{.mountPath}{"\n"}{end}' \
+  | grep '/etc/alertmanager/secrets/'
+```
+
+The output should list `/etc/alertmanager/secrets/smtp-ca-bundle` alongside any pre-existing entries such as `/etc/alertmanager/secrets/callback-secret`.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
