### PR TITLE
[virtualization] Pinning a VM live-migration destination via nodeSelector on ACP Virtualization

### DIFF
--- a/docs/en/solutions/Pinning_a_VM_live_migration_destination_via_nodeSelector_on_ACP_Virtualization.md
+++ b/docs/en/solutions/Pinning_a_VM_live_migration_destination_via_nodeSelector_on_ACP_Virtualization.md
@@ -1,0 +1,78 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Pinning a VM live-migration destination via nodeSelector on ACP Virtualization
+
+## Issue
+
+On Alauda Container Platform with the `kubevirt-operator` bundle installed (CSV `kubevirt-hyperconverged-operator.v4.3.5`, KubeVirt `v1.7.0-alauda.2`, HCO operator `1.17.0`, HyperConverged singleton in the `kubevirt` namespace), a virtualization administrator sometimes needs to live-migrate a specific `VirtualMachineInstance` onto a chosen target node — for evacuation rehearsal, hardware-affinity validation, or working around a noisy neighbour — rather than letting the scheduler pick any eligible node. The `VirtualMachine` CRD (`kubevirt.io/v1`) carries a `.spec.template.spec.nodeSelector` field of type `map[string]string` whose documented role is "selector which must match a node's labels for the VMI to be scheduled on that node", and the same `nodeSelector` field appears on the projected `VirtualMachineInstance` shape that virt-controller produces from the template.
+
+## Root Cause
+
+`VirtualMachineInstanceMigration` (`kubevirt.io/v1`) triggers a live migration of a named VMI; one supported path for steering the migration-target virt-launcher pod is to let the standard Kubernetes scheduler decide against the VMI's own scheduling constraints. The VMI inherits `.spec.nodeSelector` from `.spec.template.spec.nodeSelector` on the parent `VirtualMachine`, so the set of nodes the migration target is allowed to land on is exactly the set selected by that map. Narrowing the map to labels matched by only one node therefore narrows the migration's candidate set to that node. (On the KubeVirt v1.7.0-alauda.2 build referenced in the Issue section the `VirtualMachineInstanceMigration` CRD also exposes a first-class `spec.addedNodeSelector` map as a surgical alternative restrictor on the migration object itself; the recipe below stays on the template-side `nodeSelector` path because that is the field the rest of this article anchors against.)
+
+## Resolution
+
+The supported sequence is: edit the parent `VirtualMachine` to add a `nodeSelector` whose labels match only the intended destination node, create a `VirtualMachineInstanceMigration` to trigger the migration, then edit the `VirtualMachine` again to remove the `nodeSelector` once the VMI reports landing on the new node. The first edit narrows the candidate set so the migration target pod can only schedule onto the chosen node; the final un-edit restores cluster-wide scheduling for any subsequent migrations or restarts.
+
+Label the destination node (skip if a suitable label already exists):
+
+```bash
+kubectl label node <destination-node-name> migration-target=true --overwrite
+```
+
+Patch the `VirtualMachine` to add the `nodeSelector` matching that label. The field path is `.spec.template.spec.nodeSelector`; placing the selector here causes the projected VMI to carry the same constraint, which the KubeVirt-driven scheduling path then honours when picking the virt-launcher pod's host:
+
+```bash
+kubectl patch vm <vm-name> -n <vm-namespace> --type merge -p \
+  '{"spec":{"template":{"spec":{"nodeSelector":{"migration-target":"true"}}}}}'
+```
+
+Trigger the migration by creating a `VirtualMachineInstanceMigration` referencing the VMI:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstanceMigration
+metadata:
+  name: pin-to-target
+  namespace: <vm-namespace>
+spec:
+  vmiName: <vm-name>
+```
+
+After the VMI reports the new node in `.status.nodeName`, remove the `nodeSelector` from the `VirtualMachine` so the VM is free to schedule cluster-wide on future migrations or restarts. Without this final step the constraint would persist, and subsequent migration or restart events would still be funnelled to the labelled node:
+
+```bash
+kubectl patch vm <vm-name> -n <vm-namespace> --type json -p \
+  '[{"op":"remove","path":"/spec/template/spec/nodeSelector"}]'
+```
+
+## Diagnostic Steps
+
+Confirm the projected VMI carries the intended `nodeSelector` before creating the migration object — the field on the running VMI is what the migration-target pod's scheduling is filtered against, not the VM template directly:
+
+```bash
+kubectl get vmi <vm-name> -n <vm-namespace> -o jsonpath='{.spec.nodeSelector}'
+```
+
+Track migration progress and confirm the new host once the VMI moves:
+
+```bash
+kubectl get vmim -n <vm-namespace> pin-to-target -o jsonpath='{.status.phase}'
+kubectl get vmi <vm-name> -n <vm-namespace> -o jsonpath='{.status.nodeName}'
+```
+
+After removing the `nodeSelector`, re-read `.spec.template.spec.nodeSelector` on the `VirtualMachine` and `.spec.nodeSelector` on the `VirtualMachineInstance`; both should be empty or absent, indicating the VM is back to unconstrained scheduling for the next migration or restart:
+
+```bash
+kubectl get vm <vm-name> -n <vm-namespace> \
+  -o jsonpath='{.spec.template.spec.nodeSelector}'
+kubectl get vmi <vm-name> -n <vm-namespace> \
+  -o jsonpath='{.spec.nodeSelector}'
+```

--- a/docs/en/solutions/Pinning_a_Virtual_Machines_Live_Migration_Destination_to_a_Specific_Node.md
+++ b/docs/en/solutions/Pinning_a_Virtual_Machines_Live_Migration_Destination_to_a_Specific_Node.md
@@ -1,0 +1,134 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+An operator wants to trigger a live migration of a running virtual machine and, as part of that migration, force the VM to land on a specific destination node — for example to drain a failing host, to consolidate workloads onto a smaller node set before a maintenance window, or to put a latency-sensitive workload next to a specific accelerator. The ACP virtualization stack (`docs/en/virtualization/`, KubeVirt-based) does not expose a first-class "target node" field on the `VirtualMachineInstanceMigration` object: the scheduler picks any node that satisfies the VM's constraints, which may or may not be the node the operator had in mind.
+
+## Root Cause
+
+Live migration in KubeVirt is implemented as a scheduler-driven placement: when a `VirtualMachineInstanceMigration` (VMIM) is created, the control plane starts a new `virt-launcher` pod for the VM, the scheduler picks a node for that pod according to the VM's `spec.template.spec.nodeSelector`, affinity rules, tolerations, and cluster-wide constraints, and then KubeVirt performs the memory/state handoff. There is deliberately no "pin me to node X for this single migration" API on the VMIM object itself — letting a user bypass the scheduler at migration time would break eviction semantics and drain protection.
+
+Newer KubeVirt (and the corresponding virtualization stack versions) expose targeted-destination-node selection as a first-class feature. On the versions shipped with older deployments that feature is not yet available, which means the only way to influence the destination is through the same scheduler inputs the VM already uses — namely `nodeSelector` or affinity on the VM template.
+
+## Resolution
+
+Force the desired destination by temporarily constraining the VM's scheduler inputs so the only node that can host the next launcher pod is the intended target, trigger the migration, then restore the original scheduling surface once the VM has landed.
+
+### 1. Record the current VM scheduling hints
+
+```bash
+NS=<vm-namespace>
+VM=<vm-name>
+
+kubectl -n $NS get vm $VM \
+  -o jsonpath='{.spec.template.spec.nodeSelector}{"\n"}{.spec.template.spec.affinity}{"\n"}'
+```
+
+Copy the output somewhere you can restore from — the edit below will overwrite it.
+
+### 2. Pin the target node on the VM template
+
+Patch the VM to set `nodeSelector` (or a more precise `requiredDuringSchedulingIgnoredDuringExecution` affinity) to a label that only the target node carries. The Kubernetes-managed `kubernetes.io/hostname` label is present on every node and is usually the simplest handle:
+
+```bash
+TARGET_NODE=<destination-node-name>
+
+kubectl -n $NS patch vm $VM --type=merge -p "$(cat <<EOF
+{
+  "spec": {
+    "template": {
+      "spec": {
+        "nodeSelector": {
+          "kubernetes.io/hostname": "${TARGET_NODE}"
+        }
+      }
+    }
+  }
+}
+EOF
+)"
+```
+
+Setting this on `spec.template.spec.nodeSelector` (as opposed to `spec.template.metadata` or anywhere else) is load-bearing — the VMI inherits that field and the next launcher pod created for migration uses it.
+
+### 3. Trigger the live migration
+
+Create a `VirtualMachineInstanceMigration` for the VM:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstanceMigration
+metadata:
+  generateName: migrate-to-target-
+  namespace: <vm-namespace>
+spec:
+  vmiName: <vmi-name>   # usually identical to the VM name
+```
+
+```bash
+kubectl apply -f migration.yaml
+kubectl -n $NS get vmim -w
+```
+
+The scheduler evaluates the new launcher pod against the newly-added `nodeSelector` and places it on the target node; KubeVirt then performs the memory handoff as usual.
+
+### 4. Restore the original scheduling surface once migration completes
+
+As soon as the VMIM phase reaches `Succeeded` and `kubectl get vmi -n $NS $VM -o jsonpath='{.status.nodeName}'` returns the target node, clear the pin so future scheduling decisions are not locked to that one node:
+
+```bash
+kubectl -n $NS patch vm $VM --type=json -p '[
+  {"op": "remove", "path": "/spec/template/spec/nodeSelector/kubernetes.io~1hostname"}
+]'
+```
+
+If the original `nodeSelector` had other entries, re-apply those from the value you captured in step 1. Leaving the hostname pin in place is dangerous: a subsequent reschedule (e.g. node reboot) would find no other candidate and the VM would stay pending.
+
+### Caveats
+
+- The target node must satisfy **all** the VM's other constraints — CPU / memory capacity, any existing affinity / anti-affinity, PVC topology, accelerator device plugins, etc. If not, the launcher pod stays `Pending` and the VMIM eventually fails. Pre-check with `kubectl describe node <target>` and run a dry-run placement if the cluster has the admission hooks for it.
+- This workaround changes the VM spec (and therefore its generation). If GitOps reconciles the VM, the pin may be undone between step 2 and step 3 unless the change is applied through the GitOps source of truth or the reconciler is paused for the duration.
+- On newer virtualization stack versions that expose a first-class destination-node field on the VMIM, prefer that API instead — it avoids mutating the VM spec and is robust to GitOps drift.
+
+## Diagnostic Steps
+
+1. Confirm the patch landed on the VM template and not somewhere else:
+
+   ```bash
+   kubectl -n $NS get vm $VM \
+     -o jsonpath='{.spec.template.spec.nodeSelector}{"\n"}'
+   ```
+
+2. Watch the newly-created launcher pod being scheduled during the migration:
+
+   ```bash
+   kubectl -n $NS get pods -l kubevirt.io=virt-launcher,vm.kubevirt.io/name=$VM \
+     -o wide -w
+   ```
+
+   During migration, two launcher pods are briefly visible — the original (on the source node) and the new one (expected to appear on the target node). Once the handoff completes, the source pod terminates.
+
+3. If the new launcher pod stays `Pending`, describe it and confirm the reason is scheduling, not image pull or PVC binding:
+
+   ```bash
+   POD=$(kubectl -n $NS get pods -l vm.kubevirt.io/name=$VM \
+     --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}')
+   kubectl -n $NS describe pod $POD | sed -n '/Events/,$p'
+   ```
+
+   A `FailedScheduling` event naming the pinned hostname is expected only if the target node is tainted, full, or labelled out of consideration — resolve whichever of those the message points at.
+
+4. After the migration, verify the VMI is actually on the target node and that the pin has been removed from the VM:
+
+   ```bash
+   kubectl -n $NS get vmi $VM -o jsonpath='{.status.nodeName}{"\n"}'
+   kubectl -n $NS get vm $VM -o jsonpath='{.spec.template.spec.nodeSelector}{"\n"}'
+   ```
+
+   The first command should show `<destination-node-name>`. The second should show whatever the original `nodeSelector` was (or an empty map) — not the pinned value.

--- a/docs/en/solutions/Pinning_a_Virtual_Machines_Live_Migration_Destination_to_a_Specific_Node.md
+++ b/docs/en/solutions/Pinning_a_Virtual_Machines_Live_Migration_Destination_to_a_Specific_Node.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Pinning a Virtual Machine's Live-Migration Destination to a Specific Node
 ## Issue
 
 An operator wants to trigger a live migration of a running virtual machine and, as part of that migration, force the VM to land on a specific destination node — for example to drain a failing host, to consolidate workloads onto a smaller node set before a maintenance window, or to put a latency-sensitive workload next to a specific accelerator. The ACP virtualization stack (`docs/en/virtualization/`, KubeVirt-based) does not expose a first-class "target node" field on the `VirtualMachineInstanceMigration` object: the scheduler picks any node that satisfies the VM's constraints, which may or may not be the node the operator had in mind.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
