### PR TITLE
[virtualization] All KubeVirt VMs simultaneously power off after the VirtualMachineInstance CRD is deleted by a cluster-admin third-party service account on ACP

### DIFF
--- a/docs/en/solutions/All_KubeVirt_VMs_simultaneously_power_off_after_the_VirtualMachineInstance_CRD_is_deleted_by_a_cluster_admin_third_party_service_account_on_ACP.md
+++ b/docs/en/solutions/All_KubeVirt_VMs_simultaneously_power_off_after_the_VirtualMachineInstance_CRD_is_deleted_by_a_cluster_admin_third_party_service_account_on_ACP.md
@@ -1,0 +1,71 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# All KubeVirt VMs simultaneously power off after the VirtualMachineInstance CRD is deleted by a cluster-admin third-party service account on ACP
+
+## Issue
+
+On Alauda Container Platform, KubeVirt is installed through the `kubevirt-operator` OperatorBundle. The control plane runs in the `kubevirt` namespace and is composed of `virt-operator` (2/2), `virt-api` (1/1), `virt-controller` (1/1), and the per-node `virt-handler` DaemonSet (one pod per linux node), all packaged by the OLM CSV `kubevirt-hyperconverged-operator.v4.3.5` and reporting `observedKubeVirtVersion=v1.7.0-alauda.2`. The `virtualmachineinstances.kubevirt.io` CRD is registered cluster-wide under `apiextensions.k8s.io/v1`, `group=kubevirt.io`, `plural=virtualmachineinstances`, `shortNames=[vmi,vmis]`, `scope=Namespaced`, and carries the label `app.kubernetes.io/managed-by=virt-operator` plus the annotation `kubevirt.io/install-strategy-version=v1.7.0-alauda.2` — `virt-operator` owns and reconciles this CRD.
+
+The reported symptom: every running KubeVirt-managed virtual machine on the cluster powers off at the same moment. On each affected node, `virt-handler` (image `build-harbor.alauda.cn/3rdparty/kubevirt/virt-handler:v1.7.0-alauda.2`) drives a graceful shutdown of the underlying QEMU process for the VMs it manages and waits for up to `--graceful-shutdown-seconds=315` while QEMU delivers an ACPI power-button event and SIGTERM propagates to guest processes. During the teardown window `virt-handler` emits structured JSON log lines following the upstream envelope `{component, level, msg, pos, timestamp}` (for example a `"Signaled graceful shutdown"`-shape message keyed off the per-VM teardown path).
+
+## Root Cause
+
+The KubeVirt control plane reconciles VMs against the cluster-scoped `virtualmachineinstances.kubevirt.io` CRD; when that CRD object is deleted from `apiextensions.k8s.io/v1`, the cluster no longer admits VMI instances and the per-VM teardown path runs on every node — producing the simultaneous power-off pattern.
+
+Deletion of the VMI CRD is reachable by any principal bound to the upstream `cluster-admin` ClusterRole, whose rule is the RBAC wildcard `{apiGroups:[*], resources:[*], verbs:[*]}` and therefore grants delete on every cluster-scoped resource including CRDs. In the observed scenario, a third-party automation/backup service account had been bound to `cluster-admin` and used that authorization to delete the VMI CRD as part of its workflow. The legitimate principal that owns this CRD is the `virt-operator` ServiceAccount (`system:serviceaccount:kubevirt:kubevirt-operator`), which the bound ClusterRole grants `[get,list,watch,create,delete,patch]` on `apiextensions.k8s.io/customresourcedefinitions`; any other service account showing up as the `create` principal on a CRD recreation is therefore out of band.
+
+## Resolution
+
+Restore the `virtualmachineinstances.kubevirt.io` CRD so that VMs which were running before the deletion can be reconciled again. `virt-operator` (image `build-harbor.alauda.cn/3rdparty/kubevirt/virt-operator:v1.7.0-alauda.2`) owns the CRD and reconciles it back when it is missing; the recommended path is to let `virt-operator` recreate it rather than re-applying the CRD object out of band, which avoids leaving a recreate-moment `creationTimestamp` and a non-operator principal on the audit trail.
+
+Confirm the CRD has been restored by listing it with `kubectl`:
+
+```bash
+kubectl get crd | grep virtualmachineinstance
+kubectl get crd virtualmachineinstances.kubevirt.io -o yaml
+```
+
+The restored CRD should carry `group=kubevirt.io`, `plural=virtualmachineinstances`, `shortNames=[vmi,vmis]`, `scope=Namespaced`, label `app.kubernetes.io/managed-by=virt-operator`, and annotation `kubevirt.io/install-strategy-version=v1.7.0-alauda.2`. Once present, VMs that were running before the deletion restart automatically and service is restored.
+
+Revoke the third-party automation/backup service account's binding to `cluster-admin` and rebind it to a least-privilege role that does not grant `delete` on `apiextensions.k8s.io/customresourcedefinitions`; otherwise the same outage class can recur on the next workflow run.
+
+## Diagnostic Steps
+
+Inspect the restored CRD object's `generation` and `creationTimestamp` to confirm whether a delete/recreate event happened. The signature is `generation: 1` with a `creationTimestamp` matching the recreation moment rather than the original cluster install time (the live install-time stamp on this cluster is `2026-05-13T05:21:49Z`):
+
+```bash
+kubectl get crd virtualmachineinstances.kubevirt.io \
+  -o jsonpath='{.metadata.generation}{"\t"}{.metadata.creationTimestamp}{"\n"}'
+```
+
+Pull `virt-handler` logs from the `kubevirt` namespace during the outage window. `virt-handler` emits structured JSON of the upstream envelope `{component, level, msg, pos, timestamp}`; a graceful-shutdown signal for each VM whose VMI is being torn down appears on this stream:
+
+```bash
+kubectl -n kubevirt logs ds/virt-handler --since=1h
+```
+
+Confirm whether the third-party automation/backup service account is bound to `cluster-admin` and therefore has the privilege required to delete the VMI CRD. Use the upstream `kubectl auth can-i` probe with `--as` impersonation to evaluate the binding without touching the live CRD:
+
+```bash
+kubectl auth can-i delete crd \
+  --as=system:serviceaccount:<ns>:<sa>
+kubectl get clusterrolebinding -o json \
+  | jq '.items[] | select(.roleRef.name=="cluster-admin") | {name:.metadata.name, subjects:.subjects}'
+```
+
+Attribute the recreation principal by reading the kube-apiserver audit log. On ACP the audit log file lives on each control-plane host at `/etc/kubernetes/audit/audit.log`; reach it by opening a shell on a control-plane host (or attaching to a debug pod that mounts the host filesystem) and reading the file directly, then filtering for the CRD path:
+
+```bash
+ssh <user>@<control-plane-host>
+sudo grep '"resource":"customresourcedefinitions"' /etc/kubernetes/audit/audit.log \
+  | grep 'virtualmachineinstances.kubevirt.io'
+```
+
+Each matching record is an `audit.k8s.io/v1` Event with `user.username`, `verb`, `objectRef.resource`, `requestURI`, and `responseStatus.code` fields. A `create` event whose `user.username` is anything other than `system:serviceaccount:kubevirt:kubevirt-operator` indicates the CRD was recreated by a principal other than `virt-operator` — typically the same out-of-band actor that originally deleted it.

