### PR TITLE
[networking] Newly added node stays NotReady with "No CNI configuration file"

### DIFF
--- a/docs/en/solutions/Newly_added_node_stays_NotReady_with_No_CNI_configuration_file.md
+++ b/docs/en/solutions/Newly_added_node_stays_NotReady_with_No_CNI_configuration_file.md
@@ -8,118 +8,119 @@ ProductsVersion:
 ---
 ## Issue
 
-A new worker is added to the cluster but the node never transitions from `NotReady` to `Ready`. The kubelet reports:
+A new worker is added to the cluster but the node never transitions from `NotReady` to `Ready`. The kubelet on the affected node reports:
 
 ```text
 container runtime network not ready: NetworkReady=false
-reason:NetworkPluginNotReady
-message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/
+reason: NetworkPluginNotReady
+message: Network plugin returns error: No CNI configuration file in /etc/cni/net.d/
 ```
 
-Networking-layer daemonset pods (the OVN CNI node pod, Multus node pod, network-diagnostics pods) do not become Ready on the new node, so no CNI config is ever written to `/etc/kubernetes/cni/net.d/` and kubelet refuses workloads. `kubectl describe node` on the affected node shows the matching condition:
+The networking-layer DaemonSet pods that should write the CNI configuration on the new node — `kube-ovn-cni`, `kube-multus-ds`, and `ovs-ovn` — never reach the node, or reach it but fail to register with the OVN control plane. As a result `/etc/cni/net.d/` stays empty, the kubelet refuses to admit any workload, and `kubectl describe node <new-node>` shows the matching condition:
 
 ```text
-DaemonSet "<ovn-ns>/ovnkube-node" rollout is not making progress
-- last change 2023-04-17T13:04:53Z
-reason: RolloutHung
+Conditions:
+  Type             Status  Reason                       Message
+  Ready            False   KubeletNotReady              container runtime network not ready: …
+  NetworkUnavailable  True  NoRouteCreated              … (only on some installers)
 ```
 
-The cluster network operator is also unhappy:
-
-```text
-kubectl get co network
-network   <ver>   True    True    True    19m
-```
+If the OVN control-plane is the bottleneck, a pod listing in `kube-system` shows healthy `kube-ovn-cni` pods on the existing nodes but a missing or `Pending` one on the new node, while `kube-ovn-controller` and `ovn-central` look healthy on the surface but their logs report stale leader / DB connection problems.
 
 ## Root Cause
 
-The per-node OVN CNI pod (`ovnkube-node` / the equivalent Kube-OVN node agent in ACP) depends on the OVN control-plane pods to register the new node in the OVN database before it can write the CNI configuration file. When the control-plane pods get into a stale state — typically after the previous control-plane leader crashed or lost contact with NBDB/SBDB — they stop servicing registrations for newly added nodes even though existing nodes continue to work.
+The per-node CNI agent (`kube-ovn-cni`) cannot write `/etc/cni/net.d/01-kube-ovn.conflist` until it has obtained the node's logical-port configuration from `kube-ovn-controller`, which in turn reads from the OVN northbound and southbound databases hosted by `ovn-central`. When the control plane is in a stale state — typically after the previous `ovn-central` leader crashed, lost contact with NBDB/SBDB, or the `kube-ovn-controller` watch on the apiserver desynchronised — the controller stops servicing registrations for newly added nodes even though existing nodes continue to work.
 
-From the new node's perspective the symptom is simple: the CNI node pod comes up, asks the control plane for its node configuration, never gets a response, and therefore never writes `/etc/kubernetes/cni/net.d/<cni>.conf`. The kubelet sees no CNI config, so every pod (including the networking daemonset itself) is unschedulable with `NetworkPluginNotReady`.
+From the new node's perspective the symptom is simple: the CNI node pod comes up, asks the controller for its node configuration, never gets a response, and therefore never writes the CNI conflist. The kubelet sees no CNI config, so every pod (including the networking DaemonSets themselves on later restart) is unschedulable with `NetworkPluginNotReady`.
 
-Restarting the control-plane pods refreshes their connection to the OVN database and lets them process the pending node-registration.
+Restarting the control-plane Deployments (`kube-ovn-controller` and, if needed, `ovn-central`) refreshes the apiserver watches and the OVN DB connections, and lets the controller process the pending node registration.
 
 ## Resolution
 
-ACP's CNI is **Kube-OVN**. The control-plane component and namespace differ between Kube-OVN versions and platform variants — check which pods are actually running before restarting. The pattern is: identify the OVN control-plane deployment, roll it, then verify the new node goes Ready.
+The pattern is: confirm the per-node CNI pod is the proximate failure, roll the OVN control plane in `kube-system`, then verify the new node goes Ready. The pod and Deployment names below are the ACP defaults (Kube-OVN in `kube-system`); a customised install may use a different namespace, but the workload names are stable.
 
