### PR TITLE
[configure] Pod CrashLoopBackOff with bind address already in use on ACP worker nodes

### DIFF
--- a/docs/en/solutions/Pod_CrashLoopBackOff_with_bind_address_already_in_use_on_ACP_worker_nodes.md
+++ b/docs/en/solutions/Pod_CrashLoopBackOff_with_bind_address_already_in_use_on_ACP_worker_nodes.md
@@ -1,0 +1,50 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Pod CrashLoopBackOff with bind address already in use on ACP worker nodes
+
+## Issue
+
+On ACP worker nodes running Kubernetes v1.34.5, a pod can enter `CrashLoopBackOff` when its container fails to acquire the TCP listening port it needs at startup, and the kubelet keeps restarting the container after each failed attempt. The kubelet emits `BackOff` events against the pod as the restart loop continues, which surface in `kubectl describe pod` output the same way as for any other repeated container failure.
+
+The container's own log stream typically ends with a `bind: address already in use` line written by the runtime when the application's `bind(2)` call is rejected. The application-level message immediately preceding that line is application-specific — for example `error received after stop sequence was engaged` or `failed to start metrics server: failed to create listener` — so it is not a reliable cross-application diagnostic on its own. The stable signal across applications is the trailing `bind: address already in use` substring in the container log.
+
+## Root Cause
+
+When a container's `bind(2)` fails this way the standard k8s-side surface is the kubelet's `BackOff` event against the failing container, with the underlying `bind: address already in use` socket-bind failure preserved in container logs. The generic POSIX/Linux meaning of `EADDRINUSE` is that another process attached to the same network namespace already holds the target port, so the new container's `bind(2)` cannot succeed. When the held port is exactly the one the new container needs, every restart attempt fails the same way and the pod stays in `CrashLoopBackOff` indefinitely; in practice the holder is often a host-side process or a third-party in-cluster agent (for example a security, monitoring, or audit agent that is not part of the ACP platform) that opened the port previously and has not released it across the pod restart.
+
+## Diagnostic Steps
+
+Confirm the pod is restarting in a loop and inspect the kubelet's `BackOff` events for the failing container, which appear in the `Events:` section of `kubectl describe pod` whenever the kubelet's restart loop is active:
+
+```bash
+kubectl -n <namespace> get pod <pod> -o wide
+kubectl -n <namespace> describe pod <pod>
+```
+
+Read the container's own log to pick up the bind error. The trailing `bind: address already in use` substring is the load-bearing signal; the line above it varies by application:
+
+```bash
+kubectl -n <namespace> logs <pod> -c <container>
+kubectl -n <namespace> logs <pod> -c <container> --previous
+```
+
+If the log shows the bind error, the cause is another process on the same network namespace already holding the target port. On the affected worker node, identify what is bound to that port (for example with `ss -ltnp` or `lsof -iTCP:<port> -sTCP:LISTEN` from a node debug session) to determine whether the holder is a host-side process or another in-cluster agent.
+
+## Resolution
+
+Stop the process or agent holding the port so the new container's `bind(2)` can succeed. When the holder is a third-party in-cluster agent (a security, monitoring, or audit agent not bundled with ACP) that has retained the port across the pod restart, disable or stop that agent on the affected node before restarting the workload.
+
+After the offending holder is stopped, recreate the affected pods so the kubelet starts fresh containers that can bind their ports and exit `CrashLoopBackOff`:
+
+```bash
+kubectl -n <namespace> delete pod <pod>
+```
+
+If the port remains held after the suspected holder is stopped — for example because an orphaned process on the worker still owns the socket — reboot the affected worker node to clear the orphaned port holders, after which the rescheduled pods can bind their ports normally.

