### PR TITLE
[devops] PipelineRun stuck after referencing a removed ClusterTask kind — migrate to a Tekton cluster resolver

### DIFF
--- a/docs/en/solutions/PipelineRun_stuck_after_referencing_a_removed_ClusterTask_kind_migrate_to_a_Tekton_cluster_resolver.md
+++ b/docs/en/solutions/PipelineRun_stuck_after_referencing_a_removed_ClusterTask_kind_migrate_to_a_Tekton_cluster_resolver.md
@@ -1,0 +1,91 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# PipelineRun stuck after referencing a removed ClusterTask kind — migrate to a Tekton cluster resolver
+
+## Issue
+
+On Alauda Container Platform (Kubernetes `v1.34.5`, Alauda DevOps Pipelines / `tektoncd-operator` CSV `tektoncd-operator.v4.2.0`, OperatorBundle channel `latest` from catalog `platform`, TektonConfig release `v0.76.0-c46274a`), a `Pipeline` that still references a Task via `taskRef.kind: ClusterTask` cannot be admitted as a v1 `Pipeline` on this build: there is no `clustertasks.tekton.dev` CRD registered, and the v1 Pipeline admission webhook (`validation.webhook.pipeline.tekton.dev`) treats `taskRef.kind: ClusterTask` as a custom task ref and rejects the apply with `invalid value: custom task ref must specify apiVersion: spec.tasks[0].taskRef.apiVersion`. The same gate is what prevents a `PipelineRun` against any older copy of that `Pipeline` (one that was admitted on an earlier build where `ClusterTask` was still a recognised kind) from making forward progress through resolution to schedule a `TaskRun` Pod — `kubectl get pipeline -n <ns> -o yaml | grep -iE 'ClusterTask|resolver'` is the first sweep to find any remaining `ClusterTask` references in the namespace.
+
+## Root Cause
+
+`ClusterTask` is no longer a first-class kind in the `tektoncd-operator` shipped on ACP. The standard tekton.dev v1 CRDs that are present in `v4.2.0` are `pipelines`, `pipelineruns`, `tasks`, `taskruns`, `customruns`, `stepactions`, and `verificationpolicies`; the cluster-scoped legacy `clustertasks.tekton.dev` is not in that set, and `kubectl get clustertask -A` returns `error: the server doesn't have a resource type "clustertask"`. Because the kind is gone, the v1 Pipeline schema no longer recognises `kind: ClusterTask` as a built-in `taskRef.kind` and falls through to the custom-task-ref branch, which requires `apiVersion` — the admission webhook then rejects the apply outright, and any prior Pipeline that still carries that field cannot resolve a Task during PipelineRun reconciliation.
+
+The supported replacement is the upstream Tekton remote-resolution framework (the "Resolvers" set), and in particular the **cluster resolver**, which fetches a `Task` (or `Pipeline`) from another namespace on the same cluster by name. On ACP DevOps Pipelines `v4.2.0` the cluster resolver is enabled by default: the `TektonConfig` singleton named `config` has `spec.pipeline.enable-cluster-resolver: true` (alongside `enable-bundles-resolver`, `enable-git-resolver`, `enable-hub-resolver`), and the broader `enable-api-fields` knob that gates remote-resolution feature surface ships as `beta` out of the box on this version.
+
+## Resolution
+
+Migrate any `Pipeline` whose `taskRef` still names `kind: ClusterTask` to use `taskRef.resolver: cluster` with the three params the cluster resolver expects (`name`, `kind`, `namespace`). The original `ClusterTask` references a cluster-scoped task by name; the resolver references the corresponding namespaced `Task` (typically the Task that ships in the `tektoncd-operator` install namespace `tekton-pipelines`, or wherever your tasks live).
+
+Before-and-after, applied to the same step:
+
+```yaml
+# legacy (rejected on ACP DevOps Pipelines v4.2.0)
+spec:
+  tasks:
+    - name: test-task
+      taskRef:
+        kind: ClusterTask
+        name: <task-name>
+```
+
+```yaml
+# migrated — uses the cluster resolver
+spec:
+  tasks:
+    - name: test-task
+      taskRef:
+        resolver: cluster
+        params:
+          - name: name
+            value: <task-name>
+          - name: kind
+            value: task
+          - name: namespace
+            value: tekton-pipelines      # or whatever namespace holds the Task
+```
+
+The cluster resolver is enabled by default on ACP DevOps Pipelines `v4.2.0` (`TektonConfig` `config` ships `spec.pipeline.enable-cluster-resolver: true` and `spec.pipeline.enable-api-fields: beta`), so no `TektonConfig` patch is required for a fresh install. If your environment has been customised and `enable-api-fields` is no longer `beta`, restore it on the singleton `TektonConfig` named `config`:
+
+```bash
+kubectl patch tektonconfig config --type=merge \
+  -p '{"spec":{"pipeline":{"enable-api-fields":"beta","enable-cluster-resolver":true}}}'
+```
+
+Verify the migration end-to-end by re-applying the migrated `Pipeline` and creating a `PipelineRun` against it: the cluster resolver fetches the referenced `Task` from the specified namespace, the controller materialises a `TaskRun`, and `kube-scheduler` places the `TaskRun` Pod on a worker node, after which the step executes normally.
+
+## Diagnostic Steps
+
+Confirm the legacy `kind: ClusterTask` is still in use in any `Pipeline` in the affected namespace:
+
+```bash
+kubectl get pipeline -n <namespace> -o yaml | grep -iE 'ClusterTask|resolver'
+```
+
+`ClusterTask` rows in the output are exactly the references that need to be migrated; `resolver` rows are already on the supported path. For a cluster-wide sweep, drop the `-n <namespace>` and add `-A`.
+
+Confirm that the cluster has no `clustertasks.tekton.dev` CRD and that the v1 Pipeline admission webhook rejects `kind: ClusterTask`, so the migration is mandatory rather than optional on this build:
+
+```bash
+kubectl get crd | grep -i clustertask    # expect: no rows
+kubectl get clustertask -A               # expect: error: the server doesn't have a resource type "clustertask"
+```
+
+Confirm the resolver-side prerequisites on the `TektonConfig` singleton — both knobs should already be in place on a default ACP install:
+
+```bash
+kubectl get tektonconfig config \
+  -o jsonpath='enable-api-fields={.spec.pipeline.enable-api-fields} enable-cluster-resolver={.spec.pipeline.enable-cluster-resolver}{"\n"}'
+```
+
+Expected output on ACP DevOps Pipelines `v4.2.0`:
+
+```
+enable-api-fields=beta enable-cluster-resolver=true
+```

