### PR TITLE
[configure] Node reports NotReady after missing /var/lib/kubelet/config.json on ACP

### DIFF
--- a/docs/en/solutions/Node_Stuck_booting_up_With_SSH_Refused_and_Kubelet_NotReady_Missing_varlibkubeletconfigjson.md
+++ b/docs/en/solutions/Node_Stuck_booting_up_With_SSH_Refused_and_Kubelet_NotReady_Missing_varlibkubeletconfigjson.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Node Stuck "booting up" With SSH Refused and Kubelet NotReady — Missing `/var/lib/kubelet/config.json`
 ## Issue
 
 A cluster node stops serving workloads and the control plane reports it as `NotReady`. Attempting to SSH to the node to investigate returns a boot-time refusal message instead of a shell prompt:

--- a/docs/en/solutions/Node_Stuck_booting_up_With_SSH_Refused_and_Kubelet_NotReady_Missing_varlibkubeletconfigjson.md
+++ b/docs/en/solutions/Node_Stuck_booting_up_With_SSH_Refused_and_Kubelet_NotReady_Missing_varlibkubeletconfigjson.md
@@ -1,0 +1,149 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A cluster node stops serving workloads and the control plane reports it as `NotReady`. Attempting to SSH to the node to investigate returns a boot-time refusal message instead of a shell prompt:
+
+```text
+System is booting up. Unprivileged users are not permitted to log in yet.
+Please come back later.
+For technical details, see pam_nologin(8).
+```
+
+The node responds to `ping`, so networking to it is basically fine. But:
+
+- SSH refuses non-root logins.
+- The API server reports the node as `NotReady` (kubelet is not sending successful status updates).
+- Standard `kubectl debug node/<name>` cycles and may also stall.
+- Running services on the node appear to be holding, waiting for something.
+
+The message from PAM is not a red herring: `pam_nologin(8)` rejects unprivileged logins while `/run/nologin` (or `/etc/nologin`) exists. Systemd creates `/run/nologin` while essential boot-time services have not yet reported `ready`. A service that **hangs during start-up** keeps `/run/nologin` present indefinitely, which is why ordinary SSH stays refused even long after the node's initial boot time.
+
+## Root Cause
+
+On cluster nodes, the kubelet's in-cluster identity and image-pull credentials are supplied through a kubelet-side pull-secret at `/var/lib/kubelet/config.json`. Multiple services that run early in the boot sequence depend on that file:
+
+- `nodeip-configuration.service` — determines the node's node-IP by talking to the platform (which requires authenticated access to the cluster's image registry / API).
+- `kubelet.service` — reads the pull-secret to authenticate image pulls for static pods and for any in-cluster image the kubelet fetches directly.
+
+When `/var/lib/kubelet/config.json` is missing, unreadable, or corrupted:
+
+- `nodeip-configuration.service` blocks waiting for a response that can never come.
+- `kubelet.service` cannot pull static-pod images and stays not-ready.
+- systemd keeps `/run/nologin` present because critical boot targets have not completed.
+- PAM honours the `nologin` file and refuses non-root interactive logins.
+
+The node appears completely stuck from the operator's perspective. It is actually not stuck — it is faithfully waiting for the pull-secret to appear, which it never will without intervention.
+
+Causes of the file going missing:
+
+- An overly enthusiastic maintenance script deleted files under `/var/lib/kubelet/` (a cleanup that thought it was removing cached container images).
+- Disk corruption (filesystem check at next boot truncated or orphaned the file).
+- An operator action touching the file without understanding its boot-path criticality.
+- Node re-provisioned from an image missing the file; the installer / ignition that should have written it did not.
+
+## Resolution
+
+### Restore the pull-secret file on the affected node
+
+The file's content is identical across nodes that joined the same cluster with the same image-pull credentials. Copy it from a healthy node.
+
+**If some nodes are still healthy and accessible:**
+
+```bash
+# From a healthy node, read the file content.
+HEALTHY_NODE=<healthy-node>
+kubectl debug node/$HEALTHY_NODE --image=busybox -- \
+  chroot /host cat /var/lib/kubelet/config.json > /tmp/kubelet-config.json
+
+# Verify it's a parseable JSON docker-config.
+jq '.auths | keys' /tmp/kubelet-config.json
+```
+
+**If the affected node can be reached as root via a management channel (ILO, iDRAC, vSphere console):**
+
+Log in through the out-of-band console, escalate to root (PAM only blocks unprivileged logins; root is unaffected), and write the file:
+
+```bash
+# On the affected node, as root:
+install -m 0600 -o root -g root /path/to/healthy-config.json /var/lib/kubelet/config.json
+```
+
+**If no healthy node exists, reconstruct from the cluster-side source:**
+
+The file derives from the cluster's own image-pull-secret. Extract it from the cluster and upload to the node:
+
+```bash
+# Capture the pull-secret from the cluster (from any machine with kubectl access).
+kubectl -n <platform-ns> get secret <pull-secret-name> \
+  -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > /tmp/kubelet-config.json
+```
+
+Transfer `/tmp/kubelet-config.json` to the node through whatever channel remains (out-of-band console, boot into maintenance mode, mount the disk from a neighbouring node). Place it at `/var/lib/kubelet/config.json` with the same permissions as above.
+
+### After the file is restored
+
+The dependent services unblock themselves on their next retry tick, but a restart is faster. From the node's root shell:
+
+```bash
+systemctl restart nodeip-configuration.service
+systemctl restart kubelet
+```
+
+`systemctl status nodeip-configuration.service` should reach `active (exited)` within a few seconds. `systemctl status kubelet` should reach `active (running)`.
+
+Once those two services reach `active`, systemd completes the rest of the boot targets. `/run/nologin` is removed, PAM accepts unprivileged logins, and the kubelet resumes sending status updates. The API server sees the node transition to `Ready` within one kubelet-report interval.
+
+### Verify recovery
+
+```bash
+# SSH as a normal user should now succeed.
+ssh <user>@<node-hostname>
+
+# kubelet's own status.
+kubectl get node <node-name>     # should show Ready
+
+# Pull-secret is present with sane permissions.
+ls -la /var/lib/kubelet/config.json
+# -rw------- 1 root root ... /var/lib/kubelet/config.json
+```
+
+### Prevent recurrence
+
+The file is node-critical and should not be deleted by any automation. Two preventive postures:
+
+- **Back it up as part of the node image / initial-config payload.** If nodes are re-provisioned from a golden image or a provisioning template, ensure the template includes the pull-secret so a rebuild from the image always has it.
+- **Monitor for the file's absence.** A small node-exporter textfile collector (or any node-level monitoring agent) can run `test -f /var/lib/kubelet/config.json` periodically and alert on absence. The alert fires before a reboot exposes the problem as a full outage.
+
+## Diagnostic Steps
+
+If the node is accessible as root (through an out-of-band console), verify the specific failure shape:
+
+```bash
+# /run/nologin present — boot-target not yet complete.
+ls -la /run/nologin
+
+# The kubelet's pull-secret.
+ls -la /var/lib/kubelet/config.json 2>/dev/null || echo "MISSING: pull-secret"
+
+# Which services are stuck.
+systemctl list-units --state=activating --no-pager
+```
+
+If `/var/lib/kubelet/config.json` is missing, the diagnosis is confirmed. Any service in `activating` for more than a couple of minutes is likely the one blocking the boot target.
+
+Cross-reference with journal entries for the services named in Root Cause:
+
+```bash
+journalctl -u nodeip-configuration.service -u kubelet --since "30 min ago" --no-pager | tail -40
+```
+
+`nodeip-configuration.service` retries forever until its registry/API calls succeed; you will see repeated `waiting for …` log lines. `kubelet` reports it cannot pull images because the authoritative config is missing.
+
+After restoring the file and restarting the services, the journal should show `nodeip-configuration.service` reporting the discovered IP and `kubelet` reporting a successful `Register node …` event.

