### PR TITLE
[extend] OperatorGroup install-mode mismatch blocks reinstall after an operator changes supported modes

### DIFF
--- a/docs/en/solutions/OperatorGroup_install_mode_mismatch_blocks_reinstall_after_an_operator_changes_supported_modes.md
+++ b/docs/en/solutions/OperatorGroup_install_mode_mismatch_blocks_reinstall_after_an_operator_changes_supported_modes.md
@@ -1,0 +1,128 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# OperatorGroup install-mode mismatch blocks reinstall after an operator changes supported modes
+
+## Issue
+
+Installing or reinstalling an OperatorBundle on ACP fails. The OLM
+controllers (`olm-operator` and `catalog-operator`) that decide
+whether a CSV may install run in the `cpaas-system` namespace on
+this platform, and a Subscription whose CSV cannot find a matching
+OperatorGroup stays stuck in `ResolutionFailed` /
+`ConstraintsNotSatisfiable` without ever installing a CSV.
+The error surfaces on the Subscription as:
+
+```text
+The OperatorGroup in the <ns> namespace does not support the
+<X> installation mode. Select a different installation mode
+or namespace.
+```
+
+## Root Cause
+
+OLM matches a CSV to an OperatorGroup by install mode. The CSV
+declares its supported modes via `spec.installModes` — a list of
+`{type, supported}` entries. The OperatorGroup picks one
+implicitly by `spec.targetNamespaces`:
+
+| `targetNamespaces` value | implied mode |
+|---|---|
+| `[<og-ns>]` (own ns) | `OwnNamespace` |
+| `[<other-ns>]` (different ns) | `SingleNamespace` |
+| `[ns1, ns2, ...]` | `MultiNamespace` |
+| absent / `[]` | `AllNamespaces` |
+
+If the operator's `installModes` set shrinks between releases (e.g.
+the new CSV drops support for `SingleNamespace`) and an OperatorGroup
+created under the old release still asks for that mode, the new CSV
+no longer has a matching supported entry and OLM keeps the
+Subscription stuck in the resolution-failed state described above.
+This is the documented upstream OLM matching behavior; it has not
+been directly reproduced on ACP by a deliberate installModes-shrink
+experiment, so treat the specific shrink scenario as the most common
+trigger of the surface symptom rather than the only one.
+
+This applies to any ACP OperatorBundle (kubevirt-operator,
+topolvm-operator, asm-operator, etc.). It does **not** affect ACP
+plugins on the ModulePlugin path (e.g. `logcenter` / `logagent` /
+`logclickhouse`), which do not use OperatorGroups.
+
+## Resolution
+
+Delete the stale OperatorGroup, then re-create one whose
+`spec.targetNamespaces` shape maps to a mode that the new CSV's
+`installModes` lists as `supported: true`. On ACP, OLM does
+**not** auto-recreate the OperatorGroup for you — the install path
+(for example the `install-acp-operator` flow) creates the OG
+explicitly with a `targetNamespaces` value chosen by the caller, so
+the namespace stays OG-less until you re-apply one. After the
+matching OG exists, the existing Subscription re-resolves on the
+next reconcile and OLM picks up a compatible CSV.
+
+```bash
+# 1. Find the OperatorGroup in the operator's namespace
+kubectl get og -n <operator-ns>
+
+# 2. Delete the stale one
+kubectl delete og -n <operator-ns> <og-name>
+
+# 3. Re-create an OG whose targetNamespaces matches a supported mode
+#    on the new CSV. Pick the shape from the table in ## Root Cause.
+cat <<'YAML' | kubectl apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: <og-name>
+  namespace: <operator-ns>
+spec:
+  targetNamespaces:
+    - <operator-ns>   # OwnNamespace; or drop the whole spec for AllNamespaces
+YAML
+
+# 4. The existing Subscription re-resolves on the next reconcile.
+```
+
+> Scope the delete + re-create to the failing operator's namespace
+> only. Don't touch OperatorGroups in unrelated namespaces — other
+> operators share them.
+
+## Diagnostic Steps
+
+Compare the modes the failing CSV actually supports against the mode
+the existing OG asks for. The first command lists the CSV's
+`installModes` entries; the second prints the OG's
+`targetNamespaces` shape — together they tell you whether the
+mismatch in the error message reflects a real shape disagreement on
+this cluster.
+
+```bash
+# Modes the failing CSV actually supports
+kubectl get csv -n <ns> <csv-name> -o jsonpath='{.spec.installModes}'
+
+# Mode the existing OG asks for
+kubectl get og -n <ns> <og-name> -o jsonpath='{.spec.targetNamespaces}{"\n"}'
+```
+
+If the OG's `targetNamespaces` shape doesn't correspond to a
+`supported: true` entry in the CSV's `installModes`, that is the
+mismatch.
+
+The Subscription's status carries the error verbatim, which is the
+quickest way to confirm this issue and rule out other OLM
+resolution failures.
+
+```bash
+kubectl get sub -n <ns> <sub-name> -o jsonpath='{.status.conditions}' | jq
+```
+
+A condition with `reason: ConstraintsNotSatisfiable` plus a message
+containing "does not support the X installation mode" confirms this
+issue rather than some other OLM resolution failure (for example a
+missing or unhealthy CatalogSource).