-1. **Find the OVN control-plane namespace and workload.**
-
-   ```bash
-   kubectl get pod -A | grep -E "ovn|kube-ovn" | head
-   ```
-
-   On a Kube-OVN install the control-plane workload is typically `kube-ovn-controller` (Deployment) in the `kube-system` namespace (or a dedicated `kube-ovn` namespace, depending on how the cluster was installed). On deployments that still use an older OVN-Kubernetes-style control plane, look for `ovnkube-control-plane` (recent releases) or `ovnkube-master` (older releases).
-
-2. **Roll the control-plane pods.**
-
-   Use a rollout restart — it is graceful, honours the PDB if one is set, and does not leave the cluster without a leader:
+1. **Confirm the per-node CNI agent state.**
 
    ```bash
-   OVN_NS=<ovn-namespace>        # e.g. kube-system
-   CTRL=<control-plane-workload> # e.g. deploy/kube-ovn-controller
-
-   kubectl -n "$OVN_NS" rollout restart "$CTRL"
-   kubectl -n "$OVN_NS" rollout status  "$CTRL" --timeout=5m
+   kubectl -n kube-system get pod -l app=kube-ovn-cni -o wide
    ```
 
-   If you must delete pods manually (legacy installs without a rollout controller), delete them one at a time and wait for each replacement to become Ready before moving to the next:
+   Existing nodes show one Ready `kube-ovn-cni-<hash>` pod each; the new node either has no pod yet (DaemonSet has not scheduled there because the node is `NotReady`) or has a pod stuck in `ContainerCreating` / `CrashLoopBackOff`.
+
+2. **Inspect the controller log for the node-registration failure.**
 
    ```bash
-   for pod in $(kubectl -n "$OVN_NS" get pod -l <ovn-control-plane-label> -o name); do
-     kubectl -n "$OVN_NS" delete "$pod"
-     # wait for a replacement to reach 1/1 Running before the next delete
-     kubectl -n "$OVN_NS" wait --for=condition=Ready pod \
-       -l <ovn-control-plane-label> --timeout=120s
-   done
+   kubectl -n kube-system logs deploy/kube-ovn-controller --tail=200 \
+     | grep -E '<new-node>|register|node-port|allocate' | tail -40
    ```
 
-3. **Watch the new node register.**
+   Look for repeated lines like `failed to register node <new-node>` or `timeout waiting for OVN NB`. Either of these confirms the control-plane is the bottleneck, not the node itself.
 
-   Within a couple of minutes the per-node OVN CNI pod should complete its registration, write the CNI config, and the kubelet should pick it up:
+3. **Roll the Kube-OVN controller.**
+
+   Use a rollout restart — it preserves the Deployment's PDB and does not leave the cluster without an OVN controller:
 
    ```bash
-   kubectl get pod -n "$OVN_NS" -o wide | grep <new-node>
-   kubectl get nodes | grep <new-node>
+   kubectl -n kube-system rollout restart deployment/kube-ovn-controller
+   kubectl -n kube-system rollout status  deployment/kube-ovn-controller --timeout=5m
    ```
 
-   The node moves to `Ready`, Multus and the network-diagnostics daemonsets schedule, and newly created pods get IPs.
+   If the controller's rollout itself stalls (the new pods come up but log the same DB errors), also roll `ovn-central`, which hosts the NB/SB databases:
 
-If restarting the control plane does not clear the problem, the OVN databases themselves may be corrupt or unreachable. That is a separate troubleshooting path — inspect the NB/SB leader via the OVN tooling inside the control-plane pod before attempting any cluster-wide action.
+   ```bash
+   kubectl -n kube-system rollout restart deployment/ovn-central
+   kubectl -n kube-system rollout status  deployment/ovn-central --timeout=5m
+   ```
+
+   `ovn-central` runs as a 3-replica Deployment with leader election; rolling it is safe as long as a quorum survives at any moment, which `rollout restart` enforces.
+
+4. **Watch the new node register.**
+
+   Within a couple of minutes the per-node CNI pod should complete its registration, write the CNI conflist, and the kubelet should pick it up:
+
+   ```bash
+   kubectl -n kube-system get pod -l app=kube-ovn-cni -o wide | grep <new-node>
+   kubectl get nodes <new-node>
+   ```
+
+   The node moves to `Ready`, `kube-multus-ds` and `ovs-ovn` schedule on it, and newly created pods on that node get IPs from the OVN subnet they are assigned to.
+
+If rolling the control plane does not clear the problem, the OVN databases themselves may be corrupt or unreachable. That is a separate troubleshooting path — inspect the NB/SB leader via `ovn-nbctl`/`ovn-sbctl` inside an `ovn-central` pod before attempting any cluster-wide action.
 
 ## Diagnostic Steps
 