--- a/docs/en/solutions/Tekton_PipelineRun_Stuck_at_Timeout_with_object_has_been_modified_on_ClusterTask.md
+++ b/docs/en/solutions/Tekton_PipelineRun_Stuck_at_Timeout_with_object_has_been_modified_on_ClusterTask.md
@@ -1,0 +1,125 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A PipelineRun enters `PipelineRunTimeout` without ever scheduling a TaskRun pod. The controller emits a stream of errors like:
+
+```text
+Operation cannot be fulfilled on pipelineruns.tekton.dev "<name>":
+  the object has been modified; please apply your changes to the
+  latest version and try again
+```
+
+New pipelines fail the same way; existing PipelineRuns accumulate in `Timeout` state. The Pipeline definition references tasks via `taskRef: { kind: ClusterTask, name: ... }`.
+
+## Root Cause
+
+**ClusterTask** is a deprecated Tekton resource. Tekton Pipelines 1.17 and later remove the controller path that reconciled `ClusterTask`-referenced tasks into each PipelineRun. The controller tries to patch the PipelineRun, finds the referenced ClusterTask unresolved, the patch races against the reconciler's own update, and the stream of `object has been modified` errors prevents any TaskRun from being scheduled — eventually the PipelineRun hits its timeout with zero work actually run.
+
+The deprecation is upstream, so ACP's `devops` (based on Tekton) follows the same removal timeline.
+
+## Resolution
+
+Migrate Pipeline definitions from `ClusterTask` references to the **resolver** mechanism. Resolvers are the supported way to reference a task from another source — including a cluster-shared task library — and they've been the recommended path since Pipelines 1.13.
+
+1. **Enable beta API fields** (default in recent Tekton; verify):
+
+   ```yaml
+   apiVersion: operator.tekton.dev/v1alpha1
+   kind: TektonConfig
+   metadata:
+     name: config
+   spec:
+     pipeline:
+       enable-api-fields: beta
+   ```
+
+2. **Rewrite ClusterTask references to use the `cluster` resolver.**
+
+   Old (broken):
+
+   ```yaml
+   spec:
+     tasks:
+       - name: build
+         taskRef:
+           kind: ClusterTask
+           name: build-app
+   ```
+
+   New (works):
+
+   ```yaml
+   spec:
+     tasks:
+       - name: build
+         taskRef:
+           resolver: cluster      # instead of kind:
+           params:
+             - name: kind
+               value: task
+             - name: name
+               value: build-app
+             - name: namespace
+               value: <shared-task-namespace>    # where the Task lives
+   ```
+
+   The resolver version references a namespaced `Task`, not a cluster-scoped `ClusterTask`. Tasks that used to be `ClusterTask` should be re-created as regular `Task` resources in a shared namespace (conventionally the Tekton install namespace or a dedicated `tekton-tasks` namespace).
+
+3. **Move the tasks themselves.** For each ClusterTask you referenced:
+
+   ```bash
+   kubectl get clustertask <name> -o yaml \
+     | sed 's/^kind: ClusterTask/kind: Task/' \
+     | sed -E 's/^([[:space:]]*)name: (.*)/\1name: \2\n\1namespace: <shared-task-namespace>/' \
+     | kubectl apply -f -
+   ```
+
+   (Double-check the YAML after the sed; ClusterTask → Task conversion is rarely 1:1 if the tasks depend on cluster-scoped state.)
+
+4. **Cancel and restart stuck PipelineRuns.** The stuck ones won't recover — their reconciliation is wedged. Cancel them, then trigger fresh runs against the migrated Pipelines:
+
+   ```bash
+   kubectl -n <ns> delete pipelinerun -l <selector>   # or specific names
+   ```
+
+5. **Prevent regression.** Reject `kind: ClusterTask` in your Pipeline repo via a policy check — either a Kyverno/Gatekeeper rule or a simple pre-merge grep in CI. Catch new definitions before they reach the cluster.
+
+## Diagnostic Steps
+
+Confirm the PipelineRun's failure mode:
+
+```bash
+kubectl -n <ns> describe pipelinerun <name> | sed -n '/Status:/,/Events:/p'
+# Timeout, no TaskRuns, events include "object has been modified"
+```
+
+Check the Pipeline definition for ClusterTask references:
+
+```bash
+kubectl -n <ns> get pipeline <name> -o yaml \
+  | grep -E 'kind: ClusterTask|resolver:'
+```
+
+Any `kind: ClusterTask` line is a candidate for migration. Any `resolver: cluster` that already exists alongside should be double-checked for correct params.
+
+See which tasks still live as ClusterTask cluster-wide (the migration scope):
+
+```bash
+kubectl get clustertask -o custom-columns=NAME:.metadata.name,AGE:.metadata.creationTimestamp
+```
+
+Cancel an individual stuck PipelineRun for investigation:
+
+```bash
+kubectl -n <ns> patch pipelinerun <name> --type=merge \
+  -p '{"spec":{"status":"Cancelled"}}'
+```
+
+After migration, PipelineRuns against the new definitions should start scheduling TaskRun pods immediately (seconds), not time out. If a PipelineRun still hangs without scheduling pods but now has no ClusterTask references, look instead at the Task's resolver status (`kubectl describe taskrun <name>`) for resolver-side errors.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
