### PR TITLE
[observability] Tempo-managed pods stream expired-cert TLS errors after operator-issued cert expiry on ACP

### DIFF
--- a/docs/en/solutions/Tempo_managed_pods_stream_expired_cert_TLS_errors_after_operator_issued_cert_expiry_on_ACP.md
+++ b/docs/en/solutions/Tempo_managed_pods_stream_expired_cert_TLS_errors_after_operator_issued_cert_expiry_on_ACP.md
@@ -1,0 +1,42 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Tempo-managed pods stream expired-cert TLS errors after operator-issued cert expiry on ACP
+
+## Issue
+
+On Alauda Container Platform (kubernetes v1.34.5, ACP install bundle `bundle-versions-v4.3.0`), tracing components deployed by a Tempo-operator-managed stack can stream continuous TLS handshake failures once the operator-issued serving certificates carried in their mounted `kubernetes.io/tls` Secrets pass their `not-after` timestamp. A Kubernetes TLS Secret of this type embeds an x509 certificate in its base64-encoded `tls.crt` field whose `not-before` / `not-after` validity window is readable directly from the Secret on ACP, with the same upstream type and PEM shape. When the workload inside such a Pod presents that certificate during a TLS handshake after `not-after` has passed, the peer's golang TLS stack rejects the handshake and surfaces the standard `x509: certificate has expired or is not yet valid` error string emitted by the `crypto/tls` / `crypto/x509` standard library — unchanged on any distribution.
+
+## Root Cause
+
+Long-running server processes that read their serving certificate from a mounted Secret at process start do not, by themselves, observe in-place rotation of that Secret — they keep presenting the certificate material they originally loaded. On Pod re-creation, however, the kubelet re-reads the referenced Secret from the API server at volume-mount time, so a freshly created Pod loads the current (rotated) `tls.crt` content from the underlying Secret object. The expired-handshake error itself remains the stdlib golang `x509: certificate has expired or is not yet valid` form, so it survives unchanged when the same condition occurs on ACP.
+
+## Resolution
+
+Trigger a Pod-level restart of the affected tracing components so that the kubelet re-mounts the referenced Secret on the recreated Pods and they load the rotated certificate material from the API server at mount time. Deleting the affected Pods via a label selector that targets the operator-managed workloads lets the owning controllers recreate them, after which the new Pods read the current `tls.crt` from the API server during their volume mount and the handshake errors against the rotated certificate stop appearing.
+
+## Diagnostic Steps
+
+Enumerate the candidate TLS secrets in the namespace where the tracing stack is deployed — `kubernetes.io/tls`-typed Secrets follow the standard upstream shape on ACP, so a vanilla `kubectl get secret` listing surfaces them and a simple `grep tls` narrows the list:
+
+```bash
+kubectl get secret -n <tempo-namespace> | grep tls
+```
+
+For each candidate, dump the Secret as YAML and read its embedded validity window — `not-before` / `not-after` are present on the encoded certificate and are accessible through the same `kubectl get secret -o yaml` pipeline on ACP because the Secret type and PEM shape are unchanged from upstream Kubernetes:
+
+```bash
+kubectl get secret -n <tempo-namespace> <secret-name> -o yaml
+```
+
+Decode the `tls.crt` field with `base64 -d | openssl x509 -noout -dates` when the validity window is not visible directly in the YAML; the dates read from the certificate confirm whether the Secret currently mounted into the Tempo-managed Pods has passed its expiry. Cross-check the affected Pod's logs for the standard golang TLS error string — the `x509: certificate has expired or is not yet valid` form is what the receiving peer prints once the condition is in effect:
+
+```bash
+kubectl logs -n <tempo-namespace> <pod-name> | grep -E 'expired|has expired'
+```