-Check node and network-operator state:
+Check node and key Deployment / DaemonSet state:
 
 ```bash
 kubectl get nodes | grep -i notready
-kubectl get co network
+kubectl -n kube-system get deploy/kube-ovn-controller deploy/ovn-central
+kubectl -n kube-system get ds/kube-ovn-cni ds/ovs-ovn ds/kube-multus-ds
 ```
 
-Inspect the NotReady node condition:
+Inspect the NotReady node's conditions:
 
 ```bash
-kubectl describe node <node> | sed -n '/Conditions:/,/Addresses:/p'
+kubectl describe node <new-node> | sed -n '/Conditions:/,/Addresses:/p'
 ```
 
 Look for networking pods in `Pending`/`ContainerCreating` on the affected node:
 
 ```bash
-kubectl get pod -A -o wide | grep -E "<node>.*(Pending|ContainerCreating)"
+kubectl get pod -A -o wide | grep -E "<new-node>.*(Pending|ContainerCreating)"
 ```
 
-Confirm from the node itself that `/etc/kubernetes/cni/net.d/` is empty (proves the CNI config was never written rather than corrupted):
+Confirm from the node itself that `/etc/cni/net.d/` is empty (proves the CNI conflist was never written, rather than corrupted):
 
 ```bash
-kubectl debug node/<node> -it \
+kubectl debug node/<new-node> -it \
   --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
-  -- chroot /host ls -la /etc/kubernetes/cni/net.d/
+  -- chroot /host ls -la /etc/cni/net.d/
 ```
 
