### PR TITLE
[virtualization] "Why a Windows VM on ACP Virtualization Shows a Loopback Pseudo-Interface — Expected Behaviour"

### DIFF
--- a/docs/en/solutions/Why_a_Windows_VM_on_ACP_Virtualization_Shows_a_Loopback_Pseudo_Interface_Expected_Behaviour.md
+++ b/docs/en/solutions/Why_a_Windows_VM_on_ACP_Virtualization_Shows_a_Loopback_Pseudo_Interface_Expected_Behaviour.md
@@ -1,0 +1,98 @@
+---
+kind:
+   - Information
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Overview
+
+A Windows VM freshly migrated onto ACP Virtualization shows, in the VM's network-interface list on the ACP console, a `Loopback Pseudo-Interface` alongside the expected Ethernet NICs. At first glance the extra entry looks like the migration toolkit or KubeVirt accidentally added a spurious interface. The entry typically carries the address `127.0.0.1` and does not participate in any configured pod-network or secondary-network attachment.
+
+This note confirms that the loopback entry is **expected** on Windows guests and explains where it comes from, so the extra interface is not mistakenly flagged as a migration artefact.
+
+## Why the Loopback Appears
+
+The network-interface list the ACP console displays for a VM is not read from the pod or the KubeVirt spec directly. Two sources combine:
+
+1. The VM's `domain` spec — the explicitly-attached interfaces (`spec.template.spec.domain.devices.interfaces`) from the `VirtualMachine` CR.
+2. The **in-guest report** from the QEMU guest agent — everything the guest OS reports through the agent as its visible network interfaces.
+
+The second source is where the loopback comes from.
+
+Windows reports its network inventory through the IP Helper API. That API treats the loopback interface (`127.0.0.1` / the "Loopback Pseudo-Interface") as a regular enumerated interface, just like a physical Ethernet card. When the QEMU guest agent queries the OS for the interface list, the loopback shows up in the response. The agent relays that response to the hypervisor, KubeVirt records it on the VMI status, and the ACP console renders the whole list — including the loopback — on the VM's network page.
+
+Linux guests also have a loopback (`lo`) but the Linux guest-agent path has historically filtered it before reporting, so the same visual surprise does not appear there. Windows does not filter it; Windows guests show loopback in the list.
+
+There is no bug. Nothing about this interface needs to be removed, hidden, or worked around. The loopback is used by the guest OS itself for in-VM IPC between processes; removing or renumbering it would break whatever in-guest software relies on `127.0.0.1`.
+
+## What the Listing Looks Like
+
+A typical inspection of a Windows VMI's interface status lists both the "real" NIC and the loopback:
+
+```bash
+kubectl -n <ns> get vmi <windows-vm> -o json | \
+  jq '.status.interfaces[] | {name, ipAddress, mac, interfaceName}'
+# {
+#   "name": "default",
+#   "ipAddress": "10.128.12.42",
+#   "mac": "02:00:00:AA:BB:42",
+#   "interfaceName": "Ethernet"
+# }
+# {
+#   "name": null,
+#   "ipAddress": "127.0.0.1",
+#   "mac": null,
+#   "interfaceName": "Loopback Pseudo-Interface 1"
+# }
+```
+
+Distinguishing features of the loopback entry:
+
+- `ipAddress: 127.0.0.1` (or an IPv6 loopback `::1`).
+- `mac: null` (loopback has no MAC).
+- `name: null` (no reference to any `VirtualMachine.spec.networks[].name` — the loopback is not a user-defined network attachment).
+- `interfaceName` matches the Windows IP Helper's representation (`Loopback Pseudo-Interface 1`).
+
+The "real" NICs carry a non-null `name` that maps to entries in `spec.template.spec.networks` and a MAC address the cluster's SDN plumbed.
+
+## When the Listing Actually Is Wrong
+
+Most Windows VM interface displays include the loopback — that is not a problem. Situations that would be worth investigating:
+
+- **Extra entries with IPs that do not correspond to any configured attachment and are not loopback.** For example, a `169.254.x.x` address (Windows' APIPA fallback) suggests the real NIC failed DHCP — the concerning fix is on the real NIC, not the extra entry.
+- **Missing real NICs.** The loopback is there but the configured Ethernet is absent from the list; suggests the guest-agent is not fully started, the NIC has not bound, or the VM's network plumbing has a problem.
+- **Duplicate non-loopback interfaces.** More real-NIC entries than the VM declares may suggest a leaked interface from a prior VM generation or a migration artefact.
+
+For each of those, the relevant logs live in the VMI's status and in the `virt-launcher` pod's events — the loopback itself is not the investigation target.
+
+## Diagnostic Steps
+
+Count the expected versus observed interfaces:
+
+```bash
+NS=<ns>; VM=<windows-vm>
+# Declared in spec:
+kubectl -n "$NS" get vm "$VM" -o json | \
+  jq '.spec.template.spec.networks | length'
+# 1
+
+# Reported by guest-agent (includes loopback for Windows):
+kubectl -n "$NS" get vmi "$VM" -o json | \
+  jq '.status.interfaces | length'
+# 2   — the one declared NIC + loopback
+```
+
+If the delta is exactly 1 (loopback), the listing is normal. If the delta is different, investigate using the bullets above.
+
+From inside the Windows guest, confirm the loopback is the only "extra" interface:
+
+```powershell
+# Inside the Windows VM:
+Get-NetIPInterface | Select-Object InterfaceAlias, AddressFamily
+```
+
+The loopback appears as `Loopback Pseudo-Interface 1` at the OS level. Matching the OS's view with the cluster-side view confirms the console's listing is a faithful reflection of the guest state.
+
+No fix is required; the interface is expected. Document the pattern so support tickets about the loopback entry can be closed with a reference to this note.

--- a/docs/en/solutions/Why_a_Windows_VM_on_ACP_Virtualization_Shows_a_Loopback_Pseudo_Interface_Expected_Behaviour.md
+++ b/docs/en/solutions/Why_a_Windows_VM_on_ACP_Virtualization_Shows_a_Loopback_Pseudo_Interface_Expected_Behaviour.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Why a Windows VM on ACP Virtualization Shows a Loopback Pseudo-Interface — Expected Behaviour
 ## Overview
 
 A Windows VM freshly migrated onto ACP Virtualization shows, in the VM's network-interface list on the ACP console, a `Loopback Pseudo-Interface` alongside the expected Ethernet NICs. At first glance the extra entry looks like the migration toolkit or KubeVirt accidentally added a spurious interface. The entry typically carries the address `127.0.0.1` and does not participate in any configured pod-network or secondary-network attachment.


### PR DESCRIPTION
新增一篇 ACP KB 文章，归入 `virtualization` 区域。

**⚠️ 自动化验证：无测试计划** — 本篇未登记验证计划，暂不自动合并，请人工确认内容后再合。

## `virtualization` 区域建议 reviewer

按 `kb/OWNERS.md`（来源：alauda-ai-base operator-list 的产品 owner）该区域候选自动挑选，@ 错了请无视。


没有 GitHub handle 的贡献者（本区域相关请人工 ping）：

- chengli &lt;chengli@alauda.io&gt;
- zyfan &lt;zyfan@alauda.io&gt;
