### PR TITLE
[virtualization] KubeVirt VM Loses Bridge Network Connectivity When br_netfilter Is Loaded on the Worker

### DIFF
--- a/docs/en/solutions/KubeVirt_VM_Loses_Bridge_Network_Connectivity_When_br_netfilter_Is_Loaded_on_the_Worker.md
+++ b/docs/en/solutions/KubeVirt_VM_Loses_Bridge_Network_Connectivity_When_br_netfilter_Is_Loaded_on_the_Worker.md
@@ -1,0 +1,91 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# KubeVirt VM Loses Bridge Network Connectivity When br_netfilter Is Loaded on the Worker
+
+## Issue
+
+On Alauda Container Platform (Kubernetes v1.34.5 with Ubuntu 22.04 worker nodes running Linux 5.15.0-56-generic), a KubeVirt VirtualMachine attached to a Linux Bridge secondary network through a Multus `NetworkAttachmentDefinition` experiences periodic or permanent loss of network connectivity. Ingress traffic such as ICMP reaches the worker's physical bond or interface but never appears on the VM's veth interface, and egress traffic such as ARP from the VM reaches the bridge but is not forwarded out the bridge port. The data path involved is the standard KubeVirt secondary-network shape on ACP: a `NetworkAttachmentDefinition` (`network-attachment-definitions.k8s.cni.cncf.io`, `k8s.cni.cncf.io/v1`) of CNI `type: bridge` referenced from `virtualmachineinstance.spec.networks[].multus.networkName` and bound on the VM side by `virtualmachineinstance.spec.domain.devices.interfaces[].bridge` (`InterfaceBridge connects to a given network via a linux bridge`), with KubeVirt running in namespace `kubevirt` and `virt-handler` shipped as `3rdparty/kubevirt/virt-handler:v1.7.0-alauda.2`.
+
+## Root Cause
+
+The trigger is the `br_netfilter` Linux kernel module becoming loaded on the worker that hosts the VM. On the Ubuntu 22.04 + Linux 5.15.0-56-generic kernel that ACP worker nodes run, loading `br_netfilter` registers three sysctls under `/proc/sys/net/bridge/` and sets each of them to 1; a privileged probe on an ACP worker shows the live values `net.bridge.bridge-nf-call-arptables = 1`, `net.bridge.bridge-nf-call-ip6tables = 1`, and `net.bridge.bridge-nf-call-iptables = 1` exactly as the module documents.
+
+When the corresponding `bridge-nf-call-*` sysctl is 1, frames traversing a Linux bridge are pushed up to the host's `iptables`, `ip6tables`, and `arptables` chains for filtering decisions instead of being switched purely at layer 2 — the kernel's sysctl carrier through which the bridged-frame iptables hook is gated is the same `/proc/sys/net/bridge/` keyset observed live on the worker. KubeVirt does not install host-side `iptables` ALLOW rules that whitelist secondary-bridge VM traffic: `virt-handler` and `virt-launcher` (image `3rdparty/kubevirt/virt-handler:v1.7.0-alauda.2`) only wire the VM's tap into the existing Linux bridge created by the upstream `bridge` CNI delegate. With the `bridge-nf-call-*` sysctls forcing bridged frames through iptables, the VM's bridged traffic is therefore subjected to whatever the host's iptables policy decides — and on a Kubernetes cluster whose pod-network agents own their own FORWARD-chain rules, the default outcome for unrelated bridged frames is to be silently dropped.
+
+The kernel-level coupling is what produces the symptom: a worker on which `br_netfilter` is loaded with `bridge-nf-call-*` = 1, plus a KubeVirt VM whose secondary NIC is bridged through a Linux Bridge `NetworkAttachmentDefinition` on that same worker, plus the absence of any explicit iptables ALLOW for that traffic. Ingress ICMP arriving on the physical NIC traverses the bridge, is handed to iptables, and is dropped before reaching the VM's veth/tap; egress ARP from the VM traverses the bridge port, is handed to arptables, and never leaves through the physical NIC.
+
+## Diagnostic Steps
+
+Confirm whether `br_netfilter` is currently loaded on the worker hosting the affected VM, and read the live values of the bridge sysctls. Open a privileged debug pod against the node and inspect kernel module state and `/proc/sys/net/bridge/` directly; on a tested ACP worker this returns `br_netfilter` loaded with the dependent `bridge` module, all three `bridge-nf-call-*` sysctls = 1, and the corresponding files under `/proc/sys/net/bridge/`:
+
+```bash
+kubectl debug node/<worker> -it=false \
+  --image=registry.alauda.cn:60080/acp/container-debug:v4.3.2 \
+  --profile=sysadmin -- \
+  chroot /host bash -c \
+    "lsmod | grep -E 'br_netfilter|bridge' ; \
+     echo --- ; \
+     sysctl -a 2>/dev/null | grep bridge-nf-call ; \
+     echo --- ; \
+     ls /proc/sys/net/bridge/"
+```
+
+The `lsmod` row reports the module's name, size, and reference count; a non-zero third column means a process inside some pod is holding the bridge subsystem and the module cannot be unloaded until that process exits. The `sysctl -a | grep bridge-nf-call` lines printing `= 1` confirm that the kernel is in the state that subjects bridged VM frames to the host's iptables chains, which is the state in which the article's silent-drop symptom occurs.
+
+Inspect the module's reference count and holders directly to see whether anything is currently keeping it loaded. A `refcnt` of `0` and an empty `holders/` directory mean the module is loaded but unreferenced, so an unload call will succeed; a non-zero `refcnt` identifies that some kernel subsystem (typically a container runtime running inside a privileged pod) is preventing unload:
+
+```bash
+kubectl debug node/<worker> -it=false \
+  --image=registry.alauda.cn:60080/acp/container-debug:v4.3.2 \
+  --profile=sysadmin -- \
+  chroot /host bash -c \
+    "cat /sys/module/br_netfilter/refcnt ; \
+     ls -la /sys/module/br_netfilter/holders/"
+```
+
+Inspect the cluster for privileged workloads that could have loaded `br_netfilter` on the affected worker. The typical pattern is a privileged pod that runs its own container daemon (for example, a self-hosted CI runner with an embedded daemon for service containers); confirm pod placement on the worker via `nodeName` and confirm pod privilege via `spec.containers[*].securityContext.privileged` before treating it as the loader:
+
+```bash
+kubectl get pods -A -o json \
+  | jq -r '.items[] | select(.spec.containers[]?.securityContext.privileged==true)
+      | "\(.metadata.namespace)/\(.metadata.name)\t\(.spec.nodeName)"'
+```
+
+## Resolution
+
+Restore VM connectivity by removing the workload that loaded `br_netfilter`, unloading the module on the worker, and verifying the bridge sysctls are no longer active. Each step is per-worker, because `br_netfilter` is a per-node kernel state — repeat the procedure on every worker that hosts a KubeVirt VM with a Linux Bridge `NetworkAttachmentDefinition` attachment.
+
+Stop the privileged workload that has the bridge subsystem held — the workload identified in Diagnostic Steps whose `nodeName` is the affected worker and whose container is privileged. The kernel unload step in the next paragraph succeeds only once the holder process exits and the module's reference count drops to 0:
+
+```bash
+kubectl delete pod -n <ns> <runner-pod>
+```
+
+Unload `br_netfilter` on the worker by calling `modprobe -r` from a privileged debug pod. The unload returns 0 only when the module's reference count is 0; if it returns `EBUSY`, return to the previous step and ensure no privileged pod on the node is still holding the bridge subsystem:
+
+```bash
+kubectl debug node/<worker> -it=false \
+  --image=registry.alauda.cn:60080/acp/container-debug:v4.3.2 \
+  --profile=sysadmin -- \
+  chroot /host modprobe -r br_netfilter
+```
+
+Verify the `bridge-nf-call-*` sysctls are no longer = 1. After `br_netfilter` is unloaded, the same probe used in Diagnostic Steps should report the three `bridge-nf-call-*` keys as absent from `/proc/sys/net/bridge/` (or, on some configurations, present with value 0); the goal is that no key reports value 1, which is the state the kernel is in when bridged VM frames are no longer pushed up to host iptables:
+
+```bash
+kubectl debug node/<worker> -it=false \
+  --image=registry.alauda.cn:60080/acp/container-debug:v4.3.2 \
+  --profile=sysadmin -- \
+  chroot /host bash -c \
+    "sysctl -a 2>/dev/null | grep net.bridge.bridge-nf-call ; \
+     ls /proc/sys/net/bridge/ 2>&1"
+```
+
+Once the sysctls are no longer = 1, the KubeVirt VM's Linux Bridge attachment regains connectivity through the same upstream data path (`NetworkAttachmentDefinition` → `bridge` CNI delegate → host Linux bridge → bridge port → VM tap/veth bound via `virtualmachineinstance.spec.domain.devices.interfaces[].bridge`) that the article describes — none of the platform-level binding changes, only the kernel-level filtering toggle does.

