### PR TITLE
[configure] Java pod PKIX SSL handshake failure due to custom JKS truststore missing intermediate CA on ACP

### DIFF
--- a/docs/en/solutions/Java_Pod_PKIX_SSL_Handshake_Failure_to_External_HTTPS_Endpoint_Custom_JKS_TrustStore_Missing_the_Servers_Issuer_CA.md
+++ b/docs/en/solutions/Java_Pod_PKIX_SSL_Handshake_Failure_to_External_HTTPS_Endpoint_Custom_JKS_TrustStore_Missing_the_Servers_Issuer_CA.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Java Pod PKIX SSL Handshake Failure to External HTTPS Endpoint — Custom JKS TrustStore Missing the Server's Issuer CA
 ## Issue
 
 A Java application pod running on ACP fails to open an HTTPS connection to an external endpoint with a PKIX-class exception. Typical messages in the pod logs:

--- a/docs/en/solutions/Java_Pod_PKIX_SSL_Handshake_Failure_to_External_HTTPS_Endpoint_Custom_JKS_TrustStore_Missing_the_Servers_Issuer_CA.md
+++ b/docs/en/solutions/Java_Pod_PKIX_SSL_Handshake_Failure_to_External_HTTPS_Endpoint_Custom_JKS_TrustStore_Missing_the_Servers_Issuer_CA.md
@@ -1,0 +1,238 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A Java application pod running on ACP fails to open an HTTPS connection to an external endpoint with a PKIX-class exception. Typical messages in the pod logs:
+
+```
+javax.net.ssl.SSLHandshakeException:
+  PKIX path building failed:
+  sun.security.provider.certpath.SunCertPathBuilderException:
+    unable to find valid certification path to requested target
+```
+
+Or the wrapper variant from a Spring / RestTemplate application:
+
+```
+org.springframework.web.client.ResourceAccessException:
+  I/O error on POST request for "https://api.partner.example.com/auth":
+  PKIX path building failed
+```
+
+Symptoms that confirm the truststore is the problem rather than the network:
+
+- `curl -v https://<endpoint>` from inside the same pod succeeds — i.e., the OS-level CA bundle works.
+- The error happens on every connection attempt, not intermittently.
+- The pod's environment exposes a `JAVA_TOOL_OPTIONS` (or `JAVA_OPTS`) variable that pins `-Djavax.net.ssl.trustStore=` to a JKS file mounted from a Kubernetes Secret.
+
+## Root Cause
+
+The JVM does not consult the operating-system CA bundle that `curl` and OpenSSL use. When `-Djavax.net.ssl.trustStore=<path>` is set, the JVM trusts **only** the certificate authorities present in that JKS keystore.
+
+The customer-provided keystore is usually a curated, project-specific bundle (private internal CA, plus a small set of partner CAs). When the application starts calling a new external endpoint that is signed by a CA the JKS does not include, the handshake fails. The JVM cannot fall back to system trust — it has been told to ignore it.
+
+To resolve, identify the issuer chain the failing endpoint presents and import the missing CA(s) into the JKS keystore that the JVM is using. Update the Secret. Restart the pod so the JVM re-reads the keystore.
+
+## Resolution
+
+### Step 1 — confirm the trust path is custom
+
+```bash
+NS=<app-namespace>
+POD=$(kubectl -n "$NS" get pod -l app=<your-app> -o=jsonpath='{.items[0].metadata.name}')
+
+# Find the truststore options the JVM was started with:
+kubectl -n "$NS" exec "$POD" -- env | grep -E 'JAVA_TOOL_OPTIONS|JAVA_OPTS|trustStore'
+```
+
+Look for `-Djavax.net.ssl.trustStore=<path>` and `-Djavax.net.ssl.trustStorePassword=<pwd>` in the value. Note the path; it is usually mounted from a Secret. To find which Secret:
+
+```bash
+kubectl -n "$NS" get pod "$POD" -o=yaml | yq '.spec.containers[].volumeMounts[] | select(.mountPath as $p | env(MOUNT) | contains($p))'
+# Or just inspect all volume mounts and match the path manually:
+kubectl -n "$NS" get pod "$POD" -o=yaml | yq '.spec.containers[].volumeMounts'
+kubectl -n "$NS" get pod "$POD" -o=yaml | yq '.spec.volumes'
+```
+
+The volume entry will show `secret: { secretName: <truststore-secret> }`.
+
+### Step 2 — capture the issuer chain the failing endpoint actually presents
+
+From the same pod (so you observe what the JVM sees on the wire), use `openssl s_client` against the failing endpoint:
+
+```bash
+ENDPOINT=api.partner.example.com:443
+
+kubectl -n "$NS" exec -it "$POD" -- /bin/sh -c "
+  openssl s_client -connect $ENDPOINT -servername ${ENDPOINT%:*} -showcerts < /dev/null 2>/dev/null |
+    awk '/BEGIN CERT/,/END CERT/'
+" > /tmp/server-chain.pem
+```
+
+`/tmp/server-chain.pem` now contains every cert the server sent — leaf, then any intermediates. Read each cert's subject and issuer to find the issuing chain:
+
+```bash
+csplit -z -f /tmp/cert- /tmp/server-chain.pem '/-----BEGIN CERTIFICATE-----/' '{*}'
+for c in /tmp/cert-*; do
+  echo "=== $c ==="
+  openssl x509 -in "$c" -noout -subject -issuer
+done
+```
+
+Walk the list. The leaf cert's issuer is the first intermediate; that intermediate's issuer is the next; the chain ends at a self-signed root. The root (and any intermediates the server does not send but the JVM also does not have) is what you need to import.
+
+If the server only sends the leaf, fetch the intermediate from the issuer's published distribution point (CRL or AIA URL embedded in the leaf):
+
+```bash
+openssl x509 -in /tmp/cert-00 -noout -text | grep -A1 'CA Issuers'
+# Then fetch the URL listed and convert to PEM if needed.
+```
+
+For widely used public roots (DigiCert, Let's Encrypt, GlobalSign), the issuer's site publishes the certs:
+
+- DigiCert: <https://www.digicert.com/kb/digicert-root-certificates.htm>
+- Let's Encrypt: <https://letsencrypt.org/certificates/>
+
+Save the missing CA(s) to local files in PEM form, e.g., `/tmp/issuer-root.pem`, `/tmp/issuer-int.pem`.
+
+### Step 3 — extract the current keystore from the Secret
+
+```bash
+SECRET=<truststore-secret>
+KS_KEY=<key-name-in-secret>   # e.g. crm.cacerts.jks
+PASSWORD=<storepass-from-JAVA_TOOL_OPTIONS>
+
+kubectl -n "$NS" get secret "$SECRET" -o=jsonpath="{.data.$KS_KEY}" | base64 -d > /tmp/truststore.jks
+```
+
+Verify the JKS is intact:
+
+```bash
+keytool -list -keystore /tmp/truststore.jks -storepass "$PASSWORD" | head -20
+```
+
+### Step 4 — import the missing CA(s)
+
+Add each missing CA to the keystore. Use a unique alias per cert; reusing an existing alias overwrites the previous entry:
+
+```bash
+keytool -import \
+  -alias my-issuer-root \
+  -file /tmp/issuer-root.pem \
+  -keystore /tmp/truststore.jks \
+  -storepass "$PASSWORD" \
+  -noprompt
+
+keytool -import \
+  -alias my-issuer-int \
+  -file /tmp/issuer-int.pem \
+  -keystore /tmp/truststore.jks \
+  -storepass "$PASSWORD" \
+  -noprompt
+```
+
+Verify the alias is now present:
+
+```bash
+keytool -list -keystore /tmp/truststore.jks -storepass "$PASSWORD" | grep my-issuer
+```
+
+### Step 5 — push the updated JKS back to the Secret
+
+```bash
+kubectl -n "$NS" create secret generic "$SECRET" \
+  --from-file="$KS_KEY=/tmp/truststore.jks" \
+  --dry-run=client -o=yaml | \
+  kubectl -n "$NS" apply -f -
+```
+
+`--dry-run=client | apply -f -` is the safe pattern: it preserves any other keys in the Secret while overwriting only the truststore key. If the Secret has no other keys, the simpler form works:
+
+```bash
+kubectl -n "$NS" patch secret "$SECRET" --type=merge -p \
+  "{\"data\":{\"$KS_KEY\":\"$(base64 -w0 /tmp/truststore.jks)\"}}"
+```
+
+### Step 6 — restart the pod so the JVM re-reads the truststore
+
+The JVM reads the truststore at start-up. Updating the Secret while the pod is running has no effect; the pod sees the change only after a restart.
+
+```bash
+# If the workload is a Deployment:
+kubectl -n "$NS" rollout restart deploy/<deployment-name>
+
+# Or simply delete the pod (if it is owned by a Deployment / StatefulSet that will recreate it):
+kubectl -n "$NS" delete pod "$POD"
+```
+
+Wait for the new pod to be Ready:
+
+```bash
+kubectl -n "$NS" rollout status deploy/<deployment-name>
+```
+
+### Step 7 — verify the handshake
+
+Trigger the same code path (a request that previously failed). Check the pod logs:
+
+```bash
+kubectl -n "$NS" logs -l app=<your-app> --tail=100 | grep -E 'PKIX|SSL|handshake'
+```
+
+Expected: no PKIX exception. The application's response succeeds.
+
+For a quick low-level check from inside the pod, use the JDK's `keytool -printcert -sslserver`:
+
+```bash
+kubectl -n "$NS" exec -it "$POD" -- \
+  keytool -printcert -sslserver "$ENDPOINT" -storepass "$PASSWORD" -keystore /path/to/jks
+```
+
+If `keytool -printcert -sslserver` succeeds, the JVM trust path is healthy.
+
+### Step 8 — codify the trust source
+
+Manual `keytool` updates are easy to forget on the next CA rotation. Two longer-term patterns:
+
+- **Build the truststore in CI**: define the trusted set in a Git repo (one PEM file per CA), have CI build the JKS and push to the cluster (cert-manager + a small operator, or a one-shot Job in the namespace). Rotation becomes a PR.
+- **Mount the OS bundle directly**: if your application can use the system trust (Spring Boot 3+ supports `-Djavax.net.ssl.trustStoreType=system`, OpenJDK 11+ supports the system PKCS#11 store), prefer that and let the platform manage CA rotations.
+
+## Diagnostic Steps
+
+Confirm the symptom is JVM-trust and not network:
+
+```bash
+# OS-level (curl uses /etc/pki or /etc/ssl):
+kubectl -n "$NS" exec "$POD" -- curl -v https://<endpoint> 2>&1 | head -30
+
+# JVM-level via a tiny Java check (if a JRE is in the image):
+kubectl -n "$NS" exec "$POD" -- jrunscript -e "
+  new java.net.URL('https://<endpoint>/').openStream().close();
+"
+```
+
+`curl` succeeds + `jrunscript` fails with PKIX → confirmed.
+
+List the CAs the JVM currently trusts (the ones in the JKS):
+
+```bash
+kubectl -n "$NS" exec "$POD" -- \
+  keytool -list -storepass "$PASSWORD" -keystore <path-to-jks> | \
+  grep -E '^[^,]+,.*trustedCertEntry'
+```
+
+Compare with the chain captured in Step 2 — any cert in the server chain that does not appear here is the missing CA.
+
+If the JKS is right but the JVM still rejects, check whether the JVM is actually loading that file:
+
+```bash
+kubectl -n "$NS" exec "$POD" -- jcmd 1 VM.system_properties | grep ssl.trustStore
+```
+
+The JVM's runtime view of `javax.net.ssl.trustStore` should match the path mounted from the Secret. If it does not, an earlier `JAVA_TOOL_OPTIONS` is being overridden by a later one in the entrypoint or a wrapper script.

--- a/docs/en/solutions/Java_pod_PKIX_SSL_handshake_failure_due_to_custom_JKS_truststore_missing_intermediate_CA_on_ACP.md
+++ b/docs/en/solutions/Java_pod_PKIX_SSL_handshake_failure_due_to_custom_JKS_truststore_missing_intermediate_CA_on_ACP.md
@@ -1,0 +1,112 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Java pod PKIX SSL handshake failure due to custom JKS truststore missing intermediate CA on ACP
+
+## Issue
+
+On Alauda Container Platform (verified on ACP base install package `v4.3.5` with Kubernetes `v1.34.5`), a Java workload pod fails its outbound TLS handshake to an external HTTPS endpoint and the JVM stack trace surfaces `javax.net.ssl.SSLHandshakeException` wrapping `sun.security.provider.certpath.SunCertPathBuilderException` with the message `unable to find valid certification path to requested target`. This wording is emitted by the JDK's default PKIX certificate-path builder when no trust anchor in the JVM's active TrustStore can chain to the peer's server certificate, and the wording is identical on any JVM regardless of the orchestrator.
+
+The same pod can reach the same endpoint with `curl -v` from inside its container, so DNS resolution, egress, and any HTTP(S) proxy hop are not the failure surface — the break is isolated to the JVM's TrustStore configuration. The JVM in question has been started with the system property `-Djavax.net.ssl.trustStore=<path>` (typically passed through `JAVA_TOOL_OPTIONS` or `JAVA_OPTS`), which directs JSSE to use that file as the sole keystore for peer-certificate validation and to ignore the JRE's default `cacerts` and the OS CA bundle. ACP does not inject a JVM or rewrite this property — JSSE reads the value at startup from inside the container's JRE.
+
+## Root Cause
+
+The custom JKS file referenced by `-Djavax.net.ssl.trustStore` does not contain the full CA chain needed to validate the target endpoint's server certificate. Concretely, the JKS is missing the intermediate CA certificate that signed the server cert and/or the corresponding public root CA — for example, an endpoint served by a `DigiCert TLS RSA SHA256 2020 CA1` intermediate chaining to a `DigiCert Global Root` requires both the intermediate and the root to be present as trusted entries when the server does not present the full chain at handshake time.
+
+Because JSSE consults only the keystore named by `-Djavax.net.ssl.trustStore` and ignores both the JRE's bundled `cacerts` and the node's OS trust bundle, a CA that is missing from this custom JKS is not made up for by anything the platform or the base image ships. The JVM cannot construct a chain back to a known trust anchor, and PKIX validation aborts with the `unable to find valid certification path to requested target` message.
+
+## Resolution
+
+Add the missing public CA certificate(s) — the root CA, plus the intermediate CA when the server does not present the full chain — to the JKS file used by the JVM, then redeliver the updated JKS into the pod and restart the workload so the JVM re-reads the TrustStore at startup.
+
+The JKS file is delivered into the pod through a Kubernetes Secret mounted as a volume; the Secret's `data.<jks-key>` entry holds the binary JKS (base64-encoded), and the pod references it via `spec.volumes[].secret.secretName` with a `spec.containers[].volumeMounts[].mountPath` that matches the path passed to `-Djavax.net.ssl.trustStore`. This is the standard Kubernetes Secret-as-volume primitive on ACP — no platform-specific mount shape is required. Updating the JKS therefore means re-writing the Secret's `data.<jks-key>` entry with the new JKS file content.
+
+Read the current JKS out of the Secret to a local working copy on a workstation that has `kubectl` and a JDK available. The `kubectl get secret ... -o jsonpath` form returns the base64-encoded value of the chosen data key, which `base64 -d` decodes into the binary JKS on disk:
+
+```bash
+kubectl get secret <secret-name> -n <namespace> \
+    -o jsonpath='{.data.<jks-key>}' | base64 -d > truststore.jks
+```
+
+Append the missing root CA and, when needed, the missing intermediate CA to the local JKS using the standard JDK `keytool -import` invocation. The flags `-alias`, `-file`, `-keystore`, `-storepass`, and `-noprompt` are standard JDK CLI and behave identically inside or outside the cluster:
+
+```bash
+keytool -import -trustcacerts -noprompt \
+    -alias digicert-global-root \
+    -file digicert-global-root.pem \
+    -keystore truststore.jks \
+    -storepass <storepass>
+
+keytool -import -trustcacerts -noprompt \
+    -alias digicert-intermediate \
+    -file digicert-intermediate.pem \
+    -keystore truststore.jks \
+    -storepass <storepass>
+```
+
+Confirm the new aliases are present in the JKS before pushing the file back into the Secret:
+
+```bash
+keytool -list -v -keystore truststore.jks -storepass <storepass> \
+    | grep -iE 'Alias name|Owner|SHA-?256'
+```
+
+Re-write the Secret's `data.<jks-key>` entry with the updated JKS file. The portable form on ACP is to render the new Secret manifest with `kubectl create secret generic --dry-run=client -o yaml` and apply it with `kubectl replace`, which atomically swaps the data key without removing other keys when the manifest is constructed to include them:
+
+```bash
+kubectl create secret generic <secret-name> \
+    --from-file=<jks-key>=truststore.jks \
+    --dry-run=client -o yaml \
+    | kubectl replace -n <namespace> -f -
+```
+
+Restart the Java workload pod so the JVM re-reads the TrustStore on startup. The JVM loads the file named by `-Djavax.net.ssl.trustStore` once during initialization, so a running pod will not pick up the new contents until its JVM process is restarted; for a Deployment-managed workload, deleting the pod (or rolling the Deployment) is sufficient because the controller respawns it and the Secret volume re-projects with the updated content:
+
+```bash
+kubectl delete pod <java-pod-name> -n <namespace>
+# or, for a Deployment-managed workload:
+kubectl rollout restart deployment/<deployment-name> -n <namespace>
+```
+
+After the new pod is Running, repeat the original outbound TLS call; the JVM now finds the missing CA in its active TrustStore and PKIX completes without the `unable to find valid certification path to requested target` error.
+
+## Diagnostic Steps
+
+Confirm first that the failure is isolated to the JVM's TrustStore rather than to network connectivity. From inside the same pod, run `curl -v` against the failing endpoint and compare against the Java client behavior; when `curl` completes the TLS handshake and the Java application still raises PKIX `unable to find valid certification path to requested target`, the break is on the JVM side and not on the network path:
+
+```bash
+kubectl exec -it -n <namespace> <java-pod-name> -- \
+    curl -v https://<external-endpoint>/
+```
+
+Identify the JKS file path that JSSE is actually using. The JVM logs its system properties at startup, and grepping the pod's stdout for the literal token `-Djavax.net.ssl.trustStore` reveals the path that JSSE is reading (commonly visible inside the `Picked up JAVA_TOOL_OPTIONS:` banner emitted by OpenJDK at startup):
+
+```bash
+kubectl logs -n <namespace> <java-pod-name> \
+    | grep -i 'javax.net.ssl.trustStore'
+```
+
+Cross-check that the path resolves to a Secret-backed volume by reading the pod's `spec.volumes[]` and `spec.containers[].volumeMounts[]`; the `mountPath` that matches the JKS path indicates the Secret carrying the keystore:
+
+```bash
+kubectl get pod <java-pod-name> -n <namespace> -o yaml \
+    | grep -E 'secretName:|mountPath:|name:' -A1
+```
+
+List the keystore entries currently trusted by the JVM. Open a shell inside the pod's container with `kubectl exec -it` (the generic Kubernetes verb for the same operation), then run `keytool -list -v` against the JKS path identified above and filter to look for the CA in question — for example, the public root or intermediate that the target endpoint's server certificate chains to:
+
+```bash
+kubectl exec -it -n <namespace> <java-pod-name> -- /bin/sh
+# inside the container:
+keytool -list -v -keystore <jks-path> -storepass <storepass> \
+    | grep -iE 'Alias name|Owner|Issuer' \
+    | grep -i '<CA-name-fragment>'
+```
+
+If the expected root or intermediate CA does not appear in the JKS listing, the diagnosis is confirmed: the active TrustStore does not contain the trust anchor needed to chain to the peer certificate, and the resolution above (import the missing CA, replace the Secret, restart the pod) applies.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