--- a/docs/en/solutions/Pods_CrashLoopBackOff_with_address_already_in_use_caused_by_an_in_cluster_security_agent.md
+++ b/docs/en/solutions/Pods_CrashLoopBackOff_with_address_already_in_use_caused_by_an_in_cluster_security_agent.md
@@ -1,0 +1,119 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Pods CrashLoopBackOff with "address already in use" caused by an in-cluster security agent
+## Issue
+
+A handful of pods on the cluster — sometimes the same workload across many nodes, sometimes a mix — sit in `CrashLoopBackOff` and never get past startup. The container logs show a generic listener-bind failure, the wording differs by language and framework but always ends in the same kernel error:
+
+```text
+"msg":"error received after stop sequence was engaged",
+"error":"listen tcp :4343: bind: address already in use"
+```
+
+```text
+failed to start metrics server: failed to create listener:
+listen tcp :8080: bind: address already in use
+```
+
+The literal port number and the prefix vary; the part to anchor on is `bind: address already in use`. Restarting the pod, deleting the pod, draining and rescheduling it — none of these clear the symptom, because nothing the kubelet does releases whoever is holding the port on the host.
+
+## Root Cause
+
+The previous container instance, or a sidecar component injected by an in-cluster security agent (Twistlock / Prisma Cloud Defender is the common offender, but any agent that runs as a privileged DaemonSet and intercepts container processes can produce the same shape), is still holding the listening socket when the new container starts. The kernel refuses the second `bind(2)` and the new process exits, the kubelet restarts it, and the loop repeats indefinitely because the socket-holder is not part of the pod the kubelet is restarting and is therefore never reaped.
+
+This is not a bug in the workload. The hint that the workload itself is innocent is that the same port works on a node where the agent is absent, and the same image works in a different cluster where the agent is uninstalled.
+
+## Resolution
+
+Two paths, in this order:
+
+### Confirm an outside process is holding the port
+
+Open a node shell on the affected node and identify what owns the listening socket *outside* the pod's network namespace. The host network namespace is what most agents inject into — that is why the pod's own namespace looks empty when inspected from inside.
+
+```bash
+kubectl debug node/<node> -it --profile=sysadmin --image=<utility-image> \
+  -- bash
+ss -tlnp | grep ":<port>"
+# or:
+lsof -nPi :<port>
+```
+
+If the holder turns out to be a `defender`, `twistlock`, `prisma`, or any non-kubelet binary running on the host, the workload's bind failure is collateral.
+
+### Drop the agent's hold and let the workload bind
+
+The supported fix for this class of agent is to **disable the agent on the affected nodes**, restart the affected pods, and confirm the listener comes up. Three concrete remediations, ordered by intrusiveness:
+
+1. Stop the agent's enforcement on the affected nodes from its own console / CR — most enterprise agents have a "monitor only" toggle that releases the injected sockets without uninstalling.
+2. Cordon the node, scale the agent's DaemonSet down on the node (taint the node so the agent's tolerations no longer match, or set `nodeSelector` on the DaemonSet), then reschedule the workload pods. The kernel releases the port as soon as the agent's process exits.
+3. If the held socket persists after the agent is stopped, reboot the node — a kernel-side socket leak that the userspace exit did not clear is the only situation that requires this. Drain first.
+
+Once the workload pods come up `Running`, re-enable the agent on a single node and verify that the workload survives that node's agent enforcement before re-enabling cluster-wide. If the workload crashes again with the agent on, the agent's policy needs to be tuned (e.g. exclude the workload's namespace, or drop the port-interception rule for the workload's PodSpec).
+
+A long-term fix lives with the agent vendor, not with the cluster — open a case with whichever vendor ships the agent and attach the `ss`/`lsof` output and the affected workload's PodSpec.
+
+## Diagnostic Steps
+
+1. Confirm the loop is on the bind step and not on something else that happens to look similar (for example, a panic before bind, or a readiness probe killing the container at second 1):
+
+   ```bash
+   kubectl -n <ns> logs <pod> --previous --tail=100
+   kubectl -n <ns> describe pod <pod> | sed -n '/Events:/,$p'
+   ```
+
+   The `Last State: Terminated` reason should be `Error` (not `OOMKilled`) and the previous-instance log should end on `bind: address already in use`.
+
+2. Map the affected pods to nodes — the symptom is per-node, so the distribution tells you the blast radius:
+
+   ```bash
+   kubectl get pod -A -o wide \
+     --field-selector=status.phase!=Running,status.phase!=Succeeded \
+     | grep CrashLoop
+   ```
+
+3. On one of the affected nodes, identify the socket holder from the host network namespace:
+
+   ```bash
+   kubectl debug node/<node> -it --profile=sysadmin --image=<utility-image> \
+     -- bash -c '
+       ss -tlnp | grep -E ":<port>\b"
+       echo "---"
+       for ns in $(ls /var/run/netns 2>/dev/null); do
+         echo "ns=$ns"
+         ip netns exec "$ns" ss -tlnp 2>/dev/null | grep -E ":<port>\b"
+       done
+     '
+   ```
+
+   If the listener appears in the host namespace and **not** in any pod namespace, an out-of-pod process owns it.
+
+4. Map the holder PID back to a Kubernetes object:
+
+   ```bash
+   pid=<from ss -tlnp>
+   ls -l /proc/$pid/cgroup
+   cat /proc/$pid/cgroup
+   ```
+
+   The cgroup path resolves to a kubelet pod path or a host systemd unit. A host systemd unit (e.g. `/system.slice/twistlock-defender.service`) confirms the agent is the holder; a `kubepods.slice/...` path means a different pod owns the port and the conflict is between two workloads — a different remediation entirely.
+
+5. After the agent is stopped, verify the port is free *before* rolling the workload pods so that the next bind-attempt is the test:
+
+   ```bash
+   ss -tlnp | grep ":<port>" || echo "port is free"
+   kubectl -n <ns> rollout restart deploy/<workload>
+   ```
+
+6. If the port stays held even after the agent's process is gone, capture the holding socket's state for the agent vendor — this is the artifact the case will turn on:
+
+   ```bash
+   ss -tlnpe state listening "( sport = :<port> )"
+   ```


### PR DESCRIPTION
新增一篇 ACP KB 文章。
