### PR TITLE
[networking] Restarting OVN/OVS containers does not reload host NIC configuration changes on ACP

### DIFF
--- a/docs/en/solutions/Restarting_OVNOVS_containers_does_not_reload_host_NIC_configuration_changes_on_ACP.md
+++ b/docs/en/solutions/Restarting_OVNOVS_containers_does_not_reload_host_NIC_configuration_changes_on_ACP.md
@@ -1,0 +1,66 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Restarting OVN/OVS containers does not reload host NIC configuration changes on ACP
+
+## Issue
+
+On Alauda Container Platform, the OVS and OVN userspace runs inside the `ovs-ovn` DaemonSet in the `kube-system` namespace. Each node hosts one pod (label `app=ovs`) whose single `openvswitch` container (image `registry.alauda.cn:60080/acp/kube-ovn:v1.15.10`) launches `ovsdb-server`, `ovs-vswitchd`, and `ovn-controller` from the `/kube-ovn/start-ovs.sh` entrypoint; the pod runs with `hostNetwork=true` and `hostPID=true` so that it shares the host network namespace. The host's network manager varies by node OS; on the reference cluster all four nodes run Ubuntu 22.04.1 LTS with kernel `5.15.0-56-generic`, and host NIC, bond, and VLAN configuration is owned by the node OS network stack (on Ubuntu the default is `systemd-networkd` driven by `netplan`). The `ovs-ovn` pod attaches to those interfaces only after the host has brought them up.
+
+After a host-level network change is applied on a node (for example editing the bond, a VLAN sub-interface, or an MTU), restarting the `ovs-ovn` pod or its constituent processes does not propagate the new configuration onto the live host interfaces — the dataplane container does not re-read or re-apply host-level interface state on restart, so host networking changes do not propagate via CNI restart.
+
+## Root Cause
+
+The OVS dataplane and the OVN southbound controller that ship inside the `ovs-ovn` pod do not author or manage host-level NIC, bond, or VLAN configuration; they consume host interfaces that the node OS network manager has already created. Because the host network owner is a separate subsystem from the CNI dataplane, restarting only the CNI userspace — by rolling the `ovs-ovn` DaemonSet or deleting the pod — leaves the host interface state untouched and re-attaches to whatever the node OS currently exposes. The same separation-of-concerns holds on any node-OS family, only the host-side configuration vehicle changes; on the reference cluster the host owner is `systemd-networkd` plus `netplan` (Ubuntu 22.04.1 LTS).
+
+## Resolution
+
+Apply host networking changes through the node OS network manager on each affected node, not through the CNI pod. On the reference Ubuntu 22.04.1 LTS nodes this means editing the relevant file under `/etc/netplan/` and reloading via `netplan apply`; the host owner re-creates or reconfigures the interface, and the `ovs-ovn` pod's `openvswitch` container then sees the updated interface state through the shared host network namespace.
+
+For substantial NIC, bond, or VLAN reshapes, plan for a node reboot — or otherwise restart the host network stack — as the standard way to bring the new host networking config into effect. A reboot is expected to fully reinitialise the host network stack and, on ACP, also recreate the `ovs-ovn` pod so that the CNI re-attaches to the freshly initialised host interfaces.
+
+The container-level restart action on ACP (rolling the `ovs-ovn` DaemonSet or deleting its pod) is still a valid recovery step for issues internal to the OVS/OVN userspace, but it is not a substitute for reapplying host network state, because the dataplane container does not own that state. The standard restart shape is:
+
+```bash
+kubectl -n kube-system rollout restart daemonset/ovs-ovn
+kubectl -n kube-system rollout status daemonset/ovs-ovn
+```
+
+## Diagnostic Steps
+
+Confirm the OVS/OVN delivery vehicle and image on the cluster. The `ovs-ovn` DaemonSet lives in `kube-system`, runs one pod per node with `hostNetwork=true` and `hostPID=true`, and packages `ovsdb-server`, `ovs-vswitchd`, and `ovn-controller` inside the single `openvswitch` container:
+
+```bash
+kubectl -n kube-system get daemonset ovs-ovn
+kubectl -n kube-system get pods -l app=ovs -o wide
+kubectl -n kube-system get daemonset ovs-ovn \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+```
+
+Identify the node OS and the active host-network manager on each node. The CNI dataplane attaches to interfaces that this subsystem owns, so any change must be made through it:
+
+```bash
+kubectl get nodes -o wide
+# On a target node (Ubuntu 22.04.1 LTS, kernel 5.15.0-56-generic on the reference cluster):
+#   ls /etc/netplan/
+#   systemctl status systemd-networkd
+```
+
+After applying a host network change, verify that the new state is visible on the host interface and that the `ovs-ovn` pod observes it through the shared host network namespace. If the host interface still shows the old configuration, the change was not committed at the host level and a pod restart will not fix it:
+
+```bash
+# Inspect host-side interface state:
+ip -d link show <iface>
+ip addr show <iface>
+
+# Inspect what OVS currently sees from inside the ovs-ovn pod:
+kubectl -n kube-system exec ds/ovs-ovn -c openvswitch -- ovs-vsctl show
+```
+
+If the change spans bonds, VLAN parents, or MTU on shared uplinks, schedule a node reboot to fully reinitialise the host network stack; the `ovs-ovn` pod is recreated by the DaemonSet controller after the node returns and re-attaches to the freshly initialised interfaces.