--- a/docs/en/solutions/VM_Network_Connectivity_Drops_on_ACP_Virtualization_When_br_netfilter_Module_Is_Loaded_on_the_Worker_Node.md
+++ b/docs/en/solutions/VM_Network_Connectivity_Drops_on_ACP_Virtualization_When_br_netfilter_Module_Is_Loaded_on_the_Worker_Node.md
@@ -1,0 +1,180 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A VirtualMachine running on ACP Virtualization suddenly loses network connectivity — periodically or permanently — on an interface backed by a `NetworkAttachmentDefinition` of type `bridge` (Linux bridge). Symptoms the administrator typically sees:
+
+- Ingress traffic (e.g., ICMP ping from outside the node) reaches the physical interface on the worker but never surfaces on the VM's `veth` (visible with `tcpdump -i <phys>` but not on `tcpdump -i <vnet-X>`).
+- Egress traffic from the VM reaches the Linux bridge interface on the host, but ARP requests are silently dropped and do not appear on the bridge port's upstream neighbors.
+- The worker node hosting the VM shows a working L3 path to the outside world; only VM-level traffic is affected.
+- A neighbouring worker in the same cluster running a similar VM works fine.
+
+## Root Cause
+
+The root cause is that the Linux kernel module `br_netfilter` has been loaded on the affected worker node. The module typically arrives one of two ways:
+
+1. **A Docker-in-Docker (DinD) pod** — a privileged container that runs a `dockerd` process inside the worker's kernel namespace. The `dockerd` start-up code calls `modprobe br_netfilter` so its own bridge networking can enforce iptables rules. Common offenders: self-hosted GitHub Actions runners, GitLab runners, Kaniko-like build pods, or any CI pod that needs "docker build" semantics.
+2. **A deliberate `modprobe br_netfilter`** run by a one-off debug session on the node.
+
+When `br_netfilter` is loaded, it sets three sysctls to `1`:
+
+```
+net.bridge.bridge-nf-call-arptables = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables  = 1
+```
+
+With these on, the kernel routes every frame that traverses a Linux bridge through the host's `iptables` / `nftables` / `arptables` chains — including frames between a VM's tap interface and the physical uplink. The ACP Virtualization data plane expects those frames to stay in L2 and never touch the host's netfilter tables. When iptables kicks in, the default `FORWARD` chain of the host (populated by Kube-OVN, kube-proxy, and the node's own firewall) drops packets that were never meant to pass through it — hence the one-way or total drop.
+
+The affected pods need not be on the same worker as the VM. The module is loaded globally on the kernel of whichever worker hosts the DinD pod, and all VMs on that node share the broken behaviour. Other workers are unaffected.
+
+## Resolution
+
+### Step 1 — confirm the module is loaded and the sysctls are on
+
+Pick the worker node that hosts the affected VM:
+
+```bash
+NS=<vm-namespace>
+VM=<vm-name>
+NODE=$(kubectl -n "$NS" get vmi "$VM" -o=jsonpath='{.status.nodeName}')
+echo "Node: $NODE"
+```
+
+Open a debug shell into the node:
+
+```bash
+kubectl debug node/"$NODE" --image=docker.io/library/ubuntu:22.04 -it -- chroot /host bash
+```
+
+Inside the node's chroot:
+
+```bash
+lsmod | grep br_netfilter
+# Output when the module is loaded:
+# br_netfilter           32768  0
+# bridge                307200  1 br_netfilter
+
+sysctl -a 2>/dev/null | grep bridge-nf-call
+# Expected (module absent): no output, or all values 0
+# Observed (module loaded): all three values = 1
+```
+
+If `br_netfilter` shows in `lsmod` and the three sysctls are `1`, the problem is confirmed.
+
+### Step 2 — identify the pod that loaded the module
+
+The module is loaded by whichever privileged pod ran `modprobe br_netfilter`. Usual suspects:
+
+```bash
+# Look for privileged pods that mention 'dind' / 'docker' / 'runner' on this node:
+kubectl get pod -A -o wide --field-selector=spec.nodeName=$NODE | \
+  grep -Ei 'dind|docker|runner|kaniko'
+```
+
+Inspect a candidate's container spec for `privileged: true` and for a `modprobe br_netfilter` in the entrypoint / image:
+
+```bash
+NS_CAND=<pod-namespace>
+POD=<pod-name>
+kubectl -n "$NS_CAND" get pod "$POD" -o=yaml | \
+  yq '.spec.containers[] | {name: .name, image: .image, privileged: .securityContext.privileged}'
+```
+
+A pod running as `privileged: true` with `dockerd` or a DinD-flavoured image (`docker:dind`, `gitlab-runner-docker-machine`, self-hosted `actions-runner-controller` with DinD) is the likely culprit.
+
+### Step 3 — remove or reconfigure the DinD workload
+
+DinD is not supported on ACP (and on Kubernetes in general) because a container loading kernel modules at the node level affects every other workload on the same node. Preferred fixes, in order of preference:
+
+**Option A — switch to a rootless / buildkit-based build path**
+
+`buildkit`, `kaniko`, and `img` build OCI images without needing a privileged container or the `br_netfilter` module. For GitLab / GitHub runners, switch the runner's build stage to one of these. For ACP-native pipelines, use the cluster's built-in image-build CRD if one is provisioned (varies by cluster plugin).
+
+**Option B — pin DinD workloads to dedicated, VM-free nodes**
+
+If the DinD workload is required and cannot be rewritten:
+
+1. Label a subset of workers as `role.dind=yes` and taint them `dind=yes:NoSchedule`.
+2. Add a matching nodeSelector + toleration to the DinD pod.
+3. Add an opposite nodeAntiAffinity to every VM in the cluster so `virt-launcher` pods never land on `role.dind=yes` nodes.
+
+This isolates the side-effect: DinD workers carry `br_netfilter`; VM workers do not.
+
+**Option C — evict the pod and unload the module manually (one-time relief)**
+
+After stopping or rescheduling the offending pod, the module remains loaded until the next reboot. Unload it from the node debug shell:
+
+```bash
+modprobe -r br_netfilter
+sysctl -a | grep bridge-nf-call   # expect no output or all zeros
+```
+
+This is a per-node manual step. If DinD is re-scheduled onto the same node later, the module will reload. Treat this as relief, not as the fix.
+
+### Step 4 — verify VM connectivity
+
+From a pod or external host, ping the VM's IP:
+
+```bash
+kubectl -n "$NS" get vmi "$VM" -o=jsonpath='{.status.interfaces[*].ipAddress}'
+# Then ping the surfaced IP from a test client on the same L2.
+```
+
+Expected: ICMP replies resume. ARP requests from the VM reach the bridge's upstream interface. `tcpdump -i vnet-X` inside the virt-launcher namespace sees both directions of traffic.
+
+### Step 5 — prevent recurrence
+
+Document in the cluster's node-level policy:
+
+- DinD / `modprobe br_netfilter` is forbidden on any node that schedules VMs.
+- Add an admission webhook (Kyverno / Gatekeeper) that denies pods with `securityContext.privileged: true` and a container image matching known DinD image names, unless they land on a `role.dind=yes` worker.
+- Add a Prometheus rule that alerts when any worker with the `role.vm=yes` label exposes `node_netfilter_bridge_nf_call_iptables == 1` — the node-exporter surfaces this sysctl.
+
+```yaml
+# Example PrometheusRule snippet:
+- alert: VMWorkerBrNetfilterActive
+  expr: node_sysctl{unit="net.bridge.bridge-nf-call-iptables"} == 1
+        and on(instance) node_labels{label_role_vm="yes"}
+  for: 5m
+  labels: {severity: warning}
+  annotations:
+    summary: "br_netfilter active on VM worker {{ $labels.instance }}"
+    description: "A privileged workload has loaded br_netfilter; VM L2 traffic will be silently dropped until the module is unloaded."
+```
+
+## Diagnostic Steps
+
+Confirm that the issue is the module and not a broken NAD / VM interface:
+
+```bash
+# 1) VM sees the interface in its guest OS (virsh console or SSH):
+ip link
+ip addr
+
+# 2) The bridge on the node has the VM's tap as a port:
+kubectl debug node/"$NODE" --image=docker.io/library/ubuntu:22.04 -it -- chroot /host bash
+bridge link show | grep br1   # or your bridge name
+
+# 3) tcpdump on the phys interface vs. the tap:
+tcpdump -i eno1 -nn icmp and host <vm-ip>   # upstream side
+tcpdump -i vnet1 -nn icmp and host <vm-ip>  # tap side
+```
+
+A working VM shows traffic on both; a VM affected by `br_netfilter` shows traffic on the phys side only.
+
+Correlate the timeline: when `br_netfilter` is loaded (you can find the timestamp with `dmesg -T | grep br_netfilter`), does connectivity break for the VM on that node? If the timestamps align within seconds, the diagnosis is confirmed.
+
+Check whether the node's netfilter tables contain any rule that would drop VM traffic when bridge frames route through them:
+
+```bash
+iptables -L FORWARD -vn | head -30
+```
+
+Expect a mix of kube-proxy / Kube-OVN rules that do not anticipate bridge-forwarded VM frames — their default-drop at the end of the chain is what silently consumes the traffic.

--- a/docs/en/solutions/VM_Network_Connectivity_Drops_on_ACP_Virtualization_When_br_netfilter_Module_Is_Loaded_on_the_Worker_Node.md
+++ b/docs/en/solutions/VM_Network_Connectivity_Drops_on_ACP_Virtualization_When_br_netfilter_Module_Is_Loaded_on_the_Worker_Node.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# VM Network Connectivity Drops on ACP Virtualization When br_netfilter Module Is Loaded on the Worker Node
 ## Issue
 
 A VirtualMachine running on ACP Virtualization suddenly loses network connectivity — periodically or permanently — on an interface backed by a `NetworkAttachmentDefinition` of type `bridge` (Linux bridge). Symptoms the administrator typically sees:


### PR DESCRIPTION
新增一篇 ACP KB 文章。
