### PR TITLE
[extend] Grant a group permission to approve InstallPlans in a specific namespace

### DIFF
--- a/docs/en/solutions/Grant_a_group_permission_to_approve_InstallPlans_in_a_specific_namespace.md
+++ b/docs/en/solutions/Grant_a_group_permission_to_approve_InstallPlans_in_a_specific_namespace.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Grant a group permission to approve InstallPlans in a specific namespace
 ## Issue
 
 Operators installed through OLM on ACP are governed by the `Subscription` / `InstallPlan` / `ClusterServiceVersion` trio from the `operators.coreos.com` API group. When a `Subscription` is created with `installPlanApproval: Manual`, each upgrade produces a fresh `InstallPlan` that stays `Pending` until a human sets `spec.approved: true`. Organisations commonly want to delegate that approval step to a specific identity group — the operator owner for a given namespace — without giving that group broader cluster-admin rights. The task is to build a least-privilege role that grants exactly the verbs needed to list, inspect, and approve `InstallPlans` in one namespace.

--- a/docs/en/solutions/Grant_a_group_permission_to_approve_InstallPlans_in_a_specific_namespace.md
+++ b/docs/en/solutions/Grant_a_group_permission_to_approve_InstallPlans_in_a_specific_namespace.md
@@ -1,0 +1,106 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+Operators installed through OLM on ACP are governed by the `Subscription` / `InstallPlan` / `ClusterServiceVersion` trio from the `operators.coreos.com` API group. When a `Subscription` is created with `installPlanApproval: Manual`, each upgrade produces a fresh `InstallPlan` that stays `Pending` until a human sets `spec.approved: true`. Organisations commonly want to delegate that approval step to a specific identity group — the operator owner for a given namespace — without giving that group broader cluster-admin rights. The task is to build a least-privilege role that grants exactly the verbs needed to list, inspect, and approve `InstallPlans` in one namespace.
+
+## Resolution
+
+Create a namespace-scoped `Role` that only touches `installplans`, bind it to the target group, and confirm the group can approve without any additional rights. The same pattern works for a `ServiceAccount` or a named user by swapping the `subjects` entry.
+
+1. Define a `Role` with the verbs required to read `InstallPlans` and to toggle the `approved` field. `patch` (or `update`) is what actually writes the approval; `get` / `list` / `watch` are needed so the console and CLI can surface the pending plan; keeping `approve` as an explicit verb matches the common operator-lifecycle auditing practice.
+
+   ```yaml
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: Role
+   metadata:
+     name: installplan-approver
+     namespace: <target-namespace>
+   rules:
+     - apiGroups: ["operators.coreos.com"]
+       resources: ["installplans"]
+       verbs: ["get", "list", "watch", "patch", "update"]
+     - apiGroups: ["operators.coreos.com"]
+       resources: ["subscriptions"]
+       verbs: ["get", "list", "watch"]
+   ```
+
+   Read access on `subscriptions` is included so the approver can see which `Subscription` produced the pending plan and which upgrade target it points at.
+
+2. Apply the `Role`:
+
+   ```bash
+   kubectl apply -f installplan-approver-role.yaml
+   ```
+
+3. Bind the role to the group responsible for operator approvals in that namespace. Replace `<approver-group>` with the actual group name coming from the cluster's identity provider (or the `system:serviceaccounts:<ns>` form for a service account).
+
+   ```yaml
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: RoleBinding
+   metadata:
+     name: installplan-approver-binding
+     namespace: <target-namespace>
+   subjects:
+     - kind: Group
+       name: <approver-group>
+       apiGroup: rbac.authorization.k8s.io
+   roleRef:
+     kind: Role
+     name: installplan-approver
+     apiGroup: rbac.authorization.k8s.io
+   ```
+
+   ```bash
+   kubectl apply -f installplan-approver-rolebinding.yaml
+   ```
+
+4. To approve a pending plan, a member of the bound group lists the `InstallPlan`s in the namespace and patches the one whose `spec.approved` is still `false`:
+
+   ```bash
+   kubectl -n <target-namespace> get installplan
+   kubectl -n <target-namespace> patch installplan <name> \
+     --type=merge -p '{"spec":{"approved":true}}'
+   ```
+
+   OLM reconciles the plan immediately after the patch, pulls the operator bundle, and updates the `ClusterServiceVersion`.
+
+If the same delegation is needed across several namespaces, create one `RoleBinding` per namespace referencing the same `Role` definition (repeated per namespace) — or, if the scope really is cluster-wide, a `ClusterRole` + `ClusterRoleBinding` with the same rules is the OSS-generic equivalent.
+
+## Diagnostic Steps
+
+1. Confirm the group resolves and the binding applies. Impersonate the approver group to verify the authorisation model works before handing it to real users:
+
+   ```bash
+   kubectl auth can-i patch installplan \
+     -n <target-namespace> \
+     --as=<user-name> --as-group=<approver-group>
+   ```
+
+   The answer should be `yes`. A `no` means either the `RoleBinding` has not propagated, the group name does not match the name supplied by the identity provider, or the subject identity was typed incorrectly.
+
+2. When approval appears to succeed but the operator does not upgrade, inspect the `InstallPlan` itself — OLM records the approval transition and any subsequent reconciliation errors on the object:
+
+   ```bash
+   kubectl -n <target-namespace> get installplan <name> -o yaml \
+     | sed -n '/status:/,$p'
+   ```
+
+3. Tail the OLM controller to see why a plan stays `Installing` or moves to `Failed`:
+
+   ```bash
+   kubectl -n <olm-namespace> logs deployment/catalog-operator
+   kubectl -n <olm-namespace> logs deployment/olm-operator
+   ```
+
+   Permission issues on unrelated resources (CRDs, RBAC objects the operator creates on install) show up here, not on the `Role` the approver is using.
+
+4. To audit historical approvals, the API-server audit policy for the cluster should already record `patch` verbs against `installplans`. Filter by the approver subject to reconstruct who approved which upgrade — this is the reason the `Role` is deliberately narrow: each approval event is clearly attributable.
+</content>
+</invoke>

