### PR TITLE
[configure] Checking ACP Cluster Health From the Command Line

### DIFF
--- a/docs/en/solutions/Checking_ACP_Cluster_Health_From_the_Command_Line.md
+++ b/docs/en/solutions/Checking_ACP_Cluster_Health_From_the_Command_Line.md
@@ -1,0 +1,156 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Checking ACP Cluster Health From the Command Line
+## Issue
+
+Routine health checks on an ACP cluster — before a change window, during an incident, or as the first pass after a page — benefit from a short CLI sequence that covers the usual fault lines: API server reachability, node readiness, platform operators, node-pool state, pending CSRs, and the etcd control plane. The goal is to answer "is anything obviously wrong?" in under a minute without having to open the web console.
+
+## Resolution
+
+Run the commands below in order on any host with a `kubeconfig` for the cluster. Each section gives the command, what a healthy output looks like, and what the common failure shapes mean.
+
+### 1. Client and server versions
+
+```bash
+kubectl version
+```
+
+Expected: the `Server Version` is populated and the `Client Version` GitVersion is the same major/minor or one version newer than the server. A blank `Server Version` block means the CLI could not reach the API — check `kubeconfig` and network path before continuing.
+
+### 2. Node status
+
+```bash
+kubectl get nodes -o wide
+```
+
+Every node should be `Ready`. Common non-healthy states and what they mean:
+
+- `NotReady` — the kubelet has stopped reporting; check the node's kubelet service and network path to the API server.
+- `Ready,SchedulingDisabled` — the node was `kubectl cordon`'d, usually during a maintenance window; nothing new will schedule there until `kubectl uncordon`.
+- Version skew between nodes — normal during a rolling upgrade; flag it only if the upgrade is not supposed to be in progress.
+
+### 3. Platform operator / controller state
+
+ACP ships a set of platform operators that reconcile the core cluster services (networking, storage, logging, monitoring, and so on). List their custom resources and look for ones whose `Available` is anything other than `True` or whose `Degraded` is not `False`:
+
+```bash
+kubectl get csv -A                            # operator subscriptions
+kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded
+kubectl get deploy -A -o wide | awk 'NR==1 || $5 != $4'
+```
+
+Any non-Running pods in a platform-owned namespace, or a Deployment whose `AVAILABLE` count is lower than `DESIRED`, is a starting point for deeper investigation. The relevant namespaces depend on what is installed on the cluster — common ones include `cluster-logging`, `cluster-monitoring`, `cluster-networking`, `cert-manager`, the virtualization operator namespace, and the GitOps / DevOps namespaces.
+
+### 4. Node-pool / machine configuration state
+
+ACP manages node configuration through the `configure/clusters/nodes` surface (and the **Immutable Infrastructure** extension where installed). The cluster keeps a set of node pools and reports on how many nodes have reconciled the current rendered configuration. The exact CRD name depends on the release; common shapes are:
+
+```bash
+# Current ACP releases (inspect which CRD the cluster actually ships):
+kubectl api-resources | grep -iE 'nodeconfig|machineconfig|nodepool'
+
+# Then list pool state against the discovered CRD name, e.g.:
+kubectl get nodeconfigpool
+# or
+kubectl get machineconfigpool
+```
+
+A healthy pool reports `UPDATED=True`, `UPDATING=False`, `DEGRADED=False` and `MACHINECOUNT == READYMACHINECOUNT == UPDATEDMACHINECOUNT`. A pool stuck on `UPDATING=True` for longer than a single node reboot usually has a stuck drain (a pod with a restrictive PDB, an unresponsive finalizer) or a failing bootstrap on one node — inspect events on the pool and logs on the holdout node.
+
+### 5. Pending CSRs
+
+A healthy cluster has no `Pending` CertificateSigningRequests:
+
+```bash
+kubectl get csr
+```
+
+`Pending` CSRs typically accumulate when:
+
+- A new node is joining and waiting for the kubelet-serving CSR to be approved.
+- Serving certificates for existing nodes are rotating and the auto-approver is not installed or is degraded.
+
+Only approve CSRs after verifying the originating node identity — blanket-approving pending CSRs is a privilege-escalation path.
+
+### 6. etcd size and health
+
+The etcd control plane runs as a static set of pods. Inspect cluster members, per-endpoint DB size, and latency:
+
+```bash
+ETCD_NS=$(kubectl get pods -A -l app=etcd -o jsonpath='{.items[0].metadata.namespace}')
+ETCD_POD=$(kubectl -n $ETCD_NS get pods -l app=etcd \
+           --field-selector='status.phase==Running' \
+           -o jsonpath='{.items[0].metadata.name}')
+
+kubectl -n $ETCD_NS exec -c etcd $ETCD_POD -- \
+  etcdctl endpoint status --cluster -w table
+
+kubectl -n $ETCD_NS exec -c etcd $ETCD_POD -- \
+  etcdctl endpoint health --cluster -w table
+```
+
+Thresholds:
+
+- DB size above **1 GiB** is a yellow flag — not a failure, but investigate why (leftover Events, a high-churn CRD, failed defrag after a compaction pass).
+- Endpoint `latency` above **10 ms** is a red flag — look for disk contention on the control-plane node, a slow remote-storage-backed etcd data volume, or a very high write QPS from a misbehaving controller.
+
+Compact and defrag when the database has grown above the guideline size:
+
+```bash
+kubectl -n $ETCD_NS exec -c etcd $ETCD_POD -- etcdctl defrag --cluster
+```
+
+Defrag blocks writes per-endpoint, so do it one member at a time during a quiet window.
+
+### 7. API-server headroom
+
+A quick sanity check on API server load — high-rate 429s or a slow API under a steady request rate is a separate class of problem:
+
+```bash
+kubectl top node 2>/dev/null          # requires metrics-server
+kubectl get --raw=/readyz?verbose | tail
+```
+
+`/readyz` returns a per-check list; every line should end in `ok`. Any `[-]...failed` line is the specific sub-subsystem to investigate next (etcd read/write, admission, leader election, and so on).
+
+## Diagnostic Steps
+
+When the commands above surface a red flag, the standard next step is to look at the offending component's events and pod logs in that namespace:
+
+```bash
+kubectl -n <ns> get events --sort-by='.lastTimestamp' | tail -20
+kubectl -n <ns> describe pod <pod>
+kubectl -n <ns> logs <pod> -c <container> --tail=200
+```
+
+For a node that is `NotReady`, drop to the node over a debug pod and inspect kubelet:
+
+```bash
+kubectl debug node/<node-name> -- \
+  journalctl -u kubelet --since=-30m --no-pager | tail -100
+```
+
+For a degraded node-pool reconcile, fetch the pool object's `.status.conditions` — the `Message` field usually names the single node that is blocking progress:
+
+```bash
+kubectl get <pool-crd>/<pool-name> -o yaml | sed -n '/conditions:/,/^[a-z]/p'
+```
+
+When in doubt, pair the CLI output above with the cluster's own event stream:
+
+```bash
+kubectl get events -A \
+  --field-selector=type!=Normal \
+  --sort-by='.lastTimestamp' | tail -40
+```
+
+A clean Warning-level event tail across the whole cluster is the strongest single-line indicator that the current state is as healthy as the individual checks suggest.
+</content>
+</invoke>

