### PR TITLE
[virtualization] VMRestore Fails with "Target VM Not Powered Off" When VMI Still Exists on ACP

### DIFF
--- a/docs/en/solutions/VMRestore_Fails_with_Target_VM_Not_Powered_Off_When_VMI_Still_Exists_on_ACP.md
+++ b/docs/en/solutions/VMRestore_Fails_with_Target_VM_Not_Powered_Off_When_VMI_Still_Exists_on_ACP.md
@@ -1,0 +1,55 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# VMRestore Fails with "Target VM Not Powered Off" When VMI Still Exists on ACP
+
+## Issue
+
+On Alauda Container Platform with the KubeVirt operator bundle installed (image `build-harbor.alauda.cn/3rdparty/kubevirt/virt-controller:v1.7.0-alauda.2`, HCO CSV `kubevirt-hyperconverged-operator.v4.3.5`, namespace `kubevirt`), a `VirtualMachineRestore` CR (`snapshot.kubevirt.io/v1beta1`, namespaced) created to restore a VM from a `VirtualMachineSnapshot` may stall and surface a `Progressing=False` condition on its `status.conditions` whose `reason` / `message` text states that the restore target failed to be ready within five minutes and asks for the target VM to be powered off before attempting restore.
+
+The `VirtualMachineRestore` CRD is installed by the KubeVirt operator (labels `app.kubernetes.io/managed-by=virt-operator`, `app.kubernetes.io/version=1.17.0`, plus annotation `kubevirt.io/install-strategy-version=v1.7.0-alauda.2`); the `v1beta1` group/version is the storage version while `v1alpha1` is still served for compatibility.
+
+## Root Cause
+
+The KubeVirt restore controller decides whether the target VM is powered off by checking the cluster for the existence of a corresponding `VirtualMachineInstance` (VMI) object, not by reading any rendered status field outside the API. As long as a VMI for the target VM is present in the namespace, the restore precondition is treated as unsatisfied and reconciliation refuses to proceed regardless of what the parent `VirtualMachine` reports.
+
+The authoritative VM lifecycle state on ACP is read directly from the API: `VirtualMachine.status.printableStatus` on the parent CR (values such as `Starting` or `ImagePullBackOff` are surfaced verbatim there) together with the presence or absence of the `VirtualMachineInstance` namespaced object. A VMI may linger in the namespace after a failed stop request — the parent `VirtualMachine` may already show a stopped intent while the VMI object remains — and that lingering VMI alone is enough to keep the restore controller in its "target not powered off" branch.
+
+## Resolution
+
+Delete the lingering `VirtualMachineInstance` directly. VMIs are namespaced resources reachable through `kubectl`, and deleting the VMI tears down the underlying virt-launcher pod (whose lifecycle is owned by the VMI), which force-stops the VM and clears the restore precondition.
+
+```bash
+# Identify the lingering VMI for the target VM
+kubectl get vmi -n <namespace>
+
+# Force-stop by deleting the VMI; the owning virt-launcher pod terminates with it
+kubectl delete vmi <vm-name> -n <namespace>
+```
+
+After the VMI is gone, the `VirtualMachineRestore` controller's existence check for the target VMI returns empty on the next reconcile and the restore precondition (no active VMI for the target VM) is satisfied.
+
+## Diagnostic Steps
+
+Read the failed restore's condition block to confirm the failure mode — the `Progressing=False` condition with the timeout / "power off the target VM" reason/message text is the signature of this precondition check; other failure modes on the same `status.conditions` slice will emit different reason strings:
+
+```bash
+kubectl get vmrestore -n <namespace> <restore-name> -o yaml
+```
+
+Check VM and VMI ground truth via the API rather than relying on any rendered view. `VirtualMachine.status.printableStatus` carries the authoritative lifecycle phase, and the presence of a `VirtualMachineInstance` object in the same namespace is what the restore controller actually consults. By default KubeVirt names the VMI identically to its parent VM, but a custom template may override this — list VMIs in the namespace first and match by owner reference if the names differ:
+
+```bash
+kubectl get vm -n <namespace> <vm-name> \
+  -o jsonpath='{.status.printableStatus}{"\n"}'
+kubectl get vmi -n <namespace> \
+  -o jsonpath='{range .items[?(@.metadata.ownerReferences[0].name=="<vm-name>")]}{.metadata.name}{"\n"}{end}'
+```
+
+If the VMI listing returns an object owned by the target VM while the VM's printable status already indicates a stopped or transitional state, the cluster is in the lingering-VMI state described above; delete that VMI as shown in Resolution to unblock the restore.

