### PR TITLE
[configure] kube-controller-manager garbage collector cache-sync timeouts driven by unreachable admission/conversion webhooks on ACP

### DIFF
--- a/docs/en/solutions/kube_controller_manager_Degraded_with_GarbageCollectorSyncFailed_Slow_Admission_Webhook_Blocks_the_GC_Dependency_Graph_Build.md
+++ b/docs/en/solutions/kube_controller_manager_Degraded_with_GarbageCollectorSyncFailed_Slow_Admission_Webhook_Blocks_the_GC_Dependency_Graph_Build.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# kube-controller-manager Degraded with GarbageCollectorSyncFailed — Slow Admission Webhook Blocks the GC Dependency-Graph Build
 ## Issue
 
 The cluster's `kube-controller-manager` reports a degraded condition continuously, with an alert named `GarbageCollectorSyncFailed` firing:

--- a/docs/en/solutions/kube_controller_manager_Degraded_with_GarbageCollectorSyncFailed_Slow_Admission_Webhook_Blocks_the_GC_Dependency_Graph_Build.md
+++ b/docs/en/solutions/kube_controller_manager_Degraded_with_GarbageCollectorSyncFailed_Slow_Admission_Webhook_Blocks_the_GC_Dependency_Graph_Build.md
@@ -1,0 +1,155 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+The cluster's `kube-controller-manager` reports a degraded condition continuously, with an alert named `GarbageCollectorSyncFailed` firing:
+
+```text
+kube-controller-manager  True False True  GarbageCollectorDegraded: alerts firing: GarbageCollectorSyncFailed
+```
+
+The garbage collector itself is still active — pods with `DeletionTimestamp` eventually finalise, orphaned objects get cleaned up. But on the control-plane status view the alert never clears. Controller-manager logs repeat:
+
+```text
+E0122 13:36:34.998039 1 shared_informer.go:316] "Unhandled Error"
+  err="unable to sync caches for garbage collector" logger="UnhandledError"
+E0122 13:36:34.999234 1 garbagecollector.go:268] "Unhandled Error"
+  err="timed out waiting for dependency graph builder sync during GC sync (attempt 10730)"
+```
+
+The attempt counter grows without bound (`attempt 10730` in this excerpt).
+
+## Root Cause
+
+The garbage collector in `kube-controller-manager` runs a **dependency-graph builder** that maintains a live view of owner-reference relationships across every API resource in the cluster. On startup and on every re-sync it must list every object of every resource kind — concretely, it issues a `list` on every Group/Version/Resource and waits for the response. When the graph is complete the GC proceeds; if the list for any resource does not complete within the sync timeout, the collector aborts that cycle and tries again.
+
+Two failure modes cause the timeout:
+
+1. **Very large total API object count.** A cluster with tens of thousands of CRDs and custom resources genuinely takes long enough to list that the per-cycle budget is exceeded. This is a capacity limit; the fix is either to reduce the CR fleet or to raise per-GC timeouts on the controller-manager.
+
+2. **A slow admission webhook fronting an API resource.** Every list, watch, and side-effect write through `kube-apiserver` traverses the webhook chain. If one webhook's endpoint is slow (the pods behind it are missing, being OOMKilled, or stuck in CrashLoopBackOff) **every API call the controller-manager makes** pays that webhook's latency tax. The controller-manager's list calls slow down proportionally; the dependency graph build blows through its budget; GC sync fails.
+
+The field-seen variant of this is a monitoring / APM agent's mutating webhook whose endpoint pods are unhealthy. Example: a `MutatingWebhookConfiguration` named `<apm-vendor>-webhook` registered as `failurePolicy: Ignore` with a `timeoutSeconds: 30`. Because the webhook is registered, every matching API operation still calls it; the `Ignore` failure policy means the request eventually succeeds — but only after the 30-second timeout expires. At scale this makes every list call 30+ seconds slow, which is far longer than the GC's per-resource budget.
+
+The fix is to either remove the orphaned webhook (if the product that registered it is no longer installed) or restore the product pods so the webhook endpoint returns quickly.
+
+## Resolution
+
+### Step 1 — confirm the signature matches this cause
+
+```bash
+kubectl logs -n kube-system -l component=kube-controller-manager --tail=300 | \
+  grep -E 'garbage collector|dependency graph builder sync' | head -20
+```
+
+A repeating `timed out waiting for dependency graph builder sync` with an ever-increasing `(attempt N)` is the match.
+
+### Step 2 — list every webhook that could be slowing API calls
+
+```bash
+kubectl get mutatingwebhookconfiguration \
+  -o=custom-columns='NAME:.metadata.name,TIMEOUT:.webhooks[*].timeoutSeconds,POLICY:.webhooks[*].failurePolicy,SERVICE:.webhooks[*].clientConfig.service.name'
+
+kubectl get validatingwebhookconfiguration \
+  -o=custom-columns='NAME:.metadata.name,TIMEOUT:.webhooks[*].timeoutSeconds,POLICY:.webhooks[*].failurePolicy,SERVICE:.webhooks[*].clientConfig.service.name'
+```
+
+Look for:
+
+- Webhooks whose `service.name` points to a namespace / service you do not recognise or that belongs to a product your team has removed.
+- High timeout values (10 s, 30 s). A healthy webhook returns in single-digit milliseconds; a multi-second timeout is space for something to go wrong.
+- `failurePolicy: Ignore` combined with a high timeout — these are the silent ones, because requests still succeed, so no user-facing error is raised even while every request slows down.
+
+### Step 3 — check the webhook's backend pods
+
+For each suspect webhook, locate the Service it points to and check its endpoints:
+
+```bash
+SVC=<service-name>; NS=<namespace>
+
+kubectl -n "$NS" get endpoints "$SVC" -o=jsonpath='{.subsets[*].addresses[*].ip}{"\n"}'
+
+# Correlate with the pods behind that selector:
+kubectl -n "$NS" get pod -l <webhook-pod-label> -o=custom-columns='NAME:.metadata.name,STATUS:.status.phase,RESTARTS:.status.containerStatuses[0].restartCount,REASON:.status.containerStatuses[0].lastState.terminated.reason'
+```
+
+Missing endpoints (empty address list) or repeated `OOMKilled` / `CrashLoopBackOff` status are the confirmation. The webhook is registered but its backend cannot answer.
+
+### Step 4 — restore or remove the webhook
+
+**If the product is required** and should be running: fix the pods. Usually this means checking the deployment's image pull (if the registry is unreachable), raising memory limits (if OOM-killed), or repairing the namespace's config (if the pods are crashing on startup).
+
+**If the product is not required**, the clean action is to remove the webhook configuration rather than leaving an orphan:
+
+```bash
+kubectl delete mutatingwebhookconfiguration <name>
+kubectl delete validatingwebhookconfiguration <name>
+```
+
+Removing the webhook immediately unblocks the slow API path — the next `kube-apiserver` request that would have traversed this webhook returns in milliseconds.
+
+### Step 5 — verify the GC recovers
+
+Within 1–2 minutes the next GC sync cycle runs. On a healthy cluster the sync completes well under its budget and the degraded condition clears:
+
+```bash
+kubectl logs -n kube-system -l component=kube-controller-manager --tail=200 | \
+  grep -c 'timed out waiting for dependency graph builder sync'
+```
+
+The line count should stop incrementing. Re-run the same grep 5 minutes later — a cluster that is still producing new timeout lines has another slow webhook or a genuine scale issue (jump to Step 6).
+
+### Step 6 — if the cluster is genuinely large and no orphan webhooks were found
+
+A cluster with millions of CRs across thousands of namespaces can run into this error without any orphan webhook. Validate by measuring a list call directly:
+
+```bash
+time kubectl get --raw='/apis/apiextensions.k8s.io/v1/customresourcedefinitions' >/dev/null
+```
+
+On a healthy cluster this returns in well under 1 second. Multi-second response time indicates either a still-slow webhook chain or a genuine scale issue.
+
+If genuinely scale-bound:
+
+- Raise the controller-manager's `--concurrent-gc-syncs` (default 20) — a higher value parallelises the list calls.
+- Consider `--leader-elect-retry-period` and the sync timeout adjustments if you administer the binary yourself.
+- Audit your CRD inventory — clusters with thousands of CRDs often have generated resources (per-user, per-tenant) that could be consolidated. Each CRD is one list call per sync cycle.
+
+## Diagnostic Steps
+
+Confirm the dependency-graph build is specifically the failing stage:
+
+```bash
+kubectl logs -n kube-system -l component=kube-controller-manager --tail=500 | \
+  grep -E 'dependency graph|caches to sync|GC sync' | tail -20
+```
+
+A healthy output shows `Waiting for caches to sync for garbage collector` followed by `Caches are synced for garbage collector` within a few seconds. A broken cluster shows the `Waiting` line followed by multiple `timed out waiting for dependency graph builder sync` lines before another `Waiting` line — the collector keeps retrying.
+
+Measure per-webhook latency by capturing webhook admission duration from the apiserver's metrics:
+
+```bash
+kubectl get --raw='/metrics' 2>/dev/null | \
+  grep -E 'apiserver_admission_webhook_admission_duration_seconds_bucket' | \
+  awk -F'[{}]' '/le="([0-9]+\.[0-9]+|\+Inf)"/ {print $2}' | \
+  sort -u | head
+```
+
+The histogram by name + URL shows you which webhook is slow. For affected clusters one webhook dominates.
+
+Check the specific error text — the GC error should name "dependency graph builder", not a different controller's sync issue. Other controller-manager syncs (e.g. deployment, replicaset) can also fail caches-sync, but those have different remediations:
+
+```bash
+kubectl logs -n kube-system -l component=kube-controller-manager --tail=500 | \
+  awk '/Unhandled Error/ {print $NF}' | sort | uniq -c | sort -rn
+```
+
+`dependency graph builder sync` should be the dominant error when this runbook applies.
+
+Finally, verify that after removing a suspect orphan webhook the `kube-controller-manager` recovery holds for at least 10 minutes. Intermittent GC failures can be caused by a webhook whose endpoint is healthy in short windows but slow under load; if the degraded condition returns, repeat Step 3 at the next event to find the flaky service.