--- a/docs/en/solutions/Checking_ACP_Cluster_Health_From_the_Command_Line.md
+++ b/docs/en/solutions/Checking_ACP_Cluster_Health_From_the_Command_Line.md
@@ -1,0 +1,104 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x,4.3.x
+---
+
+# Checking cluster health using kubectl on ACP
+
+## Issue
+
+Operators of an Alauda Container Platform 4.3.x cluster (Kubernetes server `v1.34.5`, Ubuntu 22.04.1 LTS nodes with `containerd://2.2.1-5`) need a short, reproducible set of `kubectl` checks to confirm that nodes are registered and Ready, that no CertificateSigningRequest objects are pending, and that the etcd quorum is healthy. The commands below produce the headline columns an administrator scans first when triaging a control-plane incident or before a maintenance window [ev:c3][ev:c4].
+
+## Diagnostic Steps
+
+List every node registered with the cluster along with its `STATUS`, `ROLES`, `AGE`, and kubelet `VERSION` columns [ev:c3]:
+
+```bash
+kubectl get nodes
+```
+
+```text
+NAME              STATUS   ROLES                                   AGE   VERSION
+<control-plane>   Ready    control-plane,cpaas-system,master       12d   v1.34.5
+```
+
+On ACP, the `ROLES` column carries the platform-specific `cpaas-system` role in addition to the upstream `control-plane` / `master` roles [ev:c3].
+
+Append `-o wide` to add the `INTERNAL-IP`, `EXTERNAL-IP`, `OS-IMAGE`, `KERNEL-VERSION`, and `CONTAINER-RUNTIME` columns. On this cluster the `OS-IMAGE` column reports `Ubuntu 22.04.1 LTS` and the container runtime on these nodes is `containerd://2.2.1-5` [ev:c4]:
+
+```bash
+kubectl get nodes -o wide
+```
+
+```text
+NAME              STATUS  ...  INTERNAL-IP       EXTERNAL-IP  OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
+<control-plane>   Ready   ...  192.168.135.152   <none>       Ubuntu 22.04.1 LTS   5.15.0-56-generic   containerd://2.2.1-5
+```
+
+A healthy cluster has no CertificateSigningRequest objects sitting in `Pending` status. On a steady-state ACP cluster the query typically returns `No resources found`, which is the expected healthy reading [ev:c8]:
+
+```bash
+kubectl get csr
+```
+
+```text
+No resources found
+```
+
+Inspect the etcd database size on every endpoint. On ACP, the etcd member runs as a static pod named `etcd-<control-plane-ip>` in the `kube-system` namespace, and `etcdctl` is available inside that pod; the etcd pod is reached via `kubectl exec` and the client runs with the static-pod's own PKI mounts. The `endpoint status --cluster -w table` form prints the `ENDPOINT`, `ID`, `VERSION`, `DB SIZE`, `IS LEADER`, `IS LEARNER`, `RAFT TERM`, `RAFT INDEX`, `RAFT APPLIED INDEX`, and `ERRORS` columns. On a 12-day-old single-control-plane cluster the `DB SIZE` column reads `163 MB`, well under the 1 GiB threshold that is treated as a warning sign even though it is not by itself an error, and `VERSION` reports `3.5.28` [ev:c10]:
+
+```bash
+kubectl exec -n kube-system etcd-<control-plane-ip> -- \
+  etcdctl --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+          --cert=/etc/kubernetes/pki/etcd/server.crt \
+          --key=/etc/kubernetes/pki/etcd/server.key \
+          endpoint status --cluster -w table
+```
+
+```text
++------------------------------+------------------+---------+---------+-----------+...
+|           ENDPOINT           |        ID        | VERSION | DB SIZE | IS LEADER |...
++------------------------------+------------------+---------+---------+-----------+...
+| https://<control-plane-ip>:2379 | xxxxxxxxxxxxxxxx |  3.5.28 |  163 MB |   true    |...
++------------------------------+------------------+---------+---------+-----------+...
+```
+
+Check per-endpoint health and round-trip latency with the matching `endpoint health` form. The table columns are `ENDPOINT`, `HEALTH`, `TOOK`, and `ERROR`; the `HEALTH` column reading `true` is the pass/fail signal. The `TOOK` value is a single round-trip timing, not a hard threshold — what matters for health is that `HEALTH` is `true` and that `TOOK` stays in the low-millisecond range and is stable across repeated checks, rather than any specific cutoff. On this lab single-control-plane cluster `TOOK` was observed at `11.739462ms`; treat that as an example data point, not a limit (single-digit-millisecond values are common, and a transiently higher reading on an otherwise-healthy endpoint is not by itself a problem) [ev:c11]:
+
+```bash
+kubectl exec -n kube-system etcd-<control-plane-ip> -- \
+  etcdctl --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+          --cert=/etc/kubernetes/pki/etcd/server.crt \
+          --key=/etc/kubernetes/pki/etcd/server.key \
+          endpoint health --cluster -w table
+```
+
+```text
++------------------------------+--------+---------------+-------+
+|           ENDPOINT           | HEALTH |     TOOK      | ERROR |
++------------------------------+--------+---------------+-------+
+| https://<control-plane-ip>:2379 |  true  | 11.739462ms   |       |
++------------------------------+--------+---------------+-------+
+```
+
+The legacy `kubectl get componentstatus` query is also still served by Kubernetes `v1.34.5`'s apiserver and returns the `scheduler`, `controller-manager`, and `etcd-0` rows with `STATUS`, `MESSAGE`, and `ERROR` columns; the apiserver prints `Warning: v1 ComponentStatus is deprecated in v1.19+` first because the API is marked for eventual removal. On a single-control-plane host the `scheduler` and `controller-manager` rows frequently show `Unhealthy` with a `127.0.0.1:10259: connect: connection refused`-style message, because their `/healthz` endpoints bind to `127.0.0.1` inside the static-pod's host network and are not reachable from outside the kubelet host; the `etcd-0` row meanwhile reports `Healthy` [ev:c12]:
+
+```bash
+kubectl get componentstatus
+```
+
+```text
+Warning: v1 ComponentStatus is deprecated in v1.19+
+NAME                 STATUS      MESSAGE                                                                  ERROR
+scheduler            Unhealthy   Get "https://127.0.0.1:10259/healthz": dial tcp 127.0.0.1:10259: connect: connection refused
+controller-manager   Unhealthy   Get "https://127.0.0.1:10257/healthz": ...
+etcd-0               Healthy     ok
+```
+
+## Resolution
+
+Use the `kubectl get nodes` / `kubectl get nodes -o wide` / `kubectl get csr` / `kubectl exec -n kube-system etcd-<control-plane-ip> -- etcdctl ... endpoint status|health --cluster -w table` sequence above as the standing cluster-health smoke test on ACP 4.3.x. Treat the `STATUS` column on nodes, the absence of `Pending` rows in `kubectl get csr`, the etcd `DB SIZE` staying under 1 GiB, and every etcd endpoint's `HEALTH` column reading `true` as the green-light signals; investigate any deviation before further changes [ev:c3][ev:c8][ev:c10][ev:c11]. The deprecated `kubectl get componentstatus` output is still informative for the etcd row but should not be relied on for the scheduler and controller-manager rows on a control plane whose `/healthz` listeners bind to `127.0.0.1`; those rows are expected to read `Unhealthy` from off-host and do not by themselves indicate a broken control plane [ev:c12].


### PR DESCRIPTION
ACP-native solution, re-verified on a live cluster (Kubernetes v1.34.5). Asserts only runtime-verified claims, with concrete version/namespace anchors and per-paragraph evidence references.