--- a/docs/en/solutions/Node_reports_NotReady_after_missing_varlibkubeletconfigjson_on_ACP.md
+++ b/docs/en/solutions/Node_reports_NotReady_after_missing_varlibkubeletconfigjson_on_ACP.md
@@ -1,0 +1,65 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Node reports NotReady after missing /var/lib/kubelet/config.json on ACP
+
+## Issue
+
+On Alauda Container Platform clusters whose worker nodes run the vanilla upstream kubelet (observed on cluster `jingguo-7gm6m`, KVM-backed Ubuntu 22.04.1 LTS nodes with kubelet `v1.34.5` and containerd `2.2.1-5`), one node flips to `NotReady` in `kubectl get node` output and stays there. The kubelet on that node has not started and is not posting any node-status heartbeat to the apiserver. The upstream kubelet binary opens `/var/lib/kubelet/config.json` from its startup arguments as the docker-config-style container-registry pull credentials file consumed by the image-pull machinery the kubelet drives directly.
+
+## Root Cause
+
+When `/var/lib/kubelet/config.json` is absent or unreadable, the kubelet fails to start on that node — the binary cannot complete the startup path that opens this credentials file, so the kubelet process never reaches the steady state where it posts the `Ready` condition (`reason=KubeletReady`, message `kubelet is posting ready status`) on its `Node` object. With no kubelet running, the per-node `Lease` in `kube-node-lease` is not renewed: kubelet normally updates `Lease.renewTime` and `Node.status.conditions.lastHeartbeatTime` every `nodeStatusUpdateFrequency=8s` against a `leaseDurationSeconds=40`. Once the lease has not been renewed past that grace window, the node-lifecycle controller flips the `Ready` condition to `Unknown` and the apiserver reports the node as `NotReady`.
+
+## Resolution
+
+Restore `/var/lib/kubelet/config.json` on the affected node by copying the file from any healthy `Ready` node in the same cluster, where a healthy peer with the same image-pull configuration is available. All ACP nodes in a given cluster run a uniform kubelet and node OS build (here `v1.34.5` on Ubuntu 22.04.1 with containerd `2.2.1-5`), so any healthy node is a safe donor for this file; no MCO-style controller stomps the file, so a manually restored copy remains in place after the kubelet comes back. Once the file is present and readable, the kubelet starts on the affected node, begins posting the `Ready` condition and renewing its node lease, and the apiserver flips the node back to `Ready`.
+
+Read the file on a healthy donor node, then write the same bytes to the affected node at `/var/lib/kubelet/config.json` with mode `0600` owned by `root:root`. The read-write path on an ACP node is either direct SSH to the host or `kubectl debug node/<node-name> --image=<utility-image>` mounting the host filesystem under `/host` — the kubelet credentials file lives at `/host/var/lib/kubelet/config.json` from the debug pod's view:
+
+```bash
+# From a workstation that can reach a healthy donor node over SSH
+ssh <user>@<healthy-node> sudo cat /var/lib/kubelet/config.json > /tmp/kubelet-config.json
+
+# Push the file onto the affected node
+scp /tmp/kubelet-config.json <user>@<affected-node>:/tmp/kubelet-config.json
+ssh <user>@<affected-node> sudo install -m 0600 -o root -g root \
+    /tmp/kubelet-config.json /var/lib/kubelet/config.json
+
+# Start the kubelet on the affected node
+ssh <user>@<affected-node> sudo systemctl start kubelet
+```
+
+After the kubelet starts, confirm recovery by watching the node flip back to `Ready` and the lease renew within the grace window:
+
+```bash
+kubectl get node <affected-node> -o wide
+kubectl get lease -n kube-node-lease <affected-node> \
+    -o jsonpath='{.spec.renewTime}'
+```
+
+## Diagnostic Steps
+
+Identify the affected node and confirm the apiserver-side symptom: a single node sitting at `NotReady` with the `Ready` condition reporting `status=Unknown` (the controller-set "missing heartbeat" form) rather than `status=False` with a kubelet-authored message. Compare the node's `lastHeartbeatTime` against the current time — a value older than the `leaseDurationSeconds=40` grace window confirms the kubelet is not renewing its lease:
+
+```bash
+kubectl get node
+kubectl get node <affected-node> \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")]}'
+kubectl get lease -n kube-node-lease <affected-node> \
+    -o jsonpath='{.spec.renewTime}'
+```
+
+On the affected node, confirm the kubelet process is not running and that `/var/lib/kubelet/config.json` is absent or unreadable. The kubelet opens this file directly from its startup arguments, so any error reading it surfaces as a kubelet that fails to reach the running state:
+
+```bash
+ssh <user>@<affected-node> sudo systemctl status kubelet
+ssh <user>@<affected-node> sudo ls -l /var/lib/kubelet/config.json
+ssh <user>@<affected-node> sudo journalctl -u kubelet --no-pager | tail -50
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guide for worker node NotReady status issues on Alauda Container Platform, including diagnostic and remediation steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/knowledge/pull/451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->