--- a/docs/en/solutions/kube_controller_manager_garbage_collector_cache_sync_timeouts_driven_by_unreachable_admissionconversion_webhooks_on_ACP.md
+++ b/docs/en/solutions/kube_controller_manager_garbage_collector_cache_sync_timeouts_driven_by_unreachable_admissionconversion_webhooks_on_ACP.md
@@ -1,0 +1,85 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# kube-controller-manager garbage collector cache-sync timeouts driven by unreachable admission/conversion webhooks on ACP
+
+## Issue
+
+On Alauda Container Platform (Kubernetes `v1.34.5`, kube-controller-manager image tag `v1.34.5`) the `kube-controller-manager` runs as a kubelet-managed static pod `kube-controller-manager-<nodeIP>` in the `kube-system` namespace; the garbage-collector controller built into that binary logs `Waiting for caches to sync for garbage collector` at startup and during reconcile (upstream source `shared_informer.go`, with the exact source line varying by build).
+
+When the garbage-collector controller's dependency-graph builder cannot finish syncing within its wait window, the same kube-controller-manager static pod emits `Unhandled Error err="unable to sync caches for garbage collector" logger="UnhandledError"` followed by `Unhandled Error err="timed out waiting for dependency graph builder sync during GC sync (attempt <N>)" logger="UnhandledError"` from the `garbagecollector.go` emitter. The pod-garbage-collector sub-controller inside the same binary independently emits `"Garbage collecting pods" logger="pod-garbage-collector-controller" numPods=<N>` and per-pod `"PodGC is force deleting Pod" logger="pod-garbage-collector-controller" pod="<ns>/<name>"` lines from `gc_controller.go` during a pod-GC sweep, so the two loggers are observable side-by-side when reading the static pod's log stream.
+
+The entry point for diagnosing this failure mode is inspection of the kube-controller-manager static pod itself in `kube-system` plus the GC log lines above — those log lines come from the same `garbagecollector.go` / `gc_controller.go` / `shared_informer.go` emitters observable on any conformant Kubernetes cluster running this kube-controller-manager build, with admission and conversion-webhook posture as the adjacent surface to check.
+
+## Root Cause
+
+The most common driver of these cache-sync timeouts is an unreachable admission or conversion webhook that the kube-apiserver must call while serving the list/watch requests the garbage collector's dependency-graph builder issues. When a registered `CustomResourceDefinition` declares `spec.conversion.strategy: Webhook` and its target webhook Service has no Ready endpoints, kube-apiserver's storage cacher / reflector logs `failed to list <group>/<version>, Kind=<Kind>: conversion webhook for <group>/<otherVersion>, Kind=<Kind> failed: Post "https://<svc>.<ns>.svc:443/convert?timeout=30s": no endpoints available for service "<svc>"` from the upstream `storage/cacher.go` and `reflector.go` sources and reinitializes the cacher. ACP today has at least four CRDs configured with `spec.conversion.strategy: Webhook` (`argocds.argoproj.io`, `clusterclasses.cluster.x-k8s.io`, `monitordashboards.ait.alauda.io`, `opentelemetrycollectors.opentelemetry.io`), any of which can drive this path if its backing webhook Service loses endpoints.
+
+Each conversion-webhook call that the kube-apiserver makes to an unreachable webhook Service blocks the apiserver list/watch path for the affected CRD and adds per-call latency up to the per-webhook `timeoutSeconds` (default reflected in the `?timeout=30s` query parameter on conversion calls). That latency propagates to every controller — including the kube-controller-manager garbage collector and its leader-election renewals — that needs to read the affected resources, which is why GC dependency-graph builder sync can time out even though the controller itself is healthy. The same shape applies to admission webhooks: the `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` types in `admissionregistration.k8s.io/v1` define per-webhook `timeoutSeconds` (integer 1-30, default 10) and `failurePolicy` (enum `{Fail, Ignore}`), and a webhook with `failurePolicy: Fail` whose backing Service has no Ready endpoints blocks admission until that timeout elapses.
+
+Intermittent GC cache-sync timeouts can also be driven by a very large total number of API resources / CRDs registered on the cluster, because the garbage collector's dependency-graph builder must discover and watch every resource type before it can declare caches synced; cost scales with that count. Independently, kube-controller-manager renews its leader lease via the `kube-system/kube-controller-manager` Lease object (`coordination.k8s.io/v1`) with `--leader-elect=true` set on its static pod command line, and when the API call to that lease endpoint is slowed by the same upstream apiserver latency it logs `error retrieving resource lock kube-system/kube-controller-manager: Get "<apiserver-url>/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-controller-manager?timeout=<N>s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)` or `: context deadline exceeded` from `leaderelection.go` — the same emitter, with the apiserver-URL host portion reflecting whatever the cluster's control-plane endpoint resolves to.
+
+## Resolution
+
+Restore the webhook's backing pods to a Ready state so the target Service has Ready endpoints again; this eliminates the `no endpoints available for service` rejection and allows the webhook calls to succeed without timing out, which in turn lets the garbage collector's dependency-graph builder finish syncing and the apiserver list/watch path resume normal latency.
+
+Alternatively, when the webhook's backing workload cannot be recovered promptly and the webhook is not required for the operation of the cluster, delete the offending admission webhook configuration object — removing it eliminates the per-call latency that webhook adds to kube-apiserver admission and list/watch paths:
+
+```bash
+kubectl delete mutatingwebhookconfiguration <name>
+kubectl delete validatingwebhookconfiguration <name>
+```
+
+For an unreachable conversion webhook tied to a CRD, the equivalent unblock is to restore the backing Service endpoints, since the conversion-webhook clientConfig is part of the CRD spec and the `apiextensions.k8s.io/v1` `ServiceReference` shape (`name` required, `namespace` required, `path` optional, `port` default 443) is byte-identical to the standard form.
+
+## Diagnostic Steps
+
+Read the kube-controller-manager static pod log stream in `kube-system` for the `garbage-collector-controller` and `pod-garbage-collector-controller` loggers — the upstream `shared_informer.go`, `garbagecollector.go`, and `gc_controller.go` emitters all log against these loggers, so a single log fetch surfaces the GC startup, cache-sync, and pod-GC sweep lines:
+
+```bash
+kubectl get pods -n kube-system | grep kube-controller-manager
+kubectl logs -n kube-system kube-controller-manager-<nodeIP> \
+  | grep -E 'garbage|GC|garbagecollector|gc_controller|shared_informer'
+```
+
+Look for the leader-election precursor `error retrieving resource lock kube-system/kube-controller-manager` line in the same stream — its appearance alongside GC cache-sync errors points to upstream apiserver latency rather than a controller-local problem, since lease renewals run on the same client the controllers use:
+
+```bash
+kubectl get lease -n kube-system kube-controller-manager -o yaml
+```
+
+Enumerate the admission webhooks the kube-apiserver will call during admission, plus the conversion webhooks the apiserver storage cacher will call while serving list/watch — listing `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` (cluster-scoped in `admissionregistration.k8s.io/v1`) and inspecting each for the target Service and `clientConfig` / `failurePolicy` identifies the candidate offending webhook:
+
+```bash
+kubectl get mutatingwebhookconfiguration
+kubectl get validatingwebhookconfiguration
+kubectl describe mutatingwebhookconfiguration <name>
+```
+
+Cross-reference each webhook configuration's target Service against the current Endpoints in its namespace — a webhook whose `clientConfig.service` points at a Service with no Ready endpoints is the candidate for either Service-side recovery (Resolution `c11_b`) or webhook-config deletion (Resolution `c11_a`):
+
+```bash
+kubectl -n <webhook-svc-namespace> get endpoints <webhook-svc-name> -o yaml
+```
+
+For CRDs that go through a conversion webhook, list those with `spec.conversion.strategy: Webhook` and inspect each one's `spec.conversion.webhook.clientConfig.service` against the matching Service Endpoints — the conversion-webhook clientConfig follows the upstream `apiextensions.k8s.io/v1` `ServiceReference` shape (`name` required, `namespace` required, `path` optional, `port` default 443) so the same Endpoints check applies:
+
+```bash
+kubectl get crd \
+  -o jsonpath='{range .items[?(@.spec.conversion.strategy=="Webhook")]}{.metadata.name}{"\n"}{end}'
+kubectl get crd <name> \
+  -o jsonpath='{.spec.conversion.webhook.clientConfig.service}{"\n"}'
+```
+
+When the total number of registered CRDs and API resources is unusually large, factor that into the cache-sync timeout window — the garbage collector's dependency-graph builder must discover and watch every kind before caches sync, and cost scales with the count:
+
+```bash
+kubectl api-resources | wc -l
+kubectl get crd | wc -l
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章。
