### PR TITLE
[virtualization] Granting a group start/stop/restart-only RBAC on KubeVirt VirtualMachines on ACP

### DIFF
--- a/docs/en/solutions/Granting_a_Group_StartStopRestart_Only_Permission_on_VirtualMachines_Without_Disk_Edit_Access.md
+++ b/docs/en/solutions/Granting_a_Group_StartStopRestart_Only_Permission_on_VirtualMachines_Without_Disk_Edit_Access.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Granting a Group Start/Stop/Restart-Only Permission on VirtualMachines Without Disk-Edit Access
 ## Issue
 
 A team needs to give an operations group on ACP Virtualization the ability to **power-cycle** virtual machines — start, stop, restart, pause, unpause — without granting the broader edit permissions that would let them resize disks, attach new PVCs, change CPU/memory, or alter the VM template.

--- a/docs/en/solutions/Granting_a_Group_StartStopRestart_Only_Permission_on_VirtualMachines_Without_Disk_Edit_Access.md
+++ b/docs/en/solutions/Granting_a_Group_StartStopRestart_Only_Permission_on_VirtualMachines_Without_Disk_Edit_Access.md
@@ -1,0 +1,214 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A team needs to give an operations group on ACP Virtualization the ability to **power-cycle** virtual machines — start, stop, restart, pause, unpause — without granting the broader edit permissions that would let them resize disks, attach new PVCs, change CPU/memory, or alter the VM template.
+
+The administrator wants:
+
+- A named Kubernetes `Group` (mapped from ACP's identity provider) with the limited permission set.
+- The permission scoped to a specific namespace (or set of namespaces), not cluster-wide.
+- A clear separation: anything that mutates `spec.template.spec` (disks, CPU, memory, NICs) stays with the application owners; only runtime-state actions are delegated to the ops group.
+
+## Root Cause
+
+KubeVirt models VM lifecycle actions as **subresources** on the `virtualmachines` resource, not as edits to the VM spec:
+
+- Power on: PUT `virtualmachines/start`
+- Power off: PUT `virtualmachines/stop`
+- Restart: PUT `virtualmachines/restart`
+- Pause / unpause: PUT `virtualmachines/pause`, `virtualmachines/unpause`
+- Console attach: GET `virtualmachineinstances/console`, `virtualmachineinstances/vnc`
+
+Because subresources are first-class RBAC objects under `subresources.kubevirt.io`, a `Role` can grant **only** the subresource verbs without granting `update` / `patch` on the parent `virtualmachines` resource. That separation is the lever — the ops group gets `update` on the `start`/`stop`/`restart` subresources but never on the VM's `spec`. Disk edits, CPU edits, NIC edits all happen by patching `spec.template.spec` on the VM, which the ops group cannot do.
+
+The other half is binding that `Role` to the right `Group`. ACP maps groups from its identity provider into Kubernetes via `Group` references in `RoleBinding`. The administrator declares the group name once and refers to it from the binding.
+
+## Resolution
+
+### Step 1 — define the group
+
+ACP's identity provider (LDAP, OIDC, SAML, or built-in) is the source of truth for groups. The exact procedure to create the group depends on the IdP — refer to the ACP platform's auth-management docs for the LDAP / OIDC / built-in flow. The output of this step is a stable group name (for example, `vm-operators`) that the cluster sees in the `groups` claim of every member's token.
+
+To verify the group is visible to the API server, log in as a member and check `kubectl auth whoami`:
+
+```bash
+kubectl auth whoami -o=jsonpath='{.status.userInfo.groups}'
+# Expected: ["system:authenticated", "vm-operators", ...]
+```
+
+If `vm-operators` does not appear, the IdP-to-cluster mapping is missing — fix that first before continuing.
+
+### Step 2 — write the Role with subresource-only verbs
+
+Create a `Role` in the namespace where the VMs live. The verbs map cleanly to lifecycle actions:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vm-power-cycle
+  namespace: <vm-namespace>
+rules:
+  # Read access on the VM and its runtime instance — needed so they can list / show in tools:
+  - apiGroups: ["kubevirt.io"]
+    resources: ["virtualmachines", "virtualmachineinstances"]
+    verbs: ["get", "list", "watch"]
+
+  # Lifecycle subresources — start / stop / restart / pause / unpause:
+  - apiGroups: ["subresources.kubevirt.io"]
+    resources:
+      - virtualmachines/start
+      - virtualmachines/stop
+      - virtualmachines/restart
+      - virtualmachines/pause
+      - virtualmachines/unpause
+    verbs: ["update"]
+
+  # OPTIONAL: VNC / serial console (read-only — investigation but no power):
+  # - apiGroups: ["subresources.kubevirt.io"]
+  #   resources:
+  #     - virtualmachineinstances/console
+  #     - virtualmachineinstances/vnc
+  #   verbs: ["get"]
+```
+
+Note what is **not** here:
+
+- No `update` / `patch` / `create` / `delete` on `virtualmachines` itself → spec edits and VM deletion are denied.
+- No verbs on `persistentvolumeclaims`, `datavolumes`, `secrets`, `configmaps` → they cannot attach storage or change credentials.
+- No `*` verb anywhere.
+
+Apply:
+
+```bash
+kubectl apply -f vm-power-cycle.role.yaml
+```
+
+### Step 3 — bind the Role to the group
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-power-cycle-binding
+  namespace: <vm-namespace>
+subjects:
+  - kind: Group
+    name: vm-operators                   # exact group name from Step 1
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: vm-power-cycle
+  apiGroup: rbac.authorization.k8s.io
+```
+
+```bash
+kubectl apply -f vm-power-cycle.rb.yaml
+```
+
+For the same permission on multiple namespaces, replicate the `Role` + `RoleBinding` per namespace. For an everywhere-scoped permission (rare for this use case), promote both to `ClusterRole` + `ClusterRoleBinding` — but that drops the namespace boundary, so reserve it for genuinely cluster-wide ops teams.
+
+### Step 4 — verify with `kubectl auth can-i`
+
+Log in as a group member (or use `--as-group=vm-operators --as=test1`) and confirm each verb is allowed or denied as intended:
+
+```bash
+NS=<vm-namespace>
+USR=test1
+GRP=vm-operators
+
+# Should be ALLOWED:
+kubectl --as "$USR" --as-group "$GRP" -n "$NS" auth can-i \
+  update virtualmachines/start.subresources.kubevirt.io
+kubectl --as "$USR" --as-group "$GRP" -n "$NS" auth can-i \
+  update virtualmachines/stop.subresources.kubevirt.io
+kubectl --as "$USR" --as-group "$GRP" -n "$NS" auth can-i \
+  get virtualmachines.kubevirt.io
+
+# Should be DENIED:
+kubectl --as "$USR" --as-group "$GRP" -n "$NS" auth can-i \
+  update virtualmachines.kubevirt.io                        # spec edit
+kubectl --as "$USR" --as-group "$GRP" -n "$NS" auth can-i \
+  patch virtualmachines.kubevirt.io
+kubectl --as "$USR" --as-group "$GRP" -n "$NS" auth can-i \
+  delete virtualmachines.kubevirt.io
+kubectl --as "$USR" --as-group "$GRP" -n "$NS" auth can-i \
+  create persistentvolumeclaims
+```
+
+Each ALLOWED line must print `yes`; each DENIED line must print `no`.
+
+### Step 5 — exercise the actual lifecycle actions
+
+Test the full path (not just RBAC) with `virtctl` from a member's session:
+
+```bash
+NS=<vm-namespace>
+VM=<vm-name>
+
+virtctl stop "$VM" -n "$NS"
+virtctl start "$VM" -n "$NS"
+virtctl restart "$VM" -n "$NS"
+```
+
+Each command should succeed. Trying anything outside the granted scope should fail with `forbidden`:
+
+```bash
+# Should fail:
+kubectl -n "$NS" patch vm "$VM" --type=merge -p '{"spec":{"template":{"spec":{"domain":{"resources":{"requests":{"memory":"4Gi"}}}}}}}'
+# Expected: Error from server (Forbidden): virtualmachines.kubevirt.io "<vm>" is forbidden:
+#   User "test1" cannot patch resource "virtualmachines" in API group "kubevirt.io"
+```
+
+### Step 6 — document the boundary
+
+Write down what the `vm-operators` group can and cannot do, and link the doc from the team's runbook. Useful as an audit reference and to head off the inevitable "I need to also …" requests:
+
+```
+vm-operators (namespace <ns>):
+  ALLOWED: list/get/watch VM and VMI; start, stop, restart, pause, unpause
+  DENIED:  edit VM spec, edit disks, attach/detach PVCs,
+           change CPU/memory, modify network interfaces,
+           create/delete VMs, console access (unless added in optional stanza)
+```
+
+If the team later asks for, say, console access, add the commented-out stanza in Step 2's Role and reapply — surface-area changes are explicit, one verb at a time.
+
+## Diagnostic Steps
+
+If a member reports "I cannot stop the VM", verify in this order:
+
+```bash
+# 1) Token actually carries the group:
+kubectl auth whoami -o=jsonpath='{.status.userInfo.groups}'
+
+# 2) Binding exists in the right namespace:
+kubectl -n "$NS" get rolebinding vm-power-cycle-binding -o=yaml | yq '.subjects'
+
+# 3) Role grants the subresource:
+kubectl -n "$NS" get role vm-power-cycle -o=yaml | yq '.rules'
+
+# 4) RBAC decision for the exact verb:
+kubectl --as <user> --as-group <group> -n "$NS" auth can-i \
+  update virtualmachines/stop.subresources.kubevirt.io --v=8 2>&1 | grep -E 'allow|deny|reason'
+```
+
+The `--v=8` output shows which Role and which Binding the API server matched. If no match appears, recheck Step 3.
+
+If `kubectl auth can-i` says yes but `virtctl stop` still fails, the failure is in the lifecycle action itself (the VM is in a state that cannot transition, the virt-controller is unhealthy), not in RBAC. Inspect:
+
+```bash
+kubectl -n "$NS" get vmi "$VM" -o=jsonpath='{.status.phase}'
+kubectl -n kubevirt logs deploy/virt-controller --tail=100 | grep "$VM"
+```
+
+Common transient failures: VM in `Migrating` state cannot stop until migration finishes; VM with stuck PVC unbinding cannot stop until the unmount completes. Neither is an RBAC issue.
+
+If you need to grant the same permission to many groups, prefer one `ClusterRole` (defined once) with many `RoleBindings` (one per namespace × group pair) over many copies of the same `Role`. The `ClusterRole` + namespace-scoped `RoleBinding` pattern keeps the verb set in one place.

--- a/docs/en/solutions/Granting_a_group_startstoprestart_only_RBAC_on_KubeVirt_VirtualMachines_on_ACP.md
+++ b/docs/en/solutions/Granting_a_group_startstoprestart_only_RBAC_on_KubeVirt_VirtualMachines_on_ACP.md
@@ -1,0 +1,92 @@
+---
+kind:
+   - How To
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Granting a group start/stop/restart-only RBAC on KubeVirt VirtualMachines on ACP
+
+## Issue
+
+On Alauda Container Platform, KubeVirt (build `v1.7.0-alauda.2`, control plane in namespace `kubevirt`) implements the lifecycle actions start, stop, and restart on a `VirtualMachine` as the subresources `virtualmachines/start`, `virtualmachines/stop`, and `virtualmachines/restart` under the aggregated apiGroup `subresources.kubevirt.io/v1` (namespaced, served unchanged from upstream). The desired outcome is to give a population of users the ability to start, stop, and restart any VM in any namespace via the API (`kubectl`, `virtctl`, or any console that drives the same subresources), but not the ability to add, remove, or edit a VM's disks or other spec fields.
+
+Binding the KubeVirt-shipped aggregated `kubevirt.io:edit` ClusterRole to such a group is too broad: that role grants write verbs `[get, delete, create, update, patch, list, watch]` on the parent `virtualmachines` resource in apiGroup `kubevirt.io` (it carries the aggregation label `rbac.authorization.k8s.io/aggregate-to-edit=true` and the install annotation `kubevirt.io/install-strategy-version=v1.7.0-alauda.2`), so any subject bound to it can mutate the VM spec, including disks. The disk list lives in the `VirtualMachine` spec at `spec.template.spec.domain.devices.disks[]` (per the `virtualmachines.kubevirt.io/v1` CRD), and changing it requires `update`/`patch` on `kubevirt.io/virtualmachines` — there is no path from the lifecycle subresources to that field.
+
+## Resolution
+
+Define a custom ClusterRole that grants only `update` on the three lifecycle subresources in `subresources.kubevirt.io`, together with read verbs on the parent `virtualmachines` resource so the subject can list and inspect VMs to act on. This is the canonical verb pattern the upstream-shipped `kubevirt.io:edit` ClusterRole uses for the lifecycle subresources (verb `update` against `virtualmachines/{start,stop,restart}`), and `kubevirt.io:view` confirms read on VMs uses `[get, list, watch]` on apiGroup `kubevirt.io / virtualmachines` with no write verbs. Apply the following ClusterRole:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubevirt-vm-lifecycle-only
+rules:
+  - apiGroups: ["subresources.kubevirt.io"]
+    resources:
+      - virtualmachines/start
+      - virtualmachines/stop
+      - virtualmachines/restart
+    verbs: ["update"]
+  - apiGroups: ["kubevirt.io"]
+    resources: ["virtualmachines"]
+    verbs: ["get", "list", "watch"]
+```
+
+Bind the ClusterRole to the target group with a ClusterRoleBinding. On ACP, the RBAC subject kinds remain the upstream Kubernetes set (`User`, `Group`, `ServiceAccount` — `rbac.authorization.k8s.io/v1` is served unchanged), and a `kind: Group` subject matches any authenticated user whose authentication-layer groups claim contains the bound `name`; the group identity itself is supplied by whatever identity provider (OIDC, LDAP, etc.) the cluster is integrated with — that population is established outside this RBAC recipe. Replace `<group-name>` with the group string carried in the user's token:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-vm-lifecycle-only
+subjects:
+  - kind: Group
+    name: <group-name>
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: kubevirt-vm-lifecycle-only
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Apply both objects:
+
+```bash
+kubectl apply -f kubevirt-vm-lifecycle-only-clusterrole.yaml
+kubectl apply -f kubevirt-vm-lifecycle-only-clusterrolebinding.yaml
+```
+
+Because the binding is cluster-scoped, every authenticated user whose groups claim contains `<group-name>` inherits start/stop/restart-only permission against every VM in every namespace; no other VM-spec mutation is reachable through the bound permissions.
+
+## Diagnostic Steps
+
+Confirm that the lifecycle subresources are served on the cluster and that the resource strings the ClusterRole references match the cluster's served API:
+
+```bash
+kubectl get --raw /apis/subresources.kubevirt.io/v1 \
+  | python3 -m json.tool \
+  | grep -E 'virtualmachines/(start|stop|restart)'
+```
+
+The aggregated apiGroup `subresources.kubevirt.io/v1` lists `virtualmachines/start`, `virtualmachines/stop`, and `virtualmachines/restart` as namespaced subresources — these are the exact resource strings the ClusterRole rule must use.
+
+Inspect the upstream-shipped `kubevirt.io:edit` ClusterRole to confirm the canonical verb on the lifecycle subresources is `update` and to see why a narrower custom role is required (it grants write verbs on the parent `virtualmachines` resource as well):
+
+```bash
+kubectl get clusterrole kubevirt.io:edit -o yaml
+kubectl get clusterrole kubevirt.io:view -o yaml
+```
+
+`kubevirt.io:edit` groups `virtualmachines/{start,stop,restart}` (apiGroup `subresources.kubevirt.io`) under `verbs: [update]`, carries the `rbac.authorization.k8s.io/aggregate-to-edit=true` label, and lists `[get, delete, create, update, patch, list, watch]` on `kubevirt.io / virtualmachines` — too broad for this requirement. `kubevirt.io:view` confirms the read-only half (`[get, list, watch]` on `kubevirt.io / virtualmachines` and `virtualmachineinstances`), which composes with the custom subresource-update rule to deliver start/stop/restart-only behavior with no disk-edit reachability.
+
+Verify the disk field is reachable only through write verbs on the parent resource, not through any lifecycle subresource:
+
+```bash
+kubectl explain virtualmachine.spec.template.spec.domain.devices.disks
+```
+
+The output anchors the disk list at `spec.template.spec.domain.devices.disks[]` on `virtualmachines.kubevirt.io/v1`; mutating it requires `update`/`patch` on `kubevirt.io/virtualmachines`, which the custom role deliberately omits.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
