### PR TITLE
[networking] ALB default SSL cert fails to load when the PEM bundle is malformed on ACP

### DIFF
--- a/docs/en/solutions/ALB_default_SSL_cert_fails_to_load_when_the_PEM_bundle_is_malformed_on_ACP.md
+++ b/docs/en/solutions/ALB_default_SSL_cert_fails_to_load_when_the_PEM_bundle_is_malformed_on_ACP.md
@@ -1,0 +1,58 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# ALB default SSL cert fails to load when the PEM bundle is malformed on ACP
+
+## Issue
+
+On Alauda Container Platform, the platform load balancer is the ALB2 instance (`alaudaloadbalancer2.crd.alauda.io`), whose `spec.config.defaultSSLCert` field points at a Kubernetes Secret of type `kubernetes.io/tls` carrying `tls.crt` and `tls.key`. After replacing that default TLS Secret with a freshly generated wildcard or SAN certificate bundle, components consuming the ALB default SSL cert can log Go `x509` / `crypto/tls` PEM parse errors at startup — the bundle is structurally invalid even though it looks correct in a text editor. The data plane runs on the nginx-based engine (`alb-nginx:v4.3.1` and `alb2:v4.3.1` in the `cpaas-system` namespace on a Kubernetes v1.34.5 cluster), and the consuming code path is Go's standard `encoding/pem` and `crypto/tls`, so any Go-based component that resolves the same Secret would reject the same malformed inputs through the same parser.
+
+## Root Cause
+
+The PEM bundle in a `kubernetes.io/tls` Secret's `tls.crt` is expected to be a concatenation of certificates in a fixed order: the leaf (wildcard or SAN) certificate first, followed by any intermediate CA certificates, and the root CA last. The Go `encoding/pem` parser is strict about block framing: a block whose `-----BEGIN <type>-----` and `-----END <type>-----` markers have been collapsed onto a single line — for example from a copy-paste that stripped the newline between them — is not recognized as a PEM block at all, and the certificate or key it was meant to carry is silently dropped from the parser's view. Trailing non-PEM bytes at the end of the file have the same effect on the final block: when a shell prompt is accidentally captured into the file so the last line reads `-----END CERTIFICATE-----[user@host ~]$` instead of `-----END CERTIFICATE-----` alone, the terminating marker no longer matches and the loader rejects the input. Within a multi-block bundle, consecutive PEM blocks should be separated by exactly one blank line, and there must be no trailing blank line at end of file.
+
+## Resolution
+
+Reconstruct the Secret so that `tls.crt` holds the wildcard or SAN leaf certificate, then any intermediate CAs, then the root CA, in that order; `tls.key` must hold the matching private key in a recognizable `-----BEGIN ... PRIVATE KEY-----` block (for example `RSA PRIVATE KEY` for a PKCS#1 RSA key, or `PRIVATE KEY` for a PKCS#8 key). Each block's `-----BEGIN`/`-----END` markers must sit on their own lines, blocks must be separated by exactly one blank line, and the file must not have trailing bytes after the final `-----END CERTIFICATE-----`.
+
+Recreate the Secret in the ALB's namespace and point `spec.config.defaultSSLCert` at it. With the cleaned files in hand (`tls.crt` and `tls.key`):
+
+```bash
+kubectl -n cpaas-system create secret tls <secret-name> \
+  --cert=tls.crt --key=tls.key \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+The Secret carries `tls.crt` and `tls.key` of type `kubernetes.io/tls`; the ALB2 CR references it by `namespace/name` on `spec.config.defaultSSLCert` (for example `cpaas-system/<secret-name>`), the same reference shape verified on the live ALB instance running `alb2:v4.3.1` with `alb-nginx:v4.3.1`.
+
+## Diagnostic Steps
+
+Pull the current `tls.crt` out of the Secret and inspect its framing. The first line must be `-----BEGIN CERTIFICATE-----` and the last non-empty line must be `-----END CERTIFICATE-----` exactly, with no trailing prompt bytes; collapsed BEGIN/END markers on the same line are the most common defect:
+
+```bash
+kubectl -n cpaas-system get secret <secret-name> \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/tls.crt
+head -1 /tmp/tls.crt
+tail -1 /tmp/tls.crt
+grep -c '^-----BEGIN CERTIFICATE-----$' /tmp/tls.crt
+grep -c '^-----END CERTIFICATE-----$' /tmp/tls.crt
+```
+
+The two `grep -c` counts must be equal and must match the number of certificates in the bundle (leaf + intermediates + root); a leaf-only self-signed bundle has count 1, while a leaf plus one intermediate plus root has count 3. Consecutive blocks must be separated by exactly one blank line and there must be no trailing blank line at end of file.
+
+Verify the private-key block. The `tls.key` payload's first line must be a `-----BEGIN ... PRIVATE KEY-----` marker that ends in `PRIVATE KEY` — this is the exact substring the Go `crypto/tls` loader matches when locating the key block; a file containing only `CERTIFICATE` blocks and no `PRIVATE KEY` block in the key input is what surfaces as the PEM parser's "find PEM block with type ending in PRIVATE KEY" failure:
+
+```bash
+kubectl -n cpaas-system get secret <secret-name> \
+  -o jsonpath='{.data.tls\.key}' | base64 -d > /tmp/tls.key
+head -1 /tmp/tls.key
+tail -1 /tmp/tls.key
+```
+
+Once framing is clean and the `tls.key` carries a `PRIVATE KEY`-suffixed block matching the leaf certificate's key shape (RSA on the verified secret), recreate the Secret with `kubectl create secret tls --dry-run=client -o yaml | kubectl apply -f -` and confirm the ALB2 CR's `spec.config.defaultSSLCert` still resolves to `<namespace>/<secret-name>`.

--- a/docs/en/solutions/Ingress_wildcard_certificate_fails_to_load_PEM_ordering_and_bad_characters.md
+++ b/docs/en/solutions/Ingress_wildcard_certificate_fails_to_load_PEM_ordering_and_bad_characters.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Ingress wildcard certificate fails to load — PEM ordering and bad characters
 ## Issue
 
 Right after the cluster's default ingress certificate is replaced with a custom one, components that consume the new bundle start crashing on TLS load. The most visible symptom is the cluster's authentication pods (the OAuth server pods that terminate `*.apps.<cluster>` traffic) entering a `CrashLoopBackOff` with a fatal log line of the form:

--- a/docs/en/solutions/Ingress_wildcard_certificate_fails_to_load_PEM_ordering_and_bad_characters.md
+++ b/docs/en/solutions/Ingress_wildcard_certificate_fails_to_load_PEM_ordering_and_bad_characters.md
@@ -1,0 +1,109 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+Right after the cluster's default ingress certificate is replaced with a custom one, components that consume the new bundle start crashing on TLS load. The most visible symptom is the cluster's authentication pods (the OAuth server pods that terminate `*.apps.<cluster>` traffic) entering a `CrashLoopBackOff` with a fatal log line of the form:
+
+```text
+dynamic_serving_content.go: "Loaded a new cert/key pair"
+  name="serving-cert::/var/config/system/secrets/.../tls.crt::.../tls.key"
+cmd.go: failed to load SNI cert and key: tls: failed to find PEM block with
+  type ending in "PRIVATE KEY" in key input after skipping PEM blocks of the
+  following types: [CERTIFICATE CERTIFICATE]
+```
+
+Operators that depend on the same ingress identity (console, metrics proxies, console-down handlers) report the same `failed to find PEM block with type ending in "PRIVATE KEY"` underneath, because they all read from the same TLS Secret and the parser refuses the file before any cert is served.
+
+## Root Cause
+
+The Go TLS loader walks the file from the top and accepts whatever PEM block it sees. When the bundle for the wildcard listener is built incorrectly, the loader meets two `CERTIFICATE` blocks and never reaches a `PRIVATE KEY`, so it gives up. Three concrete malformations produce that error reliably:
+
+- The certificate chain is in the wrong order — a CA certificate sits ahead of the leaf, so the leaf is hidden after the loader has already consumed two `CERTIFICATE` blocks.
+- The PEM file is corrupted by stray characters: a shell prompt that was accidentally pasted into the buffer, `BEGIN CERTIFICATE` and `END CERTIFICATE` collapsed onto a single line, CRLF line endings, or a UTF-8 BOM at the top of the file.
+- Whitespace around the blocks is wrong — extra blank lines between blocks, missing newline before the next `-----BEGIN ...-----`, or a trailing blank line after the last block.
+
+In every case the file looks correct to the eye but fails the strict PEM grammar that Go's `pem.Decode` enforces.
+
+## Resolution
+
+Rebuild the ingress bundle so that it conforms to the loader's expectations, then replace the Secret in place. The bundle for `*.apps.<cluster>` must contain, in this exact order:
+
+1. The leaf wildcard certificate with the right SANs (at minimum `*.apps.<cluster>` and any apex names that share the listener).
+2. Each intermediate CA, leaf-to-root.
+3. The root CA last.
+
+The matching private key goes in `tls.key` and is **not** concatenated into `tls.crt`.
+
+Validate the bundle locally before applying:
+
+```bash
+# 1. The chain must verify against itself end-to-end.
+openssl verify -CAfile <(awk '/BEGIN/{n++} n>1' tls.crt) \
+              <(awk '/BEGIN/{n++} n==1' tls.crt)
+
+# 2. The leaf must list *.apps.<cluster> as a SAN.
+openssl x509 -in tls.crt -noout -text \
+  | grep -A1 'Subject Alternative Name'
+
+# 3. The cert and key must share a modulus.
+diff <(openssl x509 -in tls.crt -noout -modulus | openssl md5) \
+     <(openssl rsa  -in tls.key -noout -modulus | openssl md5)
+```
+
+If any step fails, regenerate the file and re-check before pushing it to the cluster.
+
+Then refresh the Secret. With the cluster's ingress controller wired to a Secret named `<wildcard-secret>` in the ingress namespace:
+
+```bash
+kubectl -n <ingress-ns> create secret tls <wildcard-secret> \
+  --cert=tls.crt --key=tls.key \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+The ingress controller hot-reloads on Secret update; the auth pods pick the new bundle up on their next watch, so deleting them is rarely needed. Wait one to two minutes, then confirm:
+
+```bash
+kubectl -n <auth-ns> get pod -l app=<auth-app-label>
+kubectl -n <auth-ns> logs <auth-pod> | tail -20
+```
+
+The `Loaded a new cert/key pair` line should now appear without a follow-up fatal.
+
+## Diagnostic Steps
+
+1. Confirm the failing Secret is the one feeding the ingress listener and not a stale copy:
+
+   ```bash
+   kubectl -n <ingress-ns> get secret <wildcard-secret> -o yaml \
+     | yq '.data."tls.crt"' | base64 -d | openssl x509 -noout -subject -issuer -dates
+   ```
+
+   The `Subject` should be the wildcard you intend to publish, and `notAfter` should be in the future.
+
+2. Pull the certificate file out of the Secret and recount the PEM blocks. The bundle must contain at least two blocks (leaf + at least one CA) for a chained wildcard:
+
+   ```bash
+   kubectl -n <ingress-ns> get secret <wildcard-secret> \
+     -o jsonpath='{.data.tls\.crt}' | base64 -d \
+     | grep -c 'BEGIN CERTIFICATE'
+   ```
+
+3. Inspect the raw bytes for the malformations called out above. `cat -A` exposes invisible characters; `file` flags BOM/CRLF:
+
+   ```bash
+   kubectl -n <ingress-ns> get secret <wildcard-secret> \
+     -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/check.crt
+   file /tmp/check.crt              # expect: 'ASCII text'
+   cat -A /tmp/check.crt | tail     # no '$' alone after the last END line
+   head -1 /tmp/check.crt | xxd | head -1   # no 'efbbbf' BOM bytes
+   ```
+
+4. Verify the order of the chain: `openssl crl2pkcs7 -nocrl -certfile tls.crt | openssl pkcs7 -print_certs -noout` lists the certificates in file order. The first entry must be the wildcard leaf; CAs must follow leaf-to-root.
+
+5. If the listener still rejects the file after the bundle is correct, check that the controller is reading from the namespace and Secret name you updated — a stale reference (typo in a CR field, or two ingress controllers competing) is a common red herring.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
