### PR TITLE
[configure] Missing ServiceAccount blocks Deployment rollout and yields an empty observed image set

### DIFF
--- a/docs/en/solutions/Container_security_scanner_reports_no_images_for_a_deployment_that_never_produced_pods.md
+++ b/docs/en/solutions/Container_security_scanner_reports_no_images_for_a_deployment_that_never_produced_pods.md
@@ -1,0 +1,72 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A container-security workload scanner (for example, the StackRox-based Container Security service or any tool that derives image inventory from the desired state of a `Deployment`) reports `No Images` for a particular workload. The same scanner correctly enumerates images for other deployments in the same cluster. Inspecting the Deployment in question shows a fresh revision was rolled out recently, but no pods from that revision are running.
+
+## Root Cause
+
+A scanner that derives image inventory from the **latest desired** revision of a `Deployment` cannot map images for a revision whose `ReplicaSet` has produced zero pods. In Kubernetes, pod admission is rejected when the `Deployment` references a `ServiceAccount` that does not exist in the namespace. The new `ReplicaSet` therefore stays at zero ready pods, the Deployment eventually reports `ProgressDeadlineExceeded`, and the scanner has no live image references to attach to that revision — so the workload appears empty in inventory.
+
+## Resolution
+
+Restore the rollout by ensuring the referenced `ServiceAccount` exists; the scanner will refresh inventory automatically once pods from the new `ReplicaSet` reach `Ready`.
+
+1. Inspect the Deployment to find the `ServiceAccount` it expects:
+
+   ```bash
+   kubectl get deployment <name> -n <ns> -o jsonpath='{.spec.template.spec.serviceAccountName}{"\n"}'
+   ```
+
+2. If the name is non-empty and missing, create it:
+
+   ```bash
+   kubectl create serviceaccount <name> -n <ns>
+   ```
+
+   If the workload was supposed to use the namespace `default` ServiceAccount, remove the `serviceAccountName` field from the pod spec instead of creating a misnamed account.
+
+3. Trigger a fresh rollout so the existing `ReplicaSet` is retried with the new admission outcome:
+
+   ```bash
+   kubectl rollout restart deployment/<name> -n <ns>
+   ```
+
+4. Confirm the new pods reach `Running` and that the `ReplicaSet` `availableReplicas` matches the desired count:
+
+   ```bash
+   kubectl rollout status deployment/<name> -n <ns>
+   kubectl get replicaset -n <ns> -l app=<label> -o wide
+   ```
+
+After pods are healthy the scanner re-evaluates the deployment on its next reconciliation cycle and the missing image inventory disappears.
+
+## Diagnostic Steps
+
+1. List recent `Warning` events in the namespace; the admission rejection is reported by the ReplicaSet controller:
+
+   ```bash
+   kubectl get events -n <ns> --sort-by=.lastTimestamp | tail -n 20
+   ```
+
+   A typical event reads `Error creating: pods "..." is forbidden: error looking up service account <ns>/<name>: ServiceAccount "<name>" not found.`
+
+2. Read the Deployment status conditions to confirm the rollout has stalled rather than the workload simply being scaled to zero:
+
+   ```bash
+   kubectl get deployment <name> -n <ns> -o jsonpath='{range .status.conditions[*]}{.type}={.status} {.reason}{"\n"}{end}'
+   ```
+
+   `Available=False` together with `Progressing=False` and reason `ProgressDeadlineExceeded` confirms the new revision never produced live pods.
+
+3. List `ReplicaSets` for the deployment and confirm the latest one has `currentReplicas: 0`:
+
+   ```bash
+   kubectl get replicaset -n <ns> -l app=<label> -o wide
+   ```

--- a/docs/en/solutions/Container_security_scanner_reports_no_images_for_a_deployment_that_never_produced_pods.md
+++ b/docs/en/solutions/Container_security_scanner_reports_no_images_for_a_deployment_that_never_produced_pods.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Container security scanner reports no images for a deployment that never produced pods
 ## Issue
 
 A container-security workload scanner (for example, the StackRox-based Container Security service or any tool that derives image inventory from the desired state of a `Deployment`) reports `No Images` for a particular workload. The same scanner correctly enumerates images for other deployments in the same cluster. Inspecting the Deployment in question shows a fresh revision was rolled out recently, but no pods from that revision are running.