--- a/docs/en/solutions/OperatorGroup_mode_mismatch_blocks_operator_reinstall.md
+++ b/docs/en/solutions/OperatorGroup_mode_mismatch_blocks_operator_reinstall.md
@@ -1,0 +1,144 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+Reinstalling an operator into a namespace that previously hosted an older version of the same operator fails. The marketplace UI rejects the install with:
+
+```text
+The OperatorGroup in the cpaas-logging Namespace does not support the
+global installation mode. Select a different installation Namespace
+that supports this mode.
+```
+
+The CLI variant carries the same message in the Subscription's status:
+
+```yaml
+status:
+  conditions:
+    - type: ResolutionFailed
+      status: "True"
+      reason: ConstraintsNotSatisfiable
+      message: "OperatorGroup ... does not support installation mode AllNamespaces"
+```
+
+The user did not configure anything different — they simply uninstalled the previous version and clicked install on the new one.
+
+## Root Cause
+
+OLM uses an `OperatorGroup` (OG) object in the install namespace to define which namespaces an operator's controllers should watch. The OG carries a `spec.targetNamespaces` list, and OLM derives an "installation mode" from that list:
+
+- Empty list (`spec.targetNamespaces: []`) → `AllNamespaces` mode (cluster-wide).
+- One namespace listed → `OwnNamespace` mode (just the install namespace).
+- Multiple namespaces listed → `MultiNamespace` mode.
+- A namespace different from the OG's own → `SingleNamespace` mode.
+
+An operator's bundle declares which modes it supports in `spec.installModes` of its CSV. OLM checks the OG's mode against the operator's `installModes` at resolve time. If they don't match, the install is rejected.
+
+The mode an operator supports can change between releases. A frequent flip is when an operator that once was scoped per-namespace gets refactored into a cluster-wide controller, and the new bundle declares `AllNamespaces: true` while dropping `OwnNamespace: true`. If the user uninstalls the old version through the marketplace UI but the OG that was created for the old version is left behind (the UI sometimes deletes the Subscription and CSV but not the OG), the leftover OG still encodes `targetNamespaces: [<install-ns>]` — i.e. `OwnNamespace` mode. The new operator's bundle no longer supports that mode, and the resolver refuses to proceed.
+
+## Resolution
+
+Delete the leftover OperatorGroup in the install namespace, then reinstall. The marketplace controller will create a fresh OG with the right mode for the new operator bundle.
+
+```bash
+NS=cpaas-logging
+
+# 1. List every OG currently in the namespace.
+kubectl -n "$NS" get operatorgroup
+# NAME                  AGE
+# cpaas-logging-5bvj6   97d
+
+# 2. Inspect the leftover OG's targetNamespaces to confirm the mode mismatch.
+kubectl -n "$NS" get operatorgroup cpaas-logging-5bvj6 -o yaml \
+  | yq '.spec.targetNamespaces'
+# - cpaas-logging        # this is OwnNamespace mode
+
+# 3. Delete the leftover OG.
+kubectl -n "$NS" delete operatorgroup cpaas-logging-5bvj6
+```
+
+Re-issue the install. If installing through the marketplace UI, the operator wizard will create a new OG with the right mode (`AllNamespaces` → empty `targetNamespaces` list). If installing via manifest, write the OG explicitly first:
+
+```yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cpaas-logging-og
+  namespace: cpaas-logging
+spec: {}                # empty spec ⇒ AllNamespaces mode
+```
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: cpaas-logging
+spec:
+  channel: stable
+  name: cluster-logging
+  source: community-catalog
+  sourceNamespace: cpaas-marketplace
+  installPlanApproval: Automatic
+```
+
+Apply both and watch the Subscription advance through `UpgradePending` → `Installing` → `Complete`.
+
+### Why deleting the OG is safe
+
+The OG itself owns nothing in the data plane. Deleting it does not remove the operator's CRs, its workloads, or its CRDs. What an OG controls is purely the visibility scope OLM grants to the operator's ServiceAccount through generated RBAC. A fresh OG with the right mode regenerates the same RBAC. The data plane survives the brief window between OG delete and re-create — it is the operator's control loop that pauses, not the workloads it manages.
+
+That said, there is a small RBAC-coverage gap during the swap. Pods that depend on the operator continuing to reconcile (e.g. log-collector DaemonSets that rely on the logging operator validating their config) can see transient errors during the few seconds the operator's RBAC is missing. Schedule the swap during a maintenance window if any controller-of-controllers chain runs through the operator.
+
+## Diagnostic Steps
+
+To confirm the mode mismatch before deleting anything, line up the OG's effective mode against the operator bundle's supported modes.
+
+The OG's mode (derived):
+
+```bash
+kubectl -n "$NS" get operatorgroup -o yaml \
+  | yq '.items[].spec.targetNamespaces' \
+  | head
+```
+
+- A `null` or empty list → `AllNamespaces`.
+- A single entry equal to `$NS` → `OwnNamespace`.
+- A single entry different from `$NS` → `SingleNamespace`.
+- Multiple entries → `MultiNamespace`.
+
+The operator bundle's supported modes (from the bundle CSV in the catalog):
+
+```bash
+CATALOG=community-catalog
+PKG=cluster-logging
+
+kubectl exec -n cpaas-marketplace deploy/<catalog-pod> -- \
+  grpcurl -plaintext localhost:50051 api.Registry.GetBundle \
+  -d '{"pkgName":"'"$PKG"'","channelName":"stable"}' \
+  2>/dev/null | jq '.csvJson | fromjson | .spec.installModes'
+```
+
+Cross-reference: any mode the OG sits in that is not `supported: true` in the bundle is the conflict.
+
+If the OG looks right but the install still fails, check whether two OGs exist in the same namespace — OLM only allows one OG per namespace and rejects installs when multiple are present:
+
+```bash
+kubectl -n "$NS" get operatorgroup --no-headers | wc -l
+```
+
+A count > 1 is the second cause of this error class. Delete the duplicates, leaving only the OG whose mode matches the operator.
+
+For installs that succeed but the operator pod still doesn't get the right RBAC (silent half-state where the operator deploys but its reconciles fail with `Forbidden`), inspect the cluster role bindings the OG generated:
+
+```bash
+kubectl get clusterrolebinding -l olm.owner.namespace="$NS" -o name
+```
+
+Each role binding reflects one entry in the OG's effective scope. A missing binding for an expected target namespace means the OG's mode and the operator's expectations still differ — re-run the swap with the OG explicitly set to `AllNamespaces`.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
