### PR TITLE
[virtualization] Inter-cluster VM disk export lands as a tar archive when source PVC lacks the CDI content-type annotation

### DIFF
--- a/docs/en/solutions/Inter_Cluster_VM_Export_Produces_Unbootable_tar_Archived_Disks.md
+++ b/docs/en/solutions/Inter_Cluster_VM_Export_Produces_Unbootable_tar_Archived_Disks.md
@@ -1,0 +1,97 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A VirtualMachine exported from one cluster and imported into another fails to boot in the destination. The destination VM's disk shows up as a raw device that cannot be parsed by the bootloader. Inspecting the first MB of the disk reveals a **POSIX tar archive** rather than a filesystem or disk image.
+
+```bash
+kubectl exec -n <dst-ns> <virt-launcher-pod> -- dd if=/dev/vol-0 bs=1M count=1 > /tmp/disk.out
+file /tmp/disk.out
+# /tmp/disk.out: POSIX tar archive (GNU)
+```
+
+The source cluster reports the export completed successfully; the destination's CDI (Containerized Data Importer) reports the import completed successfully. Yet the bytes on disk are wrong.
+
+## Root Cause
+
+The export server picks an over-the-wire format based on the source PVC's metadata:
+
+- PVCs owned by a **DataVolume** and carrying the annotation `cdi.kubevirt.io/storage.contentType: kubevirt` are exported as **raw disk streams** — CDI writes them verbatim into the destination volume and the guest boots.
+- PVCs that lack both markers — typically those created directly by a VirtualMachine without going through a DataVolume, especially on filesystem-mode storage (NFS, filesystem CSI) — are exported as a **tar archive** containing `disk.img` inside. The destination CDI expects a raw stream, opens the target **block device** for sequential write, and dumps the entire tar file into it byte-for-byte. The tar bytes become the "disk content," and the bootloader sees garbage.
+
+This is a bug in the export/import path when the annotation is missing and the PVC is owned by the VM directly. The fix is to mark the source PVC before initiating the export so the server picks the raw-disk path.
+
+## Resolution
+
+Annotate every source PVC that will be exported, then retry. The fix is non-destructive — it only adds metadata — and takes effect on the next export reconcile.
+
+1. **Identify the source PVCs**. Each VirtualMachine's disk is a PVC referenced in `spec.template.spec.volumes`:
+
+   ```bash
+   kubectl -n <src-ns> get vm <vm> -o jsonpath='{range .spec.template.spec.volumes[*]}{.dataVolume.name}{.persistentVolumeClaim.claimName}{"\n"}{end}'
+   ```
+
+2. **Check owner and annotations before applying**:
+
+   ```bash
+   kubectl -n <src-ns> get pvc <pvc> \
+     -o jsonpath='{"owner=\n"}{.metadata.ownerReferences}{"\nannotations=\n"}{.metadata.annotations}{"\n"}'
+   ```
+
+   The buggy pattern is: `ownerReferences` points at `kind: VirtualMachine` (not `DataVolume`) and `cdi.kubevirt.io/storage.contentType` is absent.
+
+3. **Add the annotation** to every affected PVC. This is the single fix:
+
+   ```bash
+   kubectl -n <src-ns> annotate pvc <pvc> cdi.kubevirt.io/storage.contentType=kubevirt
+   ```
+
+   For a fleet, loop:
+
+   ```bash
+   for ns in <list-of-ns>; do
+     kubectl -n "$ns" get pvc -l kubevirt.io/created-by=virtualmachine \
+       --no-headers -o custom-columns=:.metadata.name \
+     | xargs -I{} kubectl -n "$ns" annotate pvc {} cdi.kubevirt.io/storage.contentType=kubevirt --overwrite
+   done
+   ```
+
+4. **Re-run the export/import workflow**. For a live migration plan, delete the failed destination VMI and re-trigger the plan:
+
+   ```bash
+   kubectl -n <dst-ns> delete vmi <vm>
+   # then retrigger the migration plan or re-run the import
+   ```
+
+5. **Prevent recurrence.** For new VMs that will need exportability, create their PVCs as `DataVolume` spec members rather than standalone PVCs. DataVolumes set the content-type annotation automatically, and downstream tooling assumes the raw-stream export path.
+
+## Diagnostic Steps
+
+Confirm the on-disk corruption pattern before annotating anything — this keeps the fix reversible if the real issue turns out to be something else:
+
+```bash
+# From inside the destination virt-launcher
+kubectl exec -n <dst-ns> <launcher-pod> -- \
+  dd if=/dev/vol-0 bs=1M count=2 of=/tmp/disk-sample 2>/dev/null
+kubectl exec -n <dst-ns> <launcher-pod> -- file /tmp/disk-sample
+```
+
+`POSIX tar archive` or `tar archive` confirms the pattern. `DOS/MBR boot sector` or `x86 boot sector` means the disk is written correctly and the boot failure is a different issue (UEFI/BIOS mismatch, missing drivers, guest-OS corruption).
+
+Audit the annotation state across source PVCs to estimate exposure before the fleet-wide fix:
+
+```bash
+kubectl get pvc -A -o json \
+  | jq -r '.items[]
+      | select((.metadata.annotations."cdi.kubevirt.io/storage.contentType" // "") != "kubevirt")
+      | select((.metadata.ownerReferences // [])[0].kind // "" != "DataVolume")
+      | "\(.metadata.namespace)/\(.metadata.name)"'
+```
+
+Every line in that output is at risk of the same bug on next export; annotate pre-emptively.

