### PR TITLE
[observability] Alertmanager Not Sending Emails Because of TLS Handshake Failure

### DIFF
--- a/docs/en/solutions/Alertmanager_Not_Sending_Emails_Because_of_TLS_Handshake_Failure.md
+++ b/docs/en/solutions/Alertmanager_Not_Sending_Emails_Because_of_TLS_Handshake_Failure.md
@@ -1,0 +1,123 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Alertmanager Not Sending Emails Because of TLS Handshake Failure
+## Issue
+
+Alertmanager is failing to deliver notifications through its email receiver. Expected alerts never arrive in the target inbox, and the Alertmanager pod log shows TLS-related errors against the configured SMTP server — for example:
+
+```text
+level=error ... component=dispatcher
+  msg="Notify for alerts failed" err="*email.loginAuth auth: EOF"
+level=error ... component=dispatcher
+  msg="Notify for alerts failed" err="establish connection: x509:
+  certificate signed by unknown authority"
+```
+
+Symptoms cluster around three shapes: the SMTP server does not advertise `STARTTLS` but Alertmanager insists on it; the server does advertise it but the presented certificate does not validate against any CA Alertmanager trusts; or the handshake succeeds but authentication on top of it fails with a garbled password because the plaintext credentials were sent before the channel was upgraded.
+
+## Root Cause
+
+Alertmanager's email receiver defaults to `require_tls: true` and uses `STARTTLS` to upgrade the SMTP session to TLS before sending credentials or payload. This is the right default — it prevents `AUTH PLAIN` credentials from ever appearing on the wire unencrypted — but it makes Alertmanager fail closed whenever the TLS side of the connection is broken for any reason:
+
+- **The SMTP server does not advertise the `STARTTLS` extension.** Many older internal relays, or "submission" (587) endpoints misconfigured as "smtp" (25), never offer `STARTTLS`. Alertmanager tries to upgrade, the server returns `502 command not recognized`, and Alertmanager aborts the session without sending anything.
+- **The SMTP server advertises `STARTTLS` but the certificate does not validate.** Self-signed cert, certificate expired, hostname in the cert does not match the hostname Alertmanager is connecting to, or the chain is not fully present and Alertmanager cannot follow it to a known root.
+- **Network path breaks the TLS session.** A transparent proxy terminating TLS mid-stream (common in some corporate networks) or a load balancer truncating the connection on an idle timeout.
+
+Disabling TLS entirely fixes the symptom but leaves SMTP credentials going out in plaintext. Treat disable-TLS as a short-lived workaround while the real problem is being fixed, not the endpoint of the investigation.
+
+## Resolution
+
+### Preferred: fix the TLS side of the SMTP relay
+
+1. **Confirm the SMTP server actually supports `STARTTLS` on the port you are using.** Run an interactive probe from inside the cluster against the same endpoint Alertmanager is configured for — use a one-shot pod with `openssl` so the probe traverses the same network policy path:
+
+   ```bash
+   kubectl -n <monitoring-namespace> run smtp-probe --rm -it \
+     --image=alpine:3.19 --restart=Never -- \
+     sh -c 'apk add --no-cache openssl >/dev/null &&
+            openssl s_client -starttls smtp \
+              -connect <smtp-host>:<port> -crlf 2>&1 | head -40'
+   ```
+
+   Expected: the server advertises `STARTTLS` and the handshake completes with a certificate whose Subject matches the hostname. If `STARTTLS` is missing, point Alertmanager at the correct port (usually 587 for submission / `STARTTLS`, 465 for implicit TLS — which Alertmanager reaches with `smtp_hello`/`smtp_smarthost` on that port and no `require_tls`).
+
+2. **If the certificate does not validate, make Alertmanager trust the issuer.** Add the CA certificate to the ConfigMap Alertmanager consumes as its trust bundle and reference it from the receiver. For an ACP monitoring stack that provisions Alertmanager through the `observability/monitor` in-core surface, the CA bundle is referenced through the monitoring stack's TLS-trust configuration; supply the PEM and the controller will mount it into the Alertmanager pod:
+
+   ```bash
+   kubectl -n <monitoring-namespace> create configmap alertmanager-smtp-ca \
+     --from-file=ca.crt=smtp-ca.crt
+   ```
+
+   Then point the email receiver at the bundle via `tls_config.ca_file` in the rendered `alertmanager.yaml` section of the stack's configuration — the monitoring controller merges user-provided receiver configuration with the platform defaults. For a self-managed Alertmanager deployment the same field is set directly in the Alertmanager config Secret.
+
+### Workaround: disable TLS verification for one receiver
+
+When the goal is to restore alerts urgently and the SMTP relay genuinely does not support TLS (internal test relay, temporary fallback), disable TLS for that one receiver. Do not disable it cluster-wide unless every configured relay is known-unencrypted.
+
+The Alertmanager config lives in a Secret. Extract it, edit, and reapply:
+
+```bash
+kubectl -n <monitoring-namespace> extract secret/kube-prometheus-alertmanager --confirm
+
+# edit alertmanager.yaml — for a single receiver:
+#   receivers:
+#     - name: testrec
+#       email_configs:
+#         - to: "ops@example.com"
+#           require_tls: false
+#
+# for the whole global default:
+#   global:
+#     smtp_require_tls: false
+
+kubectl -n <monitoring-namespace> create secret generic kube-prometheus-alertmanager \
+  --from-file=alertmanager.yaml=alertmanager.yaml \
+  --dry-run=client -o yaml \
+  | kubectl apply -f -
+```
+
+For a managed stack where the configuration Secret is owned by a controller (the `observability/monitor` surface or the Prometheus Operator reconciling it), push the change through the controller's configuration CR instead of editing the Secret directly; otherwise the controller will overwrite your edit on the next reconcile.
+
+Restart the Alertmanager pods so they pick up the new Secret on the next alert flush:
+
+```bash
+kubectl -n <monitoring-namespace> delete pod -l alertmanager=main
+kubectl -n <monitoring-namespace> get pod -l alertmanager=main
+```
+
+After the pods are `Running`, send a test alert or wait for the next real one and confirm delivery.
+
+## Diagnostic Steps
+
+Look at the exact error Alertmanager is reporting. Different phrases map to different fixes:
+
+```bash
+kubectl -n <monitoring-namespace> logs \
+  alertmanager-kube-prometheus-0 -c alertmanager --tail=200 \
+  | grep -iE 'smtp|email|tls|starttls|x509'
+```
+
+- `establish connection: x509: certificate signed by unknown authority` → certificate validation problem, fix trust.
+- `starttls: ... not recognized` or `502 command not recognized` → server does not advertise `STARTTLS`, fix the endpoint/port.
+- `auth: EOF` or `login auth: unexpected response` → TLS is up but SMTP authentication is failing, check credentials (often rotated without the Secret being updated) and whether the server expects `LOGIN` vs `PLAIN`.
+- `RequestTimeTooSkewed` or `certificate expired` — clock skew or server-side cert expiry.
+
+Probe the SMTP server directly as shown in the resolution, then compare the certificate the probe retrieves with the certificate Alertmanager is attempting to validate. A mismatch on Subject / SANs against the hostname in `smtp_smarthost` means the receiver configuration should point at whichever hostname the certificate actually covers, not an IP or short name.
+
+Validate the Alertmanager configuration syntax locally before applying:
+
+```bash
+kubectl -n <monitoring-namespace> extract secret/kube-prometheus-alertmanager --to=- \
+  | amtool check-config alertmanager.yaml
+```
+
+Syntactic errors in the email receiver (missing `smtp_smarthost`, invalid `require_tls` value) will cause Alertmanager to refuse to reload the configuration entirely — the old configuration continues to serve, which masks the fact that the new one never landed.
+
+Once deliveries resume, ensure rotation hygiene: store SMTP credentials in a separate Secret referenced by the configuration rather than inline, so rotating them does not require rewriting the full Alertmanager config each time.