--- a/docs/en/solutions/Tempo_pods_stream_expired_certificate_TLS_errors_despite_valid_secrets.md
+++ b/docs/en/solutions/Tempo_pods_stream_expired_certificate_TLS_errors_despite_valid_secrets.md
@@ -1,0 +1,122 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A `TempoStack` deployed by the Tempo Operator stops serving traces in the platform's tracing UI. Symptoms:
+
+- The tracing console shows `remote error: tls: expired certificate` and no traces render.
+- The Tempo gateway pod logs the same expiry against the upstream proxy:
+
+  ```text
+  level=warn name=observatorium ts=... caller=reverseproxy.go:675
+    msg="http: proxy error: remote error: tls: expired certificate"
+  ```
+
+- The Tempo distributor / query-frontend / querier pods log the TLS handshake error from the gateway side:
+
+  ```text
+  http: TLS handshake error from 10.0.0.1:47088:
+    tls: failed to verify certificate: x509: certificate has expired or is not yet valid:
+    current time 2025-08-29T13:04:41Z is after 2025-08-29T12:35:31Z
+  ```
+
+- Yet inspecting the certificate `Secret` objects in the `TempoStack` namespace shows valid `not-after` timestamps well in the future. The certificates on disk are not expired; only the *running* pods believe they are.
+
+## Root Cause
+
+The Tempo Operator rotates the internal TLS material that secures the gateway / distributor / querier mesh by writing fresh certificates into Secrets. The pods are mounted read-only and reload the material from the Secret without restarting — but in the affected Operator versions, the in-process certificate cache holds a stale copy across the rotation. Running pods continue to present (and verify against) the old certificate, while the Secret on disk already holds a valid replacement. A restart of the affected pods is the only path that flushes the in-memory copy and lets the gateway pick up the rotated material.
+
+This is an upstream-tracked Tempo Operator regression. Until the fixed Operator build lands, a manual restart after every rotation is required.
+
+## Resolution
+
+Restart the pods that the Tempo Operator manages in the affected `TempoStack`. The Operator owns them via labels (`app.kubernetes.io/managed-by=tempo-operator`); deleting the pods is safe — the underlying Deployments / StatefulSets recreate them and they pick up the fresh Secrets:
+
+```bash
+TEMPO_NS=<tempostack-namespace>
+kubectl -n "$TEMPO_NS" delete pod -l app.kubernetes.io/managed-by=tempo-operator
+```
+
+Watch the new pods come up and confirm the gateway log no longer carries the expired-certificate line:
+
+```bash
+kubectl -n "$TEMPO_NS" rollout status deployment -l app.kubernetes.io/managed-by=tempo-operator
+kubectl -n "$TEMPO_NS" logs -l app.kubernetes.io/component=gateway --tail=50 | grep -iE 'expired|tls'
+```
+
+After the restart, traces should render again in the tracing UI. If the same error reappears at the next rotation cycle (typical: rotation cadence is days / weeks depending on the Operator's certificate-lifetime configuration), repeat the restart — or stage a rolling restart on a CronJob until the Operator-side fix is rolled out.
+
+### Workaround that survives the next rotation
+
+Schedule a periodic rolling restart of the Tempo deployments slightly more frequent than the certificate lifetime. A CronJob that runs `kubectl rollout restart` on the Tempo workloads avoids the manual response after each rotation:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tempo-rotation-bounce
+  namespace: <tempostack-namespace>
+spec:
+  schedule: "0 3 */3 * *"               # every 3 days at 03:00; tune to your rotation
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: tempo-bouncer
+          restartPolicy: OnFailure
+          containers:
+            - name: kubectl
+              image: bitnami/kubectl:latest
+              command:
+                - sh
+                - -c
+                - |
+                  kubectl -n <tempostack-namespace> rollout restart \
+                    deploy -l app.kubernetes.io/managed-by=tempo-operator
+                  kubectl -n <tempostack-namespace> rollout restart \
+                    statefulset -l app.kubernetes.io/managed-by=tempo-operator
+```
+
+This is a workaround, not a fix — remove the CronJob once the cluster runs a Tempo Operator build with the cache-flush fix.
+
+## Diagnostic Steps
+
+1. Confirm the Secret-side certificates are themselves valid — that is, the failure is the cache, not real expiry:
+
+   ```bash
+   TEMPO_NS=<tempostack-namespace>
+   for s in $(kubectl -n "$TEMPO_NS" get secret -o name | grep tls); do
+     echo "=== $s ==="
+     kubectl -n "$TEMPO_NS" get "$s" -o jsonpath='{.data.tls\.crt}' \
+       | base64 -d \
+       | openssl x509 -noout -dates -subject
+   done
+   ```
+
+   `notAfter` in the future on every Secret while the running pods still log expiry confirms the in-memory cache theory.
+
+2. Pull the gateway and querier logs, scope to TLS errors, and capture the timestamps:
+
+   ```bash
+   kubectl -n "$TEMPO_NS" logs -l app.kubernetes.io/component=gateway --tail=200 \
+     | grep -iE 'tls|expired'
+   kubectl -n "$TEMPO_NS" logs -l app.kubernetes.io/component=tempo --tail=200 \
+     | grep -iE 'tls|certificate has expired'
+   ```
+
+3. After restarting, confirm the new pods serve a non-expired chain. From any pod that talks to the gateway:
+
+   ```bash
+   kubectl -n "$TEMPO_NS" exec -it <client-pod> -- bash -c '
+     openssl s_client -connect tempo-gateway:8443 -showcerts </dev/null 2>/dev/null \
+       | openssl x509 -noout -dates -subject
+   '
+   ```
+
+   The `notAfter` shown by `s_client` should match the Secret's `notAfter`; before the restart, it would have been the older, pre-rotation date.

--- a/docs/en/solutions/Tempo_pods_stream_expired_certificate_TLS_errors_despite_valid_secrets.md
+++ b/docs/en/solutions/Tempo_pods_stream_expired_certificate_TLS_errors_despite_valid_secrets.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Tempo pods stream "expired certificate" TLS errors despite valid secrets
 ## Issue
 
 A `TempoStack` deployed by the Tempo Operator stops serving traces in the platform's tracing UI. Symptoms:


### PR DESCRIPTION
新增一篇 ACP KB 文章。