--- a/docs/en/solutions/Inter_cluster_VM_disk_export_lands_as_a_tar_archive_when_source_PVC_lacks_the_CDI_content_type_annotation.md
+++ b/docs/en/solutions/Inter_cluster_VM_disk_export_lands_as_a_tar_archive_when_source_PVC_lacks_the_CDI_content_type_annotation.md
@@ -1,0 +1,51 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Inter-cluster VM disk export lands as a tar archive when source PVC lacks the CDI content-type annotation
+
+## Issue
+
+On Alauda Container Platform with KubeVirt installed (namespace `kubevirt`, HCO `v1.17.0`, `virt-exportproxy v1.7.0-alauda.2`, `cdi-controller v1.64.0-alauda.2`), exporting a VM disk from a filesystem-backed PVC to another cluster can produce a destination disk that the new VM cannot boot from. The trigger is a source PVC whose disk image is *not* tagged with the CDI content-type annotation: when that annotation is absent, the export server publishes the volume through its `tar.gz` format URL (the `status.links.{internal,external}.volumes[].formats[].format` surface on the `VirtualMachineExport` CR exposes both `disk_image` and `archive` form factors per volume, and the choice between them is driven by the source PVC metadata).
+
+On the destination side, when CDI on `cdi.kubevirt.io/v1beta1` consumes that stream into a PVC that is owned by a `VirtualMachine` (and not by a `DataVolume`) and whose annotations do not include `cdi.kubevirt.io/storage.contentType`, the controller writes the incoming bytes through to the target device without unpacking the tar wrapper, leaving the destination volume as a literal POSIX tar archive instead of a raw disk image.
+
+## Root Cause
+
+A tar archive on a block or file backend has no MBR/GPT, no bootloader, and no filesystem the guest firmware can hand off to — it is a sequence of header+payload records, not a disk. A VM that points at such a volume therefore cannot complete firmware-to-kernel handoff and fails to boot.
+
+The behavior on the destination cluster is governed entirely by the source PVC's CDI metadata: with the annotation missing and the ownerReference pointing at a `VirtualMachine`, the upstream-stable `cdi.kubevirt.io/v1beta1` reconciliation path treats the inbound bytes as opaque archive content rather than a disk image to extract, so the wrapping survives all the way onto the destination volume.
+
+## Resolution
+
+Set the CDI content-type annotation on the source PVC before triggering the export, so the export server selects the disk-image format rather than the archive format and the destination CDI controller treats the inbound stream as a raw disk:
+
+```bash
+kubectl annotate pvc -n <source-ns> <source-pvc> \
+  cdi.kubevirt.io/storage.contentType=kubevirt
+```
+
+Re-run the export and the downstream import after the annotation is in place; the destination volume then lands as a real disk image and the VM created against it boots normally. The same annotation key (`cdi.kubevirt.io/storage.contentType`) is interpreted identically by the cluster's `cdi-controller v1.64.0-alauda.2` because the group/version `cdi.kubevirt.io/v1beta1` is upstream-stable, so this workaround applies to any forklift-style cross-cluster VM migration workflow that round-trips disks through a `VirtualMachineExport` plus a CDI import.
+
+## Diagnostic Steps
+
+Confirm the destination PVC is actually a tar archive (and not a corrupted-but-still-disk image) by sampling the first megabyte of the volume from inside the VM's `virt-launcher` pod in the `kubevirt` namespace and running `file` against the captured bytes:
+
+```bash
+kubectl exec -n <vm-ns> <virt-launcher-pod> -- \
+  dd if=/dev/vol-0 bs=1M count=1 > vol-0.out
+file vol-0.out
+```
+
+A response of `POSIX tar archive (GNU)` confirms the destination disk was written as a tar wrapper rather than an unpacked disk image, which matches the failure mode described above and points back at the missing `cdi.kubevirt.io/storage.contentType` annotation on the source PVC as the root cause.
+
+Locate the `virt-launcher` pod for the affected VM via the standard KubeVirt pod label, which is honored on this cluster:
+
+```bash
+kubectl get pod -n <vm-ns> -l kubevirt.io=virt-launcher
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章。