--- a/docs/en/solutions/Missing_ServiceAccount_blocks_Deployment_rollout_and_yields_an_empty_observed_image_set.md
+++ b/docs/en/solutions/Missing_ServiceAccount_blocks_Deployment_rollout_and_yields_an_empty_observed_image_set.md
@@ -1,0 +1,59 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Missing ServiceAccount blocks Deployment rollout and yields an empty observed image set
+
+## Issue
+
+On Alauda Container Platform (ACP base v4.3.x, kube v1.34.5), `apps/v1` Deployment and ReplicaSet are namespaced core api-resources and the controller relies on `.spec.template.spec.serviceAccountName` to create pods. When the named ServiceAccount does not exist in the Deployment's namespace, the apiserver's in-tree ServiceAccount admission plugin denies each pod-create call the ReplicaSet controller issues, so the new ReplicaSet never produces a running pod.
+
+Because no pod of the new ReplicaSet ever reaches Ready, a container security scanner — or any system that observes the running pod set for the Deployment and projects images from `.items[*].spec.containers[*].image` — reports an empty image set for the affected workload. The desired image list on `.spec.template.spec.containers[*].image` is non-empty, but the observed image set is empty because the selector matches zero pods.
+
+## Root Cause
+
+The apiserver returns a Forbidden response to the ReplicaSet controller's pod-create call with the verbatim message `pods "<name>" is forbidden: error looking up service account <ns>/<sa>: serviceaccount "<sa>" not found` whenever the referenced ServiceAccount does not exist in the namespace.
+
+The ReplicaSet controller surfaces that admission denial as a `Warning` Event with `reason=FailedCreate` and `.involvedObject.kind=ReplicaSet`, carrying the apiserver's error string verbatim in `.message`.
+
+If the new ReplicaSet never produces pods, the Deployment controller eventually flips its `Progressing` condition to `status=False, reason=ProgressDeadlineExceeded` once `.spec.progressDeadlineSeconds` (default 600s on ACP `apps/v1` Deployments) elapses without progress, and the Deployment is left with zero ready pods.
+
+## Resolution
+
+Create the missing ServiceAccount in the Deployment's namespace. The next pod-create call from the ReplicaSet controller passes the SA admission plugin, the new pods start, and the rollout completes:
+
+```bash
+kubectl create sa <name> -n <ns>
+```
+
+Alternatively, edit the Deployment so that `.spec.template.spec.serviceAccountName` (and the legacy alias `.spec.template.spec.serviceAccount`) points at an existing ServiceAccount in the namespace. The `default` ServiceAccount is auto-created by the SA controller in every ACP namespace and is a safe fallback when no dedicated SA is required:
+
+```bash
+kubectl edit deployment/<name> -n <ns>
+```
+
+Once pods are running, a scanner that walks the Deployment's pods reports the correct image set for the workload:
+
+```bash
+kubectl get pods -n <ns> -l <deployment-selector>
+```
+
+## Diagnostic Steps
+
+List the namespace's events and look for the ReplicaSet's `Warning FailedCreate` records — the `.message` field carries the apiserver's `error looking up service account` string, which names the missing SA directly:
+
+```bash
+kubectl get event -n <ns>
+kubectl get event -n <ns> --field-selector reason=FailedCreate
+```
+
+Inspect the Deployment YAML to read off both the misconfigured `serviceAccountName` and the `Progressing` condition on a single object — when the rollout is stuck on the missing SA, the `serviceAccountName` field points at the absent ServiceAccount and `.status.conditions[]` carries the `ProgressDeadlineExceeded` reason after the 600s default elapses:
+
+```bash
+kubectl get deployment/<name> -n <ns> -o yaml
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章。