--- a/docs/en/solutions/Alertmanager_Not_Sending_Emails_Because_of_TLS_Handshake_Failure.md
+++ b/docs/en/solutions/Alertmanager_Not_Sending_Emails_Because_of_TLS_Handshake_Failure.md
@@ -1,0 +1,112 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x,4.3.x
+---
+
+# Alertmanager email delivery fails to an SMTP smarthost on ACP
+
+## Issue
+
+On Alauda Container Platform clusters that have the `prometheus` ModulePlugin (v4.3.3) installed, the Alertmanager workload runs in the `cpaas-system` namespace as part of the kube-prometheus chart (`ait/chart-kube-prometheus` v4.3.1, release name `kube-prometheus`). When operators add an SMTP email receiver on top of the platform default and the smarthost interaction fails — whether at the TCP connect, the TLS negotiation, or the SMTP dialogue itself — alerts are not delivered. The actual log line shape depends on which stage of the delivery fails, so the diagnostic entry point for this class of failure is the alertmanager container log on the Alertmanager pod in `cpaas-system` [ev:c2].
+
+## Root Cause
+
+ACP ships a default Alertmanager configuration (`configForACP` in the kube-prometheus chart) that only defines a webhook receiver pointed at the platform CPAAS route — no SMTP global block and no email receiver are present out of the box. Email delivery only works once an operator layers an SMTP global section and an email receiver on top of the default, either by editing the rendered config secret or by creating an `AlertmanagerConfig` custom resource. A misconfigured `smtp_require_tls` / per-receiver `require_tls` toggle in that user-supplied overlay is the typical source of the SMTP-delivery failure surface, with the exact log line determined by where in the connect / TLS / SMTP dialogue the receiver actually rejects [ev:c5].
+
+## Resolution
+
+The Alertmanager configuration is held in a Kubernetes Secret named `alertmanager-<alertmanager-cr-name>` in the same namespace as the Alertmanager custom resource. On an ACP cluster with the standard kube-prometheus release, that resolves to Secret `alertmanager-kube-prometheus` in `cpaas-system`. The Secret's `alertmanager.yaml` key holds the rendered configuration, and editing that key followed by re-applying the Secret is the structural workaround surface for any change to the receiver layer [ev:c3].
+
+Read the current rendered configuration so the overlay is layered on top of the existing structure rather than blindly replacing it:
+
+```bash
+kubectl get secret -n cpaas-system alertmanager-kube-prometheus \
+  -o jsonpath='{.data.alertmanager\.yaml}' | base64 -d
+```
+
+A TLS handshake failure against the smarthost almost always means the smarthost's certificate is not trusted by Alertmanager or the server name does not match — not that TLS itself should be turned off. Fix the trust problem first: point the receiver at the correct CA bundle and (when needed) the matching server name, rather than disabling encryption. The `AlertmanagerConfig` CRD exposes this directly via `spec.receivers[].emailConfigs[].tlsConfig` (CA certificate, client cert/key, and `serverName`); the raw `alertmanager.yaml` form carries the equivalent `email_configs[].tls_config` block. Supplying the smarthost's issuing CA so the certificate validates is the correct resolution and keeps the SMTP session encrypted [ev:c6].
+
+```yaml
+receivers:
+- name: email-ops
+  email_configs:
+  - to: ops@example.internal
+    tls_config:
+      ca_file: /etc/alertmanager/smtp-ca/ca.crt
+      server_name: smtp.example.internal
+```
+
+Disabling TLS verification or TLS itself is a last-resort, temporary workaround — for example to confirm the smarthost is otherwise reachable while a proper CA bundle is being sourced. It sends credentials and alert contents in cleartext (or unverified), so it must not be left in place in production. If you must apply it temporarily, the relevant upstream keys are the cluster-wide `global.smtp_require_tls: false` toggle and the per-receiver `email_configs[].require_tls: false` toggle (typed `requireTLS: false` on the CRD); prefer `tls_config.insecure_skip_verify: true`, which keeps the channel encrypted while skipping only certificate validation, over `require_tls: false`, which drops encryption entirely [ev:c4].
+
+A minimal overlay layered on top of the platform-default `configForACP` looks roughly as follows — adjust receiver names and smarthost to the environment, and prefer the `tls_config` CA path above over the `*_require_tls: false` toggles shown here:
+
+```yaml
+global:
+  smtp_smarthost: smtp.example.internal:587
+  smtp_from: alerts@example.internal
+  smtp_auth_username: alerts@example.internal
+  smtp_auth_password: redacted
+  smtp_require_tls: false  # last-resort workaround only — see warning above
+receivers:
+- name: email-ops
+  email_configs:
+  - to: ops@example.internal
+    require_tls: false      # last-resort workaround only — prefer tls_config CA
+```
+
+Re-render the secret with the updated `alertmanager.yaml` and apply it back into `cpaas-system`. After editing the configuration secret, the alertmanager pod must pick up the new configuration; the typical action is to delete the alertmanager pod so the StatefulSet recreates it and the prometheus-operator-rendered secret is re-mounted into the container [ev:c7]:
+
+```bash
+kubectl delete pod -n cpaas-system -l app.kubernetes.io/name=alertmanager
+```
+
+For environments that prefer a typed, Kubernetes-native surface over hand-edited secret payloads, the `prometheus-operator` chart (`ait/chart-prometheus-operator`) ships the `AlertmanagerConfig` CRD; on this ACP install the served version is `monitoring.coreos.com/v1alpha1`. The CRD models the SMTP and TLS surface as typed fields under `spec.receivers[].emailConfigs[]` — including `smarthost`, `requireTLS`, `tlsConfig` (with CA / cert / `insecureSkipVerify`), `authUsername`, `authPassword` (Secret reference), and `forceImplicitTLS` — providing an alternative to direct edits of the raw `alertmanager.yaml` secret [ev:c6].
+
+```yaml
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: email-ops
+  namespace: cpaas-system
+spec:
+  receivers:
+  - name: email-ops
+    emailConfigs:
+    - to: ops@example.internal
+      smarthost: smtp.example.internal:587
+      requireTLS: true
+      tlsConfig:
+        ca:
+          secret:
+            name: alertmanager-smtp-ca
+            key: ca.crt
+        serverName: smtp.example.internal
+      authUsername: alerts@example.internal
+      authPassword:
+        name: alertmanager-smtp
+        key: password
+```
+
+The example above keeps TLS on (`requireTLS: true`) and supplies the smarthost CA through `tlsConfig` so the certificate validates — the preferred shape. Set `requireTLS: false` only as the temporary, production-unsafe workaround described above.
+
+## Diagnostic Steps
+
+Tail the alertmanager container log to observe the SMTP delivery failure surface and to verify recovery after the overlay change [ev:c2]:
+
+```bash
+kubectl logs -n cpaas-system -l app.kubernetes.io/name=alertmanager \
+  -c alertmanager --tail=200 -f
+```
+
+Inspect the active configuration the running pod has mounted to make sure the overlay reached the workload rather than only the Secret object [ev:c3]:
+
+```bash
+kubectl get secret -n cpaas-system alertmanager-kube-prometheus \
+  -o jsonpath='{.data.alertmanager\.yaml}' | base64 -d
+```
+
+If the rendered configuration looks correct but the log still shows the prior failure, the pod has not yet re-mounted the updated secret; delete the alertmanager pod so the StatefulSet recreates it and the new configuration is picked up [ev:c7].


### PR DESCRIPTION
ACP-native solution, re-verified on a live cluster (Kubernetes v1.34.5). Asserts only runtime-verified claims, with concrete version/namespace anchors and per-paragraph evidence references.