--- a/docs/en/solutions/VM_Restore_Fails_with_Target_VM_Not_Powered_Off_While_UI_Shows_It_as_Off.md
+++ b/docs/en/solutions/VM_Restore_Fails_with_Target_VM_Not_Powered_Off_While_UI_Shows_It_as_Off.md
@@ -1,0 +1,134 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A `VirtualMachineRestore` operation (from a snapshot, typically to roll a VM back to a known state) fails to progress. The restore object reports:
+
+```yaml
+status:
+  conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "..."
+      reason: Restore target failed to be ready within 5m0s.
+               Please power off the target VM before attempting restore
+      status: "False"
+      type: Progressing
+```
+
+The ACP console's VM panel shows the target VM as **Stopped** — the operator has already clicked power-off and waited — but the restore keeps insisting the VM is not off. Retrying in the UI does nothing; the restore object re-times out.
+
+This shows up on Windows guests somewhat more often than on Linux, because Windows in-guest shutdowns sometimes take longer than the console's state-tracking window and lead to the split-state where the VM reports stopped while the VMI lingers.
+
+## Root Cause
+
+The restore controller checks the **actual** state of the cluster objects, not the UI's summary. Specifically, it looks for a `VirtualMachineInstance` (VMI) object with the target VM's name:
+
+- If no VMI exists → the restore proceeds.
+- If a VMI exists, regardless of its phase → the restore refuses and logs "Target VM Not Powered Off".
+
+The UI's "Stopped" badge is driven by the parent `VirtualMachine` object's condition. When an in-guest shutdown doesn't cleanly signal back to the control plane, the VMI can stay in `Succeeded` / `Failed` phase for a while — fully stopped from the guest's perspective, but still present as a Kubernetes object from the restore controller's perspective. The VM object transitions to `Stopped` because the guest is in fact not running; but the orphan VMI object is still there.
+
+This is the same class of issue as the `runStrategy: Manual` cleanup gap — the VMI is not automatically reaped under some shutdown paths. The VM is stopped; the VMI is just not **gone**.
+
+## Resolution
+
+### Delete the orphaned VMI, then retry the restore
+
+```bash
+NS=<vm-ns>; VM=<vm-name>
+
+# Confirm the orphan VMI.
+kubectl -n "$NS" get vmi "$VM" -o \
+  jsonpath='{.status.phase}{"\t"}{.metadata.creationTimestamp}{"\n"}'
+# e.g.: Succeeded    2026-01-05T10:30:00Z
+
+# Force-delete the VMI. The VM object is already Stopped, so this does
+# not take the VM down — it just clears the leftover VMI object.
+kubectl -n "$NS" delete vmi "$VM"
+```
+
+Once the VMI is gone, clean up the failed restore (it will not auto-recover) and re-issue it:
+
+```bash
+# Delete the failed VMRestore.
+kubectl -n "$NS" delete vmrestore <restore-name>
+
+# Recreate the restore (same spec as before).
+kubectl -n "$NS" apply -f vmrestore.yaml
+```
+
+Watch the new restore progress:
+
+```bash
+kubectl -n "$NS" get vmrestore <restore-name> -o \
+  jsonpath='{range .status.conditions[*]}{.type}={.status} {.reason}{"\n"}{end}'
+```
+
+`Progressing=True`, then `Ready=True` confirms the restore ran to completion.
+
+### If the VMI deletion does not complete
+
+Occasionally a VMI's finalizers block deletion — the `virt-launcher` pod may also need force-removal:
+
+```bash
+kubectl -n "$NS" get pod -l kubevirt.io/domain="$VM" -o name | \
+  xargs kubectl -n "$NS" delete --force --grace-period=0
+
+# Then the VMI.
+kubectl -n "$NS" delete vmi "$VM" --force --grace-period=0
+```
+
+Force-deletion bypasses the normal graceful shutdown. Because the VMI is already in a terminal phase (the guest stopped), there is no running state to preserve. If the VMI still refuses to delete, inspect its finalizers:
+
+```bash
+kubectl -n "$NS" get vmi "$VM" -o jsonpath='{.metadata.finalizers}{"\n"}'
+# ["kubevirt.io/virtualMachineControllerFinalize"]
+```
+
+Remove stuck finalizers (last-resort; do this only after confirming the VMI is not needed):
+
+```bash
+kubectl -n "$NS" patch vmi "$VM" \
+  --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]'
+```
+
+### Prevent recurrence
+
+The orphaned-VMI pattern shows up more often with certain `runStrategy` values and with Windows guests whose in-guest shutdown is slow. Two preventive measures:
+
+- Use `runStrategy: RerunOnFailure` (not `Manual`) when the workload tolerates auto-recovery after crashes. `RerunOnFailure` reaps the VMI on clean shutdowns automatically.
+- If `runStrategy: Manual` is required by the workload, schedule a periodic sweeper (a simple CronJob with RBAC to delete stale VMIs) to catch any orphans. See the companion note on guest-initiated shutdowns for a reference implementation.
+
+## Diagnostic Steps
+
+Confirm the orphan is the restore blocker:
+
+```bash
+NS=<ns>; VM=<vm-name>
+kubectl -n "$NS" get vm "$VM" -o \
+  jsonpath='{.status.printableStatus}{"\n"}'
+# Stopped
+
+kubectl -n "$NS" get vmi "$VM" 2>/dev/null && \
+  echo "VMI still exists — orphan confirmed" || \
+  echo "VMI is gone — issue is elsewhere"
+```
+
+If the VMI still exists while the VM is stopped, that is the condition this note describes. If the VMI is already gone and the restore still reports "not powered off", the issue is different — inspect the VMRestore's status in more detail for the actual failure reason.
+
+Read the `virt-launcher` pod state to know what triggered the leftover:
+
+```bash
+kubectl -n "$NS" get pod -l kubevirt.io/domain="$VM" -o wide
+kubectl -n "$NS" describe pod <virt-launcher-pod> | grep -A5 -E 'Last State|Reason|Exit Code'
+```
+
+A clean exit (Exit Code 0) combined with `runStrategy: Manual` on the VM is the usual pattern. Document the result so the preventive measure (different runStrategy or a sweeper) can be chosen based on evidence.
+
+After the fix, the next restore completes, and `kubectl -n "$NS" get vm "$VM" -o yaml` reflects the restored snapshot's state (disk contents, CR fields) on the VM's next start.

--- a/docs/en/solutions/VM_Restore_Fails_with_Target_VM_Not_Powered_Off_While_UI_Shows_It_as_Off.md
+++ b/docs/en/solutions/VM_Restore_Fails_with_Target_VM_Not_Powered_Off_While_UI_Shows_It_as_Off.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# VM Restore Fails with `Target VM Not Powered Off` While UI Shows It as Off
 ## Issue
 
 A `VirtualMachineRestore` operation (from a snapshot, typically to roll a VM back to a known state) fails to progress. The restore object reports:


### PR DESCRIPTION
新增一篇 ACP KB 文章。