--- a/docs/en/solutions/Restarting_OVN_or_Open_vSwitch_does_not_reload_host_networking_changes_made_through_nmcli.md
+++ b/docs/en/solutions/Restarting_OVN_or_Open_vSwitch_does_not_reload_host_networking_changes_made_through_nmcli.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Restarting OVN or Open vSwitch does not reload host networking changes made through nmcli
 ## Issue
 
 An administrator updates host networking on a worker node — adjusting a

--- a/docs/en/solutions/Restarting_OVN_or_Open_vSwitch_does_not_reload_host_networking_changes_made_through_nmcli.md
+++ b/docs/en/solutions/Restarting_OVN_or_Open_vSwitch_does_not_reload_host_networking_changes_made_through_nmcli.md
@@ -1,0 +1,163 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+An administrator updates host networking on a worker node — adjusting a
+bond, replacing a NIC, changing a VLAN, modifying an interface — by
+calling `nmcli` directly on the node. To pick up the change they restart
+the OVN and Open vSwitch services:
+
+```bash
+systemctl restart openvswitch
+systemctl restart ovn-controller
+```
+
+The restart succeeds but the change does not take effect. Pods on the node
+keep using the old configuration, the bond shows the old slaves, or the
+node loses connectivity to one of the upstream VLANs.
+
+## Root Cause
+
+The host's network stack is layered:
+
+```text
+Physical NICs --> bond0 --> OVS port --> br-ex --> CNI gateway
+```
+
+NetworkManager owns the **physical interfaces and the bonds** at the bottom
+of the stack. Open vSwitch sits one layer up — it consumes interfaces that
+NetworkManager has already brought up — and the cluster CNI (OVN-driven or
+otherwise) consumes the OVS bridges.
+
+Restarting `openvswitch` or the CNI's controller daemon only re-evaluates
+the upper layers. It does not reload anything NetworkManager owns. If the
+change was made with `nmcli` (a bond reconfigured, a NIC swapped, a VLAN
+relabelled), NetworkManager's in-memory state already reflects the change,
+but the physical layer below has not been re-applied to the kernel until
+NetworkManager itself is reloaded for the affected interface.
+
+For trivial changes (an IP added to an existing connection, a route
+modified) `nmcli connection up <conn>` is enough to reapply NetworkManager
+state. For structural changes — bond membership swaps, NIC replacements,
+VLAN re-tagging on a bridge that is currently up — the safest path is a
+node reboot, because the change disturbs interfaces that downstream
+consumers (OVS, the CNI) actively hold open.
+
+## Resolution
+
+Choose the path that matches the change:
+
+### For minor changes (IP/route/DNS/MTU)
+
+Reapply the NetworkManager profile for the affected connection:
+
+```bash
+nmcli connection down <conn>
+nmcli connection up <conn>
+```
+
+Verify the kernel state reflects the new value:
+
+```bash
+ip addr show dev <iface>
+ip route show
+```
+
+OVS and the CNI re-attach to the interface as soon as it is back up — no
+service restart required.
+
+### For structural changes (bond, VLAN, NIC swap)
+
+Drain the node first so workloads relocate cleanly:
+
+```bash
+kubectl cordon <node>
+kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
+```
+
+Then reboot the node. On boot, NetworkManager reapplies the new profile,
+OVS rebuilds its bridges from scratch on top, and the CNI reattaches
+without inheriting any stale state:
+
+```bash
+kubectl debug node/<node> -- chroot /host shutdown -r now
+# Wait for the node to come back and become Ready, then uncordon:
+kubectl uncordon <node>
+```
+
+### Long-term: declarative host networking
+
+For repeatable, declarative host-network configuration, drive node
+networking through NMState rather than ad-hoc `nmcli` invocations. A
+`NodeNetworkConfigurationPolicy` is reconciled by the NMState operator
+across all matching nodes, and the operator handles the "down + reapply"
+sequence per connection so the change converges reliably without manual
+service restarts:
+
+```yaml
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: bond0-add-slave
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    interfaces:
+      - name: bond0
+        type: bond
+        state: up
+        link-aggregation:
+          mode: 802.3ad
+          port:
+            - eth0
+            - eth1
+            - eth2   # newly added slave
+```
+
+Declarative configuration is also auditable and survives node
+re-provisioning, which makes it the recommended approach for any
+production cluster that accepts host-network changes regularly.
+
+## Diagnostic Steps
+
+1. Confirm the kernel sees the change before blaming OVS / the CNI:
+
+   ```bash
+   ip -d link show <iface>
+   ip addr show <iface>
+   ```
+
+   If `ip` does not show the new state, the failure is in NetworkManager —
+   check the connection profile (`nmcli connection show <conn>`) and
+   reapply.
+
+2. Confirm OVS sees the underlying interface:
+
+   ```bash
+   ovs-vsctl show
+   ```
+
+   The bond must be present as a port on the `br-ex` bridge. If it is
+   missing or marked as faulted, OVS lost the interface during the
+   change — restart `openvswitch` after the kernel state is correct, or
+   reboot.
+
+3. Confirm the CNI is happy:
+
+   ```bash
+   kubectl get pods -n <cni-ns> -o wide | grep <node>
+   ```
+
+   The node-side CNI pod must be `Running` and pass its readiness probes.
+   If it crash-loops, drain and reboot.
+
+4. After a node reboot, confirm the node returns `Ready` and that pods
+   scheduled on it can reach the cluster network end-to-end with a
+   `kubectl exec` curl from one of them.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
