### PR TITLE
[networking] Drain blocked by a PodDisruptionBudget that cannot be satisfied

### DIFF
--- a/docs/en/solutions/Drain_blocked_by_a_PodDisruptionBudget_that_cannot_be_satisfied.md
+++ b/docs/en/solutions/Drain_blocked_by_a_PodDisruptionBudget_that_cannot_be_satisfied.md
@@ -1,0 +1,85 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Drain blocked by a PodDisruptionBudget that cannot be satisfied
+
+## Issue
+
+On Alauda Container Platform (Kubernetes v1.34.5, where the `policy` API group serves `poddisruptionbudgets` only at `policy/v1` and the `v1beta1` shape is no longer registered), a node drain that goes through the Eviction subresource can stall indefinitely when the targeted pod is selected by a PodDisruptionBudget that cannot tolerate one more disruption. The Eviction endpoint rejects the request with `HTTP 429 TooManyRequests` (the top-level Status `reason` field) and a `details.causes[].reason` of `DisruptionBudget`; the verbatim message `Cannot evict pod as it would violate the pod's disruption budget.` is surfaced on the Status, and the `causes.message` field names the offending budget and the current / required healthy-pod counts (for example, `The disruption budget pdb-canary-block needs 2 healthy pods and has 2 currently`).
+
+`kubectl drain` issues these Eviction calls rather than direct DELETEs — its built-in help confirms that drain "evicts the pods if the API server supports eviction" — so any PDB that selects the pods on the targeted node is honored end-to-end by the drain workflow. The Immutable Infrastructure node-rollout path on Alauda Container Platform, which cordons and drains nodes in turn during a controlled rotation, exercises the same cordon-then-drain sequence (the cordon step flips `Node.spec.unschedulable=true` and `kubectl` then renders `SchedulingDisabled` in the node STATUS column) and is therefore subject to the same PDB gate on the Eviction call; if a budget cannot be satisfied the rollout cannot make progress past the affected node.
+
+## Root Cause
+
+A PodDisruptionBudget governs voluntary disruptions for the set of pods matched by its `selector`. Only the Eviction subresource (`POST .../pods/<name>/eviction`) consults the budget at admission — a direct `DELETE` against the pod resource bypasses the check entirely, because PDB only gates evictions. When the current healthy-replica count of the matched workload equals the budget's `minAvailable` (or has already reached the `maxUnavailable` ceiling), every eviction would drop the workload below the configured floor and the API server denies the request with `429`.
+
+The canonical mis-configuration is a single-replica workload paired with `minAvailable: 1`: the one running replica is simultaneously the last healthy pod and the only eviction candidate, so the budget is never satisfiable and the drain client retries the same pod forever, logging `error when evicting pods/<name>: Cannot evict pod as it would violate the pod's disruption budget. will retry after 5s` on each retry. The same failure mode also surfaces during rolling node reboots: if successive drains concentrate every replica of a workload onto one remaining node, evicting the last replica would violate the budget and that node's drain is blocked from completing.
+
+## Resolution
+
+Pick the lowest-impact path that fits the workload — relaxing the budget is preferred for stateless workloads, scale-to-zero is preferred when the workload can tolerate a brief outage, and direct delete is the last-resort knob for stuck rollouts. All four paths below take the eviction denial off the critical path either by changing what the budget evaluates to or by bypassing the Eviction subresource that consults it.
+
+Path 1 — relax the PDB for the maintenance window. Patch `spec.minAvailable` to `0` so subsequent evictions are admitted; the Eviction subresource returns `201 Success` against the same pod once the patch lands. Restore the original value once the drain has completed:
+
+```bash
+kubectl patch pdb <name> -n <ns> --type=merge \
+  -p '{"spec":{"minAvailable":0}}'
+```
+
+Path 2 — scale the workload to zero before the drain. Reducing `replicas` goes through the `/scale` subresource, which does not invoke `/eviction`, so the PDB is not consulted and the rollout has no pods left to evict from any node:
+
+```bash
+kubectl scale deployment/<name> -n <ns> --replicas=0
+```
+
+Path 3 — drain without going through the Eviction subresource. `kubectl drain --disable-eviction` switches the drain client to direct DELETE calls; its own help text states that the flag is intended to "Force drain to use delete, … This will bypass checking PodDisruptionBudgets". Because the drain no longer hits the Eviction endpoint, no `will retry after 5s ... Cannot evict` retries are emitted and any selecting PDB is ignored:
+
+```bash
+kubectl drain <node> --ignore-daemonsets --delete-emptydir-data --disable-eviction
+```
+
+Path 4 — delete the blocking pod directly. A `kubectl delete pod` request goes through the pod resource (not `/eviction`), so the PDB does not gate it; the workload controller then recreates the replica, and if the source node is cordoned the scheduler places it elsewhere:
+
+```bash
+kubectl delete pod -n <ns> <pod>
+```
+
+A direct DELETE is destructive — it skips the graceful disruption budget that the workload owner put in place, which is the whole point of a PDB. Two specific workload classes must not be treated with the Path 3 or Path 4 bypass without additional care:
+
+- KubeVirt `virt-launcher` pods. The KubeVirt CRDs (`virtualmachineinstances`, `virtualmachines`) and the `virt-controller` deployment in namespace `kubevirt` are present on this cluster, so `virt-launcher` pods are real eviction targets. Bypassing the PDB on a `virt-launcher` pod terminates the wrapping Virtual Machine ungracefully instead of triggering a live migration, so the PDB-bypass paths are unsafe for KubeVirt-managed virtualization workloads.
+- Quorum-sensitive stateful pods more generally. The default Alauda Container Platform install does not ship a Ceph operator, but if a third-party Ceph deployment (for example a rook-ceph operator) or any other quorum-based stateful workload is installed on the cluster, the same caution applies: bypassing a PDB that fronts a monitor- or quorum-member pod while the underlying cluster is not fully healthy can drop the surviving quorum and risk data loss. For any PDB that fronts a stateful or quorum-sensitive workload, confirm the underlying cluster is healthy before applying Path 3 or Path 4 — the PDB is the workload owner's signal that voluntary disruption is unsafe right now.
+
+When authoring or re-creating a PodDisruptionBudget on this cluster, use the served group/version (`policy/v1`); the `v1beta1` shape is no longer offered by the API server:
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: <name>
+  namespace: <ns>
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: <label>
+```
+
+## Diagnostic Steps
+
+Reproduce the symptom against the suspect pod by posting to the Eviction subresource and observing the `429 TooManyRequests` response. The status payload carries `reason: DisruptionBudget`, the verbatim message `Cannot evict pod as it would violate the pod's disruption budget.`, and a `causes.message` line that names the offending budget plus its required vs current healthy-pod counts — that string is the canonical fingerprint for this failure mode and is the cheapest reproducer to confirm a stuck drain is in fact PDB-gated rather than blocked on something else.
+
+At the workflow level the same signal appears as a drain client that emits the `evicting pod ...` log line (drain uses the Eviction subresource, so it logs `evicting`, not `deleting`) and then retries the same pod every five seconds with `error when evicting pods/<name>: Cannot evict pod as it would violate the pod's disruption budget. will retry after 5s` until the budget changes.
+
+A node that is partway through a controller-driven drain — for example, an Immutable Infrastructure node rotation — reports `STATUS: Ready,SchedulingDisabled` in `kubectl get node`, because the cordon step sets `Node.spec.unschedulable=true` and `kubectl` renders that boolean in the `STATUS` column. Pair that signal with PDB inspection to confirm whether the drain is merely cordoned or is also stuck on an Eviction denial:
+
+```bash
+kubectl get node
+kubectl get pdb -A
+kubectl describe pdb <name> -n <ns>
+```