--- a/docs/en/solutions/All_Virtual_Machines_Rebooted_Simultaneously_a_Third_Party_Actor_Deleted_the_VirtualMachineInstance_CRD.md
+++ b/docs/en/solutions/All_Virtual_Machines_Rebooted_Simultaneously_a_Third_Party_Actor_Deleted_the_VirtualMachineInstance_CRD.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# All Virtual Machines Rebooted Simultaneously — a Third-Party Actor Deleted the VirtualMachineInstance CRD
 ## Issue
 
 At a single moment in time every running VM across the cluster shuts down cleanly and restarts, with no node-level symptom to explain it:

--- a/docs/en/solutions/All_Virtual_Machines_Rebooted_Simultaneously_a_Third_Party_Actor_Deleted_the_VirtualMachineInstance_CRD.md
+++ b/docs/en/solutions/All_Virtual_Machines_Rebooted_Simultaneously_a_Third_Party_Actor_Deleted_the_VirtualMachineInstance_CRD.md
@@ -1,0 +1,180 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+At a single moment in time every running VM across the cluster shuts down cleanly and restarts, with no node-level symptom to explain it:
+
+- Multiple production worker nodes host affected VMs; **every VM on every node** goes down together.
+- No node rebooted. Kubelet, containerd, and the kernel are healthy — no crash, no panic.
+- The VM guest OS logs show a graceful shutdown. A Linux guest records an **ACPI Power Button** event, systemd receives SIGTERM, sshd terminates — i.e. something on the host asked the VM to power off politely.
+- No user action ran a `virtctl stop`, a `VirtualMachine/stop` API call, or any other deliberate VM shutdown.
+
+The outage appears as an infrastructure incident (mass VM reboot) but the infrastructure below the VMI layer was healthy throughout.
+
+## Root Cause
+
+The trigger is the deletion of the `virtualmachineinstances.kubevirt.io` **CustomResourceDefinition** itself, not the VMI objects it owns.
+
+A VMI object is the live-running representation of a VM — one VMI per running VM, backed by a virt-launcher pod and a QEMU process. Deleting the CRD removes every object of that kind from the API server in a single etcd transaction. The controller chain that follows:
+
+1. `virt-handler` watches VMIs on every node. When its informer list loses every VMI, it treats each as deleted.
+2. For each deleted VMI, virt-handler initiates graceful termination of the virt-launcher pod.
+3. virt-launcher asks QEMU to perform a guest-driven shutdown — an ACPI Power Button event is injected into the VM.
+4. The guest OS receives the power event, runs its shutdown sequence, and exits.
+5. If a `VirtualMachine` object with `runStrategy: Always` still exists, its controller immediately recreates the VMI as soon as the CRD is re-registered, and the VM powers back on.
+
+The key handoff is that **the whole fleet is tied to one CRD object**. Any actor that holds `delete customresourcedefinitions.apiextensions.k8s.io` permission can take every VMI down simultaneously, regardless of per-VM RBAC. Common sources:
+
+- A **backup or data-protection integration** that enumerates CRDs, "backs up" their schema, then deletes and re-creates them as part of a restore or schema-migration routine. Field-seen examples: Commvault, legacy Velero recipes that treat CRDs as regular objects, home-grown controllers that replicate schemas between clusters.
+- A CI pipeline with an over-broad cluster-admin token performing a dry-run `kubectl apply --force --prune` against a subset that accidentally includes CRD scope.
+
+The kube-apiserver audit log is the only reliable source of truth for who deleted the CRD — the VMI objects disappear too fast for an operator to catch.
+
+## Resolution
+
+### Step 1 — confirm the CRD exists and is healthy now
+
+Unless the attacker (or the integration that performed the delete) has restored the CRD, VMs are still down. Check:
+
+```bash
+kubectl get crd virtualmachineinstances.kubevirt.io -o=jsonpath='{.metadata.creationTimestamp}'
+```
+
+A timestamp that matches the outage window confirms the CRD was deleted-then-recreated around that time; the `generation: 1` value confirms it is a fresh object.
+
+```bash
+kubectl get crd virtualmachineinstances.kubevirt.io -o yaml | \
+  grep -E 'creationTimestamp|generation:'
+```
+
+If the CRD is missing, re-install it via the KubeVirt operator — never hand-apply a raw CRD yaml, because the operator-installed schema carries conversion webhooks and owner references that a hand-applied copy does not.
+
+```bash
+# The KubeVirt operator reconciles the CRD on a KubeVirt CR change. Touch it
+# to trigger a reconcile:
+kubectl get kubevirt -A -o name | head -1 | xargs -I{} kubectl annotate {} \
+  reconcile-trigger="$(date +%s)" --overwrite
+```
+
+### Step 2 — identify every affected VM
+
+With the CRD back, the VMs whose `VirtualMachine.runStrategy: Always` (or `RerunOnFailure`) will be auto-recreated. VMs with `runStrategy: Manual` remain stopped until explicitly restarted.
+
+```bash
+# VMs that are defined but currently have no matching VMI:
+kubectl get vm -A -o=jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}  runStrategy={.spec.runStrategy}  status={.status.printableStatus}{"\n"}{end}' | \
+  grep -v Running
+```
+
+For each VM in `Stopped` state whose owner intends it to be running, issue:
+
+```bash
+virtctl start <vm-name> -n <ns>
+```
+
+(or the equivalent `VirtualMachine` spec toggle if your platform provides a higher-level start API).
+
+### Step 3 — find the actor from the audit log
+
+The verb-level proof is in the apiserver audit log. Filter for a `delete` on the CRD resource with the exact name:
+
+```bash
+# Path varies by deployment; common locations:
+#   node-local:     /var/log/kube-apiserver/audit.log
+#   aggregated:     whatever Loki/LogCenter ships to
+# Example jq filter:
+cat audit.log | jq -c 'select(
+  .verb == "delete" and
+  .objectRef.resource == "customresourcedefinitions" and
+  .objectRef.name == "virtualmachineinstances.kubevirt.io"
+)' | head -5
+```
+
+A typical incident shows three audit events within a few seconds:
+
+1. `list` on `customresourcedefinitions?fieldSelector=metadata.name=virtualmachineinstances.kubevirt.io` — the actor first read the schema.
+2. `delete` on the same CRD — the impacting action.
+3. `create` on `customresourcedefinitions` with the same name — the actor "restored" the CRD from a bespoke copy (not via virt-operator).
+
+All three share a `user.username` field. In the field-seen Commvault incident this was `system:serviceaccount:commvault:cvadmin`, bound to `cluster-admin`.
+
+### Step 4 — revoke or scope the actor
+
+Once the ServiceAccount (or user, or OIDC principal) is known, reduce their permissions so the same action cannot recur:
+
+```bash
+# Inspect the ClusterRoleBinding that grants admin-level access:
+kubectl get clusterrolebinding -o=jsonpath='{range .items[*]}{.metadata.name}{" "}{.roleRef.name}{"\n"}{end}' | \
+  grep cluster-admin
+```
+
+The backup integration almost certainly does not need `delete customresourcedefinitions` — that permission level is meant for operator lifecycle, not for data protection. Define a purpose-specific Role that grants only what the backup actually needs (typically `get`, `list`, and for Velero-style backups `create` on selected resource kinds), and rebind the ServiceAccount.
+
+### Step 5 — contact the third-party owner
+
+The behaviour of "list a CRD, delete it, re-create from a saved copy" is documented as a backup/restore pattern in several commercial products. Their support will usually acknowledge the pattern and point you at a configuration flag to exclude CRDs from the backup scope — this is normally the correct resolution rather than modifying the product's behaviour in your cluster.
+
+### Step 6 — add an audit rule to catch the next attempt
+
+Prevent recurrence by adding a dedicated audit filter that records **every** delete on a VM-family CRD at `RequestResponse` level, so the next occurrence is immediately visible rather than rebuilt from Metadata-level records after the fact:
+
+```yaml
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: RequestResponse
+    verbs: ["delete"]
+    resources:
+      - group: apiextensions.k8s.io
+        resources: ["customresourcedefinitions"]
+        resourceNames:
+          - virtualmachineinstances.kubevirt.io
+          - virtualmachines.kubevirt.io
+          - virtualmachineinstancemigrations.kubevirt.io
+```
+
+Apply via the cluster's audit-policy mechanism (usually a control-plane configuration change). Pair this with an alert that fires on any hit.
+
+## Diagnostic Steps
+
+Confirm the guest-side graceful-shutdown signature. If the guest OS logs show a power-button event and a clean unit shutdown, the VMs did **not** crash — something asked them to stop:
+
+```text
+Jan 27 15:45:49 vm02 systemd-logind[964]: Power key pressed.
+Jan 27 15:45:49 vm02 systemd-logind[964]: Powering Off...
+Jan 27 15:45:49 vm02 sshd[1190081]: Received signal 15; terminating.
+```
+
+Correlate with the virt-handler log on the worker nodes during the outage window:
+
+```bash
+NODE=<worker-node-name>
+kubectl logs -n <kubevirt-ns> -l kubevirt.io=virt-handler --field-selector spec.nodeName="$NODE" --since=30m | \
+  grep -E 'Signaled graceful shutdown|grace period|VMI deleted'
+```
+
+A log line of the shape `{"component":"virt-handler","name":"vm02","msg":"Signaled graceful shutdown"}` for **every** VM on the node within the same second is the virt-handler reacting to the CRD deletion.
+
+Check the CRD metadata — a recent `creationTimestamp` and `generation: 1` together mean the CRD was replaced, not just modified:
+
+```bash
+kubectl get crd virtualmachineinstances.kubevirt.io -o yaml | \
+  grep -E 'creationTimestamp|generation:'
+```
+
+Example values after the incident:
+
+```yaml
+creationTimestamp: "2026-01-27T10:47:37Z"
+generation: 1
+```
+
+If your cluster has API audit centralisation (Loki / LogCenter / etc.), query the aggregated audit stream for the `delete`/`create` pair on the CRD and the shared `user.username`. That single query answers Step 3 without needing to pull individual node logs.
+
+Finally, cross-check whether the owner is `virt-operator` or a third party. Legitimate CRD re-creation by the KubeVirt operator comes from `system:serviceaccount:<ns>:kubevirt-operator`. Anything else — especially a ServiceAccount in a namespace named after a commercial product — is the actor to engage with.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