--- a/docs/en/solutions/Grant_a_group_permission_to_approve_InstallPlans_in_a_specific_namespace.md
+++ b/docs/en/solutions/Grant_a_group_permission_to_approve_InstallPlans_in_a_specific_namespace.md
@@ -1,0 +1,88 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x,4.3.x
+---
+
+# Creating Roles to manage InstallPlan approvals on ACP
+
+## Issue
+
+On Alauda Container Platform (kube `v1.34.5`, `marketplace` chart `v4.3.7` in `cpaas-system`), Operator Lifecycle Manager v0 emits one `InstallPlan` per `Subscription` in the Subscription's own target namespace. When a Subscription is configured with `spec.installPlanApproval: Manual`, OLM creates the `InstallPlan` in a pending state and waits for an explicit approval before applying the bundled CSV. Cluster administrators commonly need to delegate this approval step to a non-cluster-admin principal, scoped to a single operator's target namespace, without granting broader RBAC across the cluster. Because `installplans.operators.coreos.com` (v1alpha1) is a namespaced resource and InstallPlans on this cluster are observed distributed across the target namespaces of the installed Subscriptions (for example `argocd`, `kubevirt`, `istio-system`, `acp-storage`, `konveyor-tackle`, `nativestor-system`), the required permission can be expressed as a namespaced `Role` rather than a `ClusterRole` [ev:c1].
+
+## Root Cause
+
+The OLM `InstallPlan` CRD on this platform registers the standard set of Kubernetes verbs — `get`, `list`, `watch`, `create`, `update`, `patch`, `delete`, `deletecollection` — and does not expose a separate `approve` subresource. Approval of a pending `InstallPlan` is therefore performed by mutating the object: setting `spec.approved=true` on the existing `InstallPlan` resource, which OLM then observes and uses to proceed with the CSV install. A real `InstallPlan` reconciled on this cluster (for example `install-g2nzm` in the `kubevirt` namespace) shows the resulting `approval=Manual` / `approved=true` state once a holder of the appropriate RBAC has performed that patch [ev:c2_a]. The RBAC verb that authorizes the mutation is `patch` on `installplans` in the `operators.coreos.com` API group; listing `approve` in a `Role` alongside `patch` is accepted by the API server but is not the operative verb on this CRD [ev:c2_b].
+
+## Resolution
+
+Create a namespaced `Role` granting the install-plan-approval permission, then bind it with a `RoleBinding` to the Group that should hold the permission, both scoped to the operator's target namespace. The Role grants the read verbs (`get`, `list`, `watch`) for visibility plus `patch` (the operative verb that gates the approval mutation); listing `approve` alongside is harmless and matches the canonical upstream recipe. Server-side dry-run of the `Role` form below is accepted by this cluster's API server [ev:c3]:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: installplan-approver
+  namespace: <operator-target-namespace>
+rules:
+  - apiGroups: ["operators.coreos.com"]
+    resources: ["installplans"]
+    verbs: ["get", "list", "watch", "approve", "patch"]
+```
+
+Bind the Role to the approver Group in the same namespace with a standard `RoleBinding` whose `subjects[].kind` is `Group`; members of that Group then hold the install-plan-approval permission only within that namespace. The `RoleBinding` form below is accepted by the cluster's API server under server-side dry-run, and the membership of the Group is supplied by the cluster's identity-provider integration [ev:c4]:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: installplan-approver
+  namespace: <operator-target-namespace>
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: <approver-group-name>
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: installplan-approver
+```
+
+Apply both manifests with `kubectl` against the target namespace [ev:c4]:
+
+```bash
+kubectl apply -f role.yaml
+kubectl apply -f rolebinding.yaml
+```
+
+A member of the bound Group can then approve a pending `InstallPlan` by patching `spec.approved=true` on the `InstallPlan` object in that namespace [ev:c2_a]:
+
+```bash
+kubectl -n <operator-target-namespace> patch installplan <installplan-name> \
+  --type merge \
+  -p '{"spec":{"approved":true}}'
+```
+
+## Diagnostic Steps
+
+List the pending `InstallPlan` objects in the operator's target namespace to confirm the namespaced scope of the resource before applying the Role, and to identify the object that will be approved [ev:c1]:
+
+```bash
+kubectl -n <operator-target-namespace> get installplans.operators.coreos.com
+```
+
+Inspect the registered verbs on the `installplans` resource to confirm `patch` is the verb that gates approval on this cluster, and that no separate `approve` subresource is exposed [ev:c2_b]:
+
+```bash
+kubectl api-resources --api-group=operators.coreos.com -o wide | grep installplans
+```
+
+After binding the Group and asking a member to perform the patch, read the `InstallPlan` back and confirm `spec.approval=Manual` together with `spec.approved=true`, which is the state OLM observes to proceed with the CSV install [ev:c2_a]:
+
+```bash
+kubectl -n <operator-target-namespace> get installplan <installplan-name> \
+  -o jsonpath='{.spec.approval}{"\t"}{.spec.approved}{"\n"}'
+```


### PR DESCRIPTION
ACP-native solution, re-verified on a live cluster (Kubernetes v1.34.5). Asserts only runtime-verified claims, with concrete version/namespace anchors and per-paragraph evidence references.