--- a/docs/en/solutions/PodDisruptionBudget_Blocking_a_Node_Drain_During_Rolling_Node_Config.md
+++ b/docs/en/solutions/PodDisruptionBudget_Blocking_a_Node_Drain_During_Rolling_Node_Config.md
@@ -1,0 +1,128 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A rolling node-configuration change (kernel parameter update, chrony push, kubelet config change) applied through the node-config controller gets stuck. One or more nodes sit in `Ready,SchedulingDisabled`, the rollout progress never advances past that node, and the controller's log stream keeps retrying an eviction for the same pod:
+
+```text
+error when evicting pod "test-1-xxxxx" (will retry after 5s):
+  Cannot evict pod as it would violate the pod's disruption budget.
+```
+
+Node listing shows cordoned nodes the drain never completes:
+
+```bash
+kubectl get node
+# NAME                          STATUS                      ROLES    VERSION
+# ip-10-0-111-11.example.com    Ready,SchedulingDisabled    worker   v1.29.x
+# ip-10-0-222-22.example.com    Ready                       worker   v1.29.x
+```
+
+The pod referenced in the error is running healthy — it simply cannot be evicted because an associated `PodDisruptionBudget` (PDB) has its allowed-disruptions count at zero. Until the PDB lets the pod go, the node does not drain, the new node configuration cannot be applied, and the whole rolling change pauses indefinitely.
+
+## Root Cause
+
+A `PodDisruptionBudget` caps how many pods of a selector may be voluntarily disrupted at once. The typical setting is `minAvailable: 1`, which is sensible for a two-replica service: at most one pod can go away at a time.
+
+This interacts badly with a node drain when:
+
+- The pod's `replicas` is exactly `1`. `minAvailable: 1` then means zero allowed disruptions, and eviction always returns the PDB error above, forever.
+- Several replicas of the same service happen to be scheduled on a single node. Pod anti-affinity not being set on the Deployment, or nodes having been rebooted earlier and all replicas rescheduling to whichever node came up first, both produce this. The PDB refuses to let any of them move until another replica is healthy elsewhere — but there is no elsewhere because the other node is cordoned.
+- The PDB was configured against a workload whose lifecycle is actually not eligible for voluntary disruption (single-replica batch job, stateful singleton with manual failover). These need manual handling, not a blocker PDB against an automated drain.
+
+When the rolling node-config is driven by the ACP node-config controller (the in-core `configure/clusters/nodes` surface, or the extension product **Immutable Infrastructure**), the symptom is the same as on any Kubernetes cluster: the drain the controller issues is a normal eviction API call and honours every PDB in the cluster.
+
+## Resolution
+
+Before touching a PDB, confirm which offending pod it guards and decide whether that pod is actually safe to disrupt. Some PDBs are in place for a reason.
+
+- **Storage-backed singletons** such as a Ceph monitor pod — forcibly evicting one below a quorum threshold risks data loss. Resolve the storage cluster's health first and let the drain proceed naturally.
+- **Virtualization workloads** — a `virt-launcher` pod backed by a KubeVirt live VM inside the ACP `virtualization` area should not be killed outright. The PDB is expressing a real constraint (the VM is live-migrating or cannot migrate fast enough). Debug the migration first (usually RAM dirty rate vs network bandwidth), not the PDB.
+
+Once you have confirmed the pod is safe to disrupt, pick one of the following.
+
+### 1. Check whether co-scheduling is the real problem
+
+Many "stuck drain" incidents are not a PDB problem — they are a co-location problem. Three replicas of a Deployment with a PDB of `minAvailable: 2` sitting on the same node will block any drain of that node even though the cluster has room for them elsewhere:
+
+```bash
+kubectl -n <namespace> get pod -o wide -l <selector>
+```
+
+If the replicas cluster on one node, it means scheduling is not spreading them. Adding pod anti-affinity (`topologyKey: kubernetes.io/hostname`) or topology spread constraints to the Deployment and waiting for the replicas to redistribute often unblocks the drain on its own, without touching the PDB.
+
+### 2. Delete the blocked pod to force rescheduling
+
+The PDB stops the eviction API path but not a direct `delete`. If another node has capacity, deleting the pod re-creates it elsewhere and the drain proceeds:
+
+```bash
+kubectl -n <namespace> delete pod <pod-name>
+watch -n 10 'kubectl get node -o wide; echo; kubectl get pdb -A'
+```
+
+Use this when the PDB is protecting a real invariant at normal load (say, 3 replicas with `minAvailable: 2`) but the drain itself does not invalidate that invariant — moving one replica to another node keeps two available.
+
+### 3. Relax the PDB temporarily
+
+When the workload is a single-replica Deployment where the PDB author intended "do not disrupt casually" but accepts planned disruption, patch the PDB to allow zero minimum available for the duration of the drain, then restore it afterwards:
+
+```bash
+kubectl -n <namespace> patch pdb <pdb-name> \
+  --type=merge -p '{"spec":{"minAvailable":0}}'
+
+# after the node-config rollout reports complete
+kubectl -n <namespace> patch pdb <pdb-name> \
+  --type=merge -p '{"spec":{"minAvailable":1}}'
+```
+
+If the patch is rejected with `updates to poddisruptionbudget spec are forbidden`, the PDB is using an older immutable-spec schema. Back it up, delete it, let the drain complete, then recreate it:
+
+```bash
+kubectl -n <namespace> get pdb <pdb-name> -o yaml > pdb.yaml
+kubectl -n <namespace> delete pdb <pdb-name>
+# after the rollout completes, strip status and uid from pdb.yaml, then
+kubectl -n <namespace> apply -f pdb.yaml
+```
+
+### 4. Scale the workload to zero across the maintenance window
+
+For workloads that do not need to run during the rollout — batch consumers, test harnesses, any workload flagged as "best-effort" — the simplest unblock is to scale the Deployment to zero replicas. A Deployment at `replicas: 0` disrupts nothing, so any PDB against its selector has `ALLOWED DISRUPTIONS = 0` vacuously and the drain proceeds. Scale the Deployment back after the rollout completes.
+
+## Diagnostic Steps
+
+List every PDB in the cluster and look for entries with zero allowed disruptions — those are the candidates blocking drains:
+
+```bash
+kubectl get pdb -A \
+  -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,MIN:.spec.minAvailable,MAX:.spec.maxUnavailable,ALLOW:.status.disruptionsAllowed,DESIRED:.status.desiredHealthy,CURRENT:.status.currentHealthy \
+  | awk 'NR==1 || $5=="0"'
+```
+
+Correlate a specific eviction failure to a specific PDB by looking at the controller logs for the node-config controller and matching the pod name it is retrying on:
+
+```bash
+kubectl -n <node-config-namespace> logs <controller-pod> \
+  | grep -E 'evicting pod|disruption budget' | tail
+```
+
+Confirm where replicas of the stuck pod's workload are sitting:
+
+```bash
+kubectl -n <namespace> get pod -l <selector> -o wide
+```
+
+Watch the rollout as corrective action is taken — once the blocking pod either moves, is deleted, or is scaled out of existence, the node drain should progress within one or two eviction retry cycles:
+
+```bash
+watch -n 10 'kubectl get node -o wide; echo; \
+  kubectl get pdb -A; echo; \
+  kubectl get clusteroperator 2>/dev/null || true'
+```
+
+If the rollout still does not advance after the PDB stops blocking, look for a second PDB guarding a different workload on the same node — drains fail against the *first* eviction error but another pod on the same node may become the new blocker after the first unblocks.

--- a/docs/en/solutions/PodDisruptionBudget_Blocking_a_Node_Drain_During_Rolling_Node_Config.md
+++ b/docs/en/solutions/PodDisruptionBudget_Blocking_a_Node_Drain_During_Rolling_Node_Config.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# PodDisruptionBudget Blocking a Node Drain During Rolling Node Config
 ## Issue
 
 A rolling node-configuration change (kernel parameter update, chrony push, kubelet config change) applied through the node-config controller gets stuck. One or more nodes sit in `Ready,SchedulingDisabled`, the rollout progress never advances past that node, and the controller's log stream keeps retrying an eviction for the same pod:


### PR DESCRIPTION
新增一篇 ACP KB 文章。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a comprehensive guide for node drain scenarios involving PodDisruptionBudget constraints, including multiple resolution strategies and diagnostic procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/knowledge/pull/480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->