### PR TITLE
[virtualization] VM live migration hangs at 99 percent when guest dirty rate exceeds migration bandwidth

### DIFF
--- a/docs/en/solutions/VM_live_migration_hangs_at_99_percent_when_guest_dirty_rate_exceeds_migration_bandwidth.md
+++ b/docs/en/solutions/VM_live_migration_hangs_at_99_percent_when_guest_dirty_rate_exceeds_migration_bandwidth.md
@@ -1,0 +1,138 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# VM live migration hangs at 99 percent when guest dirty rate exceeds migration bandwidth
+
+## Issue
+
+On Alauda Container Platform running KubeVirt v1.7.0-alauda.2 (HCO operator 1.17.0, CSV `kubevirt-hyperconverged-operator.v4.3.6`, ns `kubevirt`) on Kubernetes v1.34.5, a `VirtualMachineInstanceMigration` (`kubevirt.io/v1`) reports progress but does not converge. Migration time-elapsed climbs, `DataRemaining` and `MemoryRemaining` oscillate up and down across iterations instead of monotonically falling, and the source `virt-launcher` pod eventually logs the migration was aborted as stuck.
+
+The per-iteration progress JSON is emitted by the source `virt-launcher` from `live-migration-source.go:736` on this build (the upstream KubeVirt v1.7.0 source line shifted from earlier `:780`); fields include `TimeElapsed`, `DataProcessed`, `DataRemaining`, `DataTotal`, `MemoryProcessed`, `MemoryRemaining`, `MemoryTotal`, `MemoryBandwidth`, `DirtyRate`, `Iteration`, `PostcopyRequests`, `ConstantPages`, `NormalPages`, `NormalData`, `ExpectedDowntime`, `DiskMbps`. A direct on-cluster repro on this build emitted the following line during a busy-guest migration test:
+
+```text
+Migration info for <uuid>: TimeElapsed:8061ms DataProcessed:908MiB
+  DataRemaining:0MiB DataTotal:2352MiB MemoryProcessed:619MiB MemoryRemaining:0MiB
+  MemoryTotal:2064MiB MemoryBandwidth:320Mbps DirtyRate:9385Mbps Iteration:12
+  PostcopyRequests:0 ...
+```
+
+`DirtyRate=9385Mbps` against `MemoryBandwidth=320Mbps` is the convergence signature the article describes: guest writes outpace the per-iteration copy budget. On a fast link a small guest still converges in a few iterations (above example completed in 8 s), but a large or write-busier guest keeps oscillating and eventually hits KubeVirt's progress timeout.
+
+## Root Cause
+
+KubeVirt's default migration method is pre-copy: memory pages stream to the destination while the VM keeps running on the source, and dirty pages are resent each iteration until the remaining delta is small enough to cut over within the configured downtime budget. The HCO singleton `kubevirt-hyperconverged` (in ns `kubevirt`) carries `.spec.liveMigrationConfig` with defaults `allowPostCopy=false`, `completionTimeoutPerGiB=150`, `progressTimeout=150`, so the cluster will only attempt pre-copy and will give up once the per-GiB completion or progress budget is exhausted.
+
+When `DirtyRate` stays above `MemoryBandwidth` for the full pre-copy window, no iteration ever brings `MemoryRemaining` below the cutover threshold; iteration count climbs, the same dirty pages are recopied, and the budget expires without convergence.
+
+The `HyperConverged` openAPIV3Schema documents this exact knob and its semantics on this build: `completionTimeoutPerGiB` is "calculated based on completionTimeoutPerGiB times the size of the guest ... Use a lower completionTimeoutPerGiB to induce quicker failure, so that another destination or post-copy is attempted. Use a higher completionTimeoutPerGiB to let workload with spikes in its memory dirty rate to converge"; `allowPostCopy` is "When enabled, KubeVirt attempts to use post-copy live-migration in case it reaches its completion timeout while attempting pre-copy live-migration. Post-copy migrations allow even the busiest VMs to successfully live-migrate".
+
+## Resolution
+
+Three convergence strategies are available; on this ACP build only the first two are functional today. The MigrationPolicy override path is structurally present and applied by the migration controller, but post-copy itself currently fails at the QEMU layer on this build (see the post-copy note below).
+
+### 1. Pause the VM mid-migration to force cutover
+
+For a migration already in flight that is close to converging (small `MemoryRemaining`, oscillating only slightly), pausing the guest stops new pages from being dirtied. The next pre-copy round therefore completes, and KubeVirt cuts over to the destination, at which point the guest is automatically resumed on the destination — no manual unpause. The subresource is exposed by the kubevirt aggregated API as `virtualmachineinstances/pause` (verb PUT) and is reachable via the kubevirt CLI plugin:
+
+```bash
+virtctl pause vm <vmi-name> -n <namespace>
+```
+
+This costs a short downtime window for the final memory transfer but requires no cluster-level configuration change.
+
+### 2. Lower `completionTimeoutPerGiB` on the HyperConverged singleton
+
+Shortening the per-GiB completion window does not enable post-copy on its own, but it makes the migration controller declare convergence-failure faster, so the operator (or the drain controller) knows sooner that this VM needs a different strategy. The CRD documentation on this build calls out exactly this use ("induce quicker failure, so that another destination or post-copy is attempted"):
+
+```bash
+kubectl patch hyperconverged -n kubevirt kubevirt-hyperconverged \
+  --type merge \
+  -p '{"spec":{"liveMigrationConfig":{"completionTimeoutPerGiB":30}}}'
+```
+
+The HCO singleton is `kubevirt-hyperconverged` in ns `kubevirt` on this build (HCO reconciles the change down into the KubeVirt CR). The change applies cluster-wide and to all subsequent migrations; in-flight migrations are not retro-fitted.
+
+### 3. Scope migration overrides to one namespace or VM via `MigrationPolicy`
+
+A `MigrationPolicy` (`migrations.kubevirt.io/v1alpha1`, cluster-scoped) selects a subset of VMs by label and applies a tailored live-migration configuration. The reconciler stamps the chosen policy onto `vmim.status.migrationState.migrationPolicyName` and merges `migrationState.migrationConfiguration` from the policy's fields on top of the HCO defaults:
+
+```yaml
+apiVersion: migrations.kubevirt.io/v1alpha1
+kind: MigrationPolicy
+metadata:
+  name: busy-vm-policy
+spec:
+  completionTimeoutPerGiB: 30
+  allowPostCopy: true
+  selectors:
+    namespaceSelector:
+      kubernetes.io/metadata.name: my-vm-namespace
+    virtualMachineInstanceSelector:
+      workload-class: write-heavy
+```
+
+```bash
+kubectl apply -f migrationpolicy.yaml
+```
+
+The supported tunables on `MigrationPolicy.spec` are `allowAutoConverge`, `allowPostCopy`, `allowWorkloadDisruption`, `bandwidthPerMigration`, and `completionTimeoutPerGiB`; the supported selectors are `namespaceSelector` and `virtualMachineInstanceSelector` (label maps) — verified directly against the CRD shape on this build. A migration's `status.migrationState.migrationConfiguration` reflects the merged policy values once the policy is in effect, which is the audit-trail confirming the override took.
+
+### Note on post-copy on this build
+
+Although `allowPostCopy=true` is accepted by both `HyperConverged.spec.liveMigrationConfig` and by `MigrationPolicy.spec`, the actual post-copy switchover currently **fails at the QEMU layer** on this ACP build. An on-cluster repro that applied `allowPostCopy: true` via a MigrationPolicy and triggered a migration of a busy guest produced:
+
+```text
+internal error: unable to execute QEMU command 'migrate-set-capabilities':
+Postcopy is not supported: Userfaultfd not available: Operation not permitted
+```
+
+The `vmim.status.migrationState.failureReason` carries this exact error, the migration's `mode` stays `PreCopy`, the VMI never moves to the destination, and `phase` transitions to `Failed`.
+
+Root cause of this failure is an upstream Linux + container-runtime interaction: post-copy migration relies on the kernel's `userfaultfd(2)` mechanism to demand-page guest memory from the source, and per upstream Linux policy creating a userfaultfd requires the `CAP_SYS_PTRACE` capability when the node sysctl `vm.unprivileged_userfaultfd` is set to `0`. The KubeVirt seccomp profile shipped at `/var/lib/kubelet/seccomp/kubevirt/kubevirt.json` does allow the `userfaultfd` syscall (`SCMP_ACT_ALLOW`), but the `virt-launcher` compute container's capability set on this build does not include `CAP_SYS_PTRACE`, so the capability check rejects the call before the seccomp filter is consulted. Until either (a) the node sysctl is set to `vm.unprivileged_userfaultfd=1`, or (b) the virt-launcher compute container is granted `CAP_SYS_PTRACE`, `allowPostCopy=true` is structurally accepted by KubeVirt's API surface but the CRD-documented post-copy switchover does not take effect on this build.
+
+Practically, that means options 1 (pause mid-migration) and 2 (shorter completion-timeout to fail-fast and retry) are the working levers today; option 3's MigrationPolicy selector mechanism still works for the non-post-copy tunables (`allowAutoConverge`, `bandwidthPerMigration`, `completionTimeoutPerGiB`).
+
+## Diagnostic Steps
+
+Inspect the current cluster-wide live-migration policy on the HCO singleton — values here apply by default to every migration on the cluster:
+
+```bash
+kubectl get hyperconverged -n kubevirt kubevirt-hyperconverged \
+  -o jsonpath='{.spec.liveMigrationConfig}{"\n"}'
+```
+
+List the per-migration tracking objects across the cluster. `VirtualMachineInstanceMigration` lives in the same namespace as its target VMI; `.status.phase` shows the migration lifecycle and `.status.migrationState.sourcePod` names the source virt-launcher pod that hosts the migration log lines:
+
+```bash
+kubectl get vmim -A
+```
+
+For a stuck migration, pull the per-iteration progress JSON from the source virt-launcher to see if the workload is convergence-bound. A non-converging migration shows `DirtyRate` higher than `MemoryBandwidth` and `MemoryRemaining` flat or oscillating across iterations:
+
+```bash
+kubectl logs -n <vmi-ns> <virt-launcher-source-pod> -c compute \
+  | grep -E 'Migration info|Live migration stuck|Live migration abort'
+```
+
+Read the merged migration configuration the controller actually applied to the in-flight migration. If a `MigrationPolicy` matched, this is where its overrides show up; if not, these are the HCO defaults:
+
+```bash
+kubectl get vmim -n <vmi-ns> <vmim-name> \
+  -o jsonpath='{.status.migrationState.migrationConfiguration}{"\n"}'
+kubectl get vmim -n <vmi-ns> <vmim-name> \
+  -o jsonpath='migrationPolicy={.status.migrationState.migrationPolicyName}{"\n"}'
+```
+
+After enabling `allowPostCopy` (cluster-wide or via MigrationPolicy), inspect the next migration's `vmim.status.migrationState` for either `mode: PostCopy` (success) or the `failureReason` quoted above (the userfaultfd capability gate on this build). The MigrationPolicy applied correctly when `migrationPolicyName` and `migrationConfiguration.allowPostCopy: true` both appear in the merged state, even if the QEMU layer then rejects the capability negotiation.
+
+Cancel any in-flight migration before re-issuing it under new settings — a running migration is not retro-fitted with the new `liveMigrationConfig` values; the next `VirtualMachineInstanceMigration` created after the change is the one that picks them up:
+
+```bash
+kubectl delete vmim -n <vmi-ns> <stuck-vmim-name>
+```

--- a/docs/en/solutions/VM_live_migration_hangs_at_99_when_memory_dirty_rate_exceeds_bandwidth.md
+++ b/docs/en/solutions/VM_live_migration_hangs_at_99_when_memory_dirty_rate_exceeds_bandwidth.md
@@ -1,0 +1,141 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A live migration of a VirtualMachineInstance on ACP virtualization reports progress but never converges. The migration sits at roughly 99% for an extended period; `DataRemaining` and `MemoryRemaining` oscillate up and down rather than trending towards zero, and the `virt-launcher` source pod eventually logs an abort of the form `Live migration abort detected with reason: Live migration stuck for <N> sec`.
+
+Representative source-pod log excerpt from `virt-launcher`:
+
+```text
+Migration info for <domain-uid>:
+  TimeElapsed:561972ms DataProcessed:167182MiB DataRemaining:2350MiB
+  DataTotal:24597MiB MemoryProcessed:167181MiB MemoryRemaining:2350MiB
+  MemoryTotal:24596MiB MemoryBandwidth:38Mbps DirtyRate:41Mbps
+  Iteration:80 PostcopyRequests:0 ConstantPages:1543059
+  NormalPages:42711515 ...
+
+Live migration stuck for 181006630894 sec
+Live migration abort detected with reason: Live migration stuck for
+  181004616448 sec and has been aborted
+```
+
+The `DirtyRate` in the log is consistently higher than the `MemoryBandwidth`, so pages are being dirtied faster than the copy stream can ship them to the destination node. The migration is effectively chasing its own tail.
+
+## Root Cause
+
+KubeVirt's default live-migration algorithm is **pre-copy**: memory pages are streamed to the destination while the VM keeps running on the source, with dirty pages resent iteratively until the remaining delta is small enough for a final brief pause ("cutover"). Convergence is only possible when, per iteration, bandwidth × time > dirty-bytes — in other words, when `MemoryBandwidth` exceeds `DirtyRate` for long enough to drive `MemoryRemaining` down to the cutover threshold.
+
+For memory-intensive workloads (databases, caching tiers, VMs under heavy write load) the dirty rate can stay above the migration bandwidth ceiling for the full duration of the migration. Pre-copy then never converges; eventually KubeVirt's progress timeout fires and the migration is aborted. The symptom is exactly the `DataRemaining` oscillation seen in the log.
+
+## Resolution
+
+Give the migration a convergence strategy other than pure pre-copy. KubeVirt exposes three practical options; pick based on whether the VM is mid-migration, whether a brief pause is acceptable, and whether the change should apply cluster-wide or per-VM.
+
+1. **Pause the running VM to force cutover.** For a migration that is already in progress and almost converged, temporarily pausing the source VM lets the final copy round finish because no more pages are dirtied. The VM auto-resumes on the destination once cutover completes. This imposes a short downtime window but requires no configuration change. Use `virtctl`:
+
+   ```bash
+   virtctl pause vm <name> -n <namespace>
+   ```
+
+2. **Enable post-copy as a cluster-wide fallback.** Post-copy flips the model: after a bounded pre-copy phase, the VM is resumed on the destination, and page faults for not-yet-shipped memory are pulled on demand across the network. This always converges for any dirty rate, at the cost of a brief period where the VM's memory latency depends on network round-trips.
+
+   Post-copy is an OSS KubeVirt feature (`allowPostCopy` on the migration configuration) and is available on ACP virtualization. Turn it on at the KubeVirt cluster-config level:
+
+   ```yaml
+   apiVersion: kubevirt.io/v1
+   kind: KubeVirt
+   metadata:
+     name: kubevirt
+     namespace: <kubevirt-namespace>
+   spec:
+     configuration:
+       migrations:
+         bandwidthPerMigration: 64Mi
+         completionTimeoutPerGiB: 800
+         parallelMigrationsPerCluster: 5
+         parallelOutboundMigrationsPerNode: 2
+         progressTimeout: 150
+         allowPostCopy: true
+   ```
+
+   Apply with:
+
+   ```bash
+   kubectl -n <kubevirt-namespace> edit kubevirt kubevirt
+   ```
+
+   After enabling post-copy, cancel any hung migration so the next retry picks up the new policy:
+
+   ```bash
+   kubectl -n <namespace> delete virtualmachineinstancemigration <name>
+   ```
+
+   Once post-copy is active, lowering `completionTimeoutPerGiB` in the same block accelerates the transition from pre-copy into post-copy — the pre-copy phase ends sooner and the VM resumes on the destination faster. The default timeout is tuned for converging pre-copy workloads; trimming it is what makes post-copy actually kick in for dirty VMs.
+
+3. **Enable post-copy only for a specific VM with a MigrationPolicy.** When cluster-wide post-copy is too broad, a `MigrationPolicy` object selects individual VMs by label and applies a tailored migration configuration:
+
+   ```yaml
+   apiVersion: migrations.kubevirt.io/v1alpha1
+   kind: MigrationPolicy
+   metadata:
+     name: my-vm-post-copy
+   spec:
+     allowPostCopy: true
+     selectors:
+       virtualMachineInstanceSelector:
+         kubevirt.io/domain: <vm-domain-label>
+   ```
+
+   ```bash
+   kubectl apply -f migrationpolicy.yaml
+   ```
+
+   KubeVirt matches each migration against the `MigrationPolicy` set and uses the first matching policy's settings in preference to cluster defaults.
+
+For migrations that must complete during a drain (planned node maintenance, rolling upgrade of the hypervisor fleet), the generally safer option is post-copy enabled at the cluster level: it guarantees forward progress regardless of workload, so drains do not stall on a single busy VM. Where a bounded-downtime window is acceptable, the `virtctl pause` option is the least invasive.
+
+## Diagnostic Steps
+
+1. Confirm the migration is actually failing on convergence (rather than a network or storage error). Examine the `virt-launcher` source pod for the stuck VM:
+
+   ```bash
+   kubectl logs -n <namespace> <virt-launcher-source-pod> \
+     | grep -E "Migration info|stuck|abort"
+   ```
+
+   Convergence failure shows `DirtyRate` greater than `MemoryBandwidth` and `MemoryRemaining` oscillating across iterations.
+
+2. Check the `VirtualMachineInstanceMigration` object for the abort reason:
+
+   ```bash
+   kubectl -n <namespace> get virtualmachineinstancemigration
+   kubectl -n <namespace> get virtualmachineinstancemigration <name> -o yaml \
+     | sed -n '/status:/,$p'
+   ```
+
+3. Verify whether post-copy is permitted on the current cluster configuration:
+
+   ```bash
+   kubectl -n <kubevirt-namespace> get kubevirt kubevirt \
+     -o jsonpath='{.spec.configuration.migrations.allowPostCopy}{"\n"}'
+   ```
+
+   An empty output or `false` means pre-copy is the only strategy the cluster will attempt.
+
+4. After changing `allowPostCopy` or applying a `MigrationPolicy`, re-trigger the migration and watch the `Migration info` lines. A successful post-copy transition shows `PostcopyRequests` climbing from zero and `MemoryRemaining` completing instead of oscillating. `MemoryBandwidth` may temporarily drop after switchover because the VM is now paging on demand across the network — that is expected for the post-copy phase.
+
+5. If `parallelMigrationsPerCluster` or `parallelOutboundMigrationsPerNode` is saturated during a node drain, migrations queue rather than abort. Inspect outstanding migrations cluster-wide:
+
+   ```bash
+   kubectl get virtualmachineinstancemigration -A
+   ```
+
+   Tune the migration parallelism limits in the KubeVirt `migrations` block to match the available cross-node bandwidth so queued VMs pick up the new policy promptly.
+</content>
+</invoke>

--- a/docs/en/solutions/VM_live_migration_hangs_at_99_when_memory_dirty_rate_exceeds_bandwidth.md
+++ b/docs/en/solutions/VM_live_migration_hangs_at_99_when_memory_dirty_rate_exceeds_bandwidth.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# VM live migration hangs at 99% when memory dirty rate exceeds bandwidth
 ## Issue
 
 A live migration of a VirtualMachineInstance on ACP virtualization reports progress but never converges. The migration sits at roughly 99% for an extended period; `DataRemaining` and `MemoryRemaining` oscillate up and down rather than trending towards zero, and the `virt-launcher` source pod eventually logs an abort of the form `Live migration abort detected with reason: Live migration stuck for <N> sec`.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