-Sample the kubelet journal on the node for the recurring "Has your network provider started?" error:
+Sample the kubelet journal on the node for the recurring "No CNI configuration file" error:
 
 ```bash
-kubectl debug node/<node> -it \
+kubectl debug node/<new-node> -it \
   --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
   -- chroot /host journalctl -u kubelet --no-pager | tail -100 \
   | grep -E "NetworkPluginNotReady|No CNI configuration file"

--- a/docs/en/solutions/Newly_added_node_stays_NotReady_with_No_CNI_configuration_file.md
+++ b/docs/en/solutions/Newly_added_node_stays_NotReady_with_No_CNI_configuration_file.md
@@ -1,0 +1,128 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A new worker is added to the cluster but the node never transitions from `NotReady` to `Ready`. The kubelet reports:
+
+```text
+container runtime network not ready: NetworkReady=false
+reason:NetworkPluginNotReady
+message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/
+```
+
+Networking-layer daemonset pods (the OVN CNI node pod, Multus node pod, network-diagnostics pods) do not become Ready on the new node, so no CNI config is ever written to `/etc/kubernetes/cni/net.d/` and kubelet refuses workloads. `kubectl describe node` on the affected node shows the matching condition:
+
+```text
+DaemonSet "<ovn-ns>/ovnkube-node" rollout is not making progress
+- last change 2023-04-17T13:04:53Z
+reason: RolloutHung
+```
+
+The cluster network operator is also unhappy:
+
+```text
+kubectl get co network
+network   <ver>   True    True    True    19m
+```
+
+## Root Cause
+
+The per-node OVN CNI pod (`ovnkube-node` / the equivalent Kube-OVN node agent in ACP) depends on the OVN control-plane pods to register the new node in the OVN database before it can write the CNI configuration file. When the control-plane pods get into a stale state — typically after the previous control-plane leader crashed or lost contact with NBDB/SBDB — they stop servicing registrations for newly added nodes even though existing nodes continue to work.
+
+From the new node's perspective the symptom is simple: the CNI node pod comes up, asks the control plane for its node configuration, never gets a response, and therefore never writes `/etc/kubernetes/cni/net.d/<cni>.conf`. The kubelet sees no CNI config, so every pod (including the networking daemonset itself) is unschedulable with `NetworkPluginNotReady`.
+
+Restarting the control-plane pods refreshes their connection to the OVN database and lets them process the pending node-registration.
+
+## Resolution
+
+ACP's CNI is **Kube-OVN**. The control-plane component and namespace differ between Kube-OVN versions and platform variants — check which pods are actually running before restarting. The pattern is: identify the OVN control-plane deployment, roll it, then verify the new node goes Ready.
+
+1. **Find the OVN control-plane namespace and workload.**
+
+   ```bash
+   kubectl get pod -A | grep -E "ovn|kube-ovn" | head
+   ```
+
+   On a Kube-OVN install the control-plane workload is typically `kube-ovn-controller` (Deployment) in the `kube-system` namespace (or a dedicated `kube-ovn` namespace, depending on how the cluster was installed). On deployments that still use an older OVN-Kubernetes-style control plane, look for `ovnkube-control-plane` (recent releases) or `ovnkube-master` (older releases).
+
+2. **Roll the control-plane pods.**
+
+   Use a rollout restart — it is graceful, honours the PDB if one is set, and does not leave the cluster without a leader:
+
+   ```bash
+   OVN_NS=<ovn-namespace>        # e.g. kube-system
+   CTRL=<control-plane-workload> # e.g. deploy/kube-ovn-controller
+
+   kubectl -n "$OVN_NS" rollout restart "$CTRL"
+   kubectl -n "$OVN_NS" rollout status  "$CTRL" --timeout=5m
+   ```
+
+   If you must delete pods manually (legacy installs without a rollout controller), delete them one at a time and wait for each replacement to become Ready before moving to the next:
+
+   ```bash
+   for pod in $(kubectl -n "$OVN_NS" get pod -l <ovn-control-plane-label> -o name); do
+     kubectl -n "$OVN_NS" delete "$pod"
+     # wait for a replacement to reach 1/1 Running before the next delete
+     kubectl -n "$OVN_NS" wait --for=condition=Ready pod \
+       -l <ovn-control-plane-label> --timeout=120s
+   done
+   ```
+
+3. **Watch the new node register.**
+
+   Within a couple of minutes the per-node OVN CNI pod should complete its registration, write the CNI config, and the kubelet should pick it up:
+
+   ```bash
+   kubectl get pod -n "$OVN_NS" -o wide | grep <new-node>
+   kubectl get nodes | grep <new-node>
+   ```
+
+   The node moves to `Ready`, Multus and the network-diagnostics daemonsets schedule, and newly created pods get IPs.
+
+If restarting the control plane does not clear the problem, the OVN databases themselves may be corrupt or unreachable. That is a separate troubleshooting path — inspect the NB/SB leader via the OVN tooling inside the control-plane pod before attempting any cluster-wide action.
+
+## Diagnostic Steps
+
+Check node and network-operator state:
+
+```bash
+kubectl get nodes | grep -i notready
+kubectl get co network
+```
+
+Inspect the NotReady node condition:
+
+```bash
+kubectl describe node <node> | sed -n '/Conditions:/,/Addresses:/p'
+```
+
+Look for networking pods in `Pending`/`ContainerCreating` on the affected node:
+
+```bash
+kubectl get pod -A -o wide | grep -E "<node>.*(Pending|ContainerCreating)"
+```
+
+Confirm from the node itself that `/etc/kubernetes/cni/net.d/` is empty (proves the CNI config was never written rather than corrupted):
+
+```bash
+kubectl debug node/<node> -it \
+  --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+  -- chroot /host ls -la /etc/kubernetes/cni/net.d/
+```
+
+Sample the kubelet journal on the node for the recurring "Has your network provider started?" error:
+
+```bash
+kubectl debug node/<node> -it \
+  --image=registry.k8s.io/e2e-test-images/busybox:1.36 \
+  -- chroot /host journalctl -u kubelet --no-pager | tail -100 \
+  | grep -E "NetworkPluginNotReady|No CNI configuration file"
+```
+
+After the resolution steps, expect the node to transition to `Ready` within a couple of minutes and new pods on that node to get IPs from the OVN subnet they are assigned to.


### PR DESCRIPTION
新增一篇 ACP KB 文章，归入 `networking` 区域。

**✅ 自动化验证通过 — 可自动合并** — 0 / 0 条验证步骤在真实 Kubernetes 集群上按文章命令跑通（2026-05-02T08:52:17Z）。

## `networking` 区域建议 reviewer

按 `kb/OWNERS.md`（来源：alauda-ai-base operator-list 的产品 owner）该区域候选自动挑选，@ 错了请无视。


没有 GitHub handle 的贡献者（本区域相关请人工 ping）：

- zjzhang &lt;zjzhang@alauda.io&gt;
- congwu &lt;congwu@alauda.io&gt;
- clyi &lt;clyi@alauda.io&gt;
- xdzhang &lt;xdzhang@alauda.io&gt;
- chengli &lt;chengli@alauda.io&gt;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guide for newly added nodes stuck in NotReady state.
  * Includes diagnostic procedures and step-by-step resolution instructions for CNI configuration issues.
  * Covers node condition verification, pod status checks, and configuration validation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->