### PR TITLE
[networking] ACP ALB pods OOMKilled with high restart counts — remove memory limits on global-alb2

### DIFF
--- a/docs/en/solutions/ACP_ALB_pods_OOMKilled_with_high_restart_counts_remove_memory_limits_on_global_alb2.md
+++ b/docs/en/solutions/ACP_ALB_pods_OOMKilled_with_high_restart_counts_remove_memory_limits_on_global_alb2.md
@@ -1,0 +1,63 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# ACP ALB pods OOMKilled with high restart counts — remove memory limits on global-alb2
+
+## Issue
+
+On Alauda Container Platform the ingress data-plane is provided by the ALB plugin (CRD `alaudaloadbalancer2.crd.alauda.io`, short name `alb2`), deployed as the `global-alb2` Deployment in the `cpaas-system` namespace. Each `global-alb2-*` pod runs two containers — `nginx` (image `registry.alauda.cn:60080/acp/alb-nginx:v4.3.1`) and `alb2` (image `registry.alauda.cn:60080/acp/alb2:v4.3.1`) — and both ship with a `resources.limits.memory` of `2Gi` by default. If the working set of either container approaches or crosses its cgroup memory limit, the standard OOMKilled mechanism applies: the kernel OOM-killer terminates the container with SIGKILL and the kubelet restarts it; the symptom that reaches the operator is `global-alb2-*` pods with elevated `restartCount` values.
+
+## Root Cause
+
+The two ALB containers are bounded by `spec.template.spec.containers[*].resources.limits.memory=2Gi` on the `global-alb2` Deployment, with matching `resources.requests` of `cpu=50m, memory=128Mi`; the `nginx` container additionally carries `cpu=2` and the `alb2` container `cpu=200m` on its limits block. When a container's resident set grows past its memory limit, the Linux cgroup memory controller invokes the OOM-killer, which sends SIGKILL — the container exits with code 137 (128 + 9) and is restarted in place by the kubelet, incrementing `containerStatuses[*].restartCount` on the pod. Once the limit is removed, the container is bounded only by node capacity and its `requests` floor, so the standard OOMKill mechanism no longer fires on the 2Gi headroom and any associated restart loop stops.
+
+## Resolution
+
+Remove the `resources.limits` block from both containers of the `global-alb2` Deployment in `cpaas-system`. The `spec.template.spec.containers[*].resources` field uses the standard apps/v1 shape with `limits` and `requests` subkeys for `cpu` and `memory`, so a JSON-Patch `remove` op on the `limits` path is sufficient and accepted by the apiserver.
+
+Patch container index 0 (`nginx`):
+
+```bash
+kubectl patch deployment global-alb2 -n cpaas-system \
+  --type=json \
+  -p='[{"op":"remove","path":"/spec/template/spec/containers/0/resources/limits"}]'
+```
+
+Patch container index 1 (`alb2`) the same way:
+
+```bash
+kubectl patch deployment global-alb2 -n cpaas-system \
+  --type=json \
+  -p='[{"op":"remove","path":"/spec/template/spec/containers/1/resources/limits"}]'
+```
+
+After the patch lands, the Deployment rolls out new pods with no `resources.limits` on either container; the `requests` remain in place so the scheduler still reserves the floor on each node. Validate that the new pods stay up and `restartCount` no longer climbs.
+
+## Diagnostic Steps
+
+List the ALB pods and watch `RESTARTS` for the `global-alb2-*` set. The pod's `containerStatuses[*].restartCount` field is exposed directly by `kubectl get pods` and increments each time the kubelet restarts a container in place after termination.
+
+```bash
+kubectl get pods -n cpaas-system -l service_name=alb2-global-alb2
+```
+
+Inspect a single pod's last-termination state. A container terminated by the cgroup OOM-killer shows `Last State: Terminated` with `Reason: OOMKilled` and an exit code of 137 in `kubectl describe pod`; `Reason: OOMKilled` is the kubelet label set specifically when the cgroup memory limit was hit, so its presence is the authoritative confirmation that the restart loop is memory-limit-driven rather than a generic crash.
+
+```bash
+kubectl describe pod -n cpaas-system <global-alb2-pod-name>
+```
+
+Read the current `resources` blocks on the Deployment to confirm what is configured before patching. The `nginx` container's limits should show `cpu=2, memory=2Gi` and the `alb2` container's limits `cpu=200m, memory=2Gi`, with both requests at `cpu=50m, memory=128Mi` on the v4.3.1 ALB plugin.
+
+```bash
+kubectl get deployment global-alb2 -n cpaas-system -o yaml \
+  | grep -A4 resources:
+```
+
+If `kubectl describe` shows a generic `Reason: Error` and exit code 137 rather than `Reason: OOMKilled`, the container was killed by SIGKILL from another source (for example, a node-level eviction or an external signal) — only the kubelet's `OOMKilled` reason string conclusively attributes the termination to the cgroup memory limit, so treat the two surfaces separately when triaging.

--- a/docs/en/solutions/ALB_HAProxy_router_pods_OOMKilled_with_high_restart_count_remove_the_deployment_limits.md
+++ b/docs/en/solutions/ALB_HAProxy_router_pods_OOMKilled_with_high_restart_count_remove_the_deployment_limits.md
@@ -1,0 +1,126 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+The platform's edge ingress data-plane pods — the HAProxy-based ALB router pods that serve cluster Ingress traffic — restart frequently with `OOMKilled` as the termination reason. Symptoms:
+
+- The router DaemonSet / Deployment shows accumulated restart counts in the tens or hundreds over a few days:
+
+  ```text
+  NAME                              READY   STATUS    RESTARTS         AGE
+  router-default-6dxxxf9-4xx6       2/2     Running   69 (9h ago)      13d
+  router-default-6dxxx9-7pxx2       2/2     Running   25 (9h ago)      15d
+  router-default-6xxxx9-8xxxb       2/2     Running   20 (9h ago)      13d
+  router-default-6dxxxf9-cxxz6      2/2     Running   27 (9h ago)      15d
+  ```
+
+- `kubectl describe pod` on a restarting router shows the pattern of OOM-driven termination:
+
+  ```text
+  Containers:
+    router:
+      State:        Running
+      Last State:   Terminated
+        Reason:     OOMKilled
+  ```
+
+- Ingress traffic disrupts during the OOMKill / restart window — connections drop, health probes flap, and downstream services see intermittent 503s clustered around the restart.
+
+## Root Cause
+
+The router Deployment ships with both `requests` and `limits` set on its container — a typical spec carries `limits.cpu: "2"` and `limits.memory: "4Gi"`. HAProxy's working-set is dominated by:
+
+- The number of concurrent connections (each one keeps a per-connection buffer).
+- The size of the resolved configuration (every Ingress rule is compiled into the running config).
+- The reload behaviour — during a config reload, HAProxy briefly holds the old and the new process simultaneously, which can spike memory by ~2x.
+
+On clusters with many Ingress rules and bursty traffic, the steady-state working set sits well under the limit, but the reload spike or a connection burst pushes the cgroup over the limit and the kernel OOMKills the container. The DaemonSet restarts it; cycle repeats.
+
+The container's `requests` reserve resources for scheduling but do not constrain the runtime. The `limits` are the cgroup ceiling that triggers OOMKill — and on a router pod, that ceiling is what hurts. Removing the limits (while keeping `requests` so the scheduler still places the pod sensibly) lets HAProxy use the headroom that is actually available on the node, eliminating the reload-spike OOMKill.
+
+## Resolution
+
+Patch the router Deployment to remove the `resources.limits` block. Keep `requests` so the scheduler still respects the workload's footprint. The patch shape, applied to whichever namespace the cluster's ALB / router controller manages:
+
+```bash
+ALB_NS=<alb-or-ingress-namespace>
+kubectl -n "$ALB_NS" patch deployment router-default --type=json \
+  -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/resources/limits"}]'
+```
+
+If the router runs as a DaemonSet, the same patch shape applies — change `deployment` to `daemonset`. If the router has multiple containers (HAProxy + a metrics sidecar), confirm container index 0 is the HAProxy one before applying:
+
+```bash
+kubectl -n "$ALB_NS" get deployment router-default \
+  -o jsonpath='{.spec.template.spec.containers[*].name}'
+```
+
+After the patch:
+
+```bash
+kubectl -n "$ALB_NS" rollout status deployment router-default
+kubectl -n "$ALB_NS" get pod -l app.kubernetes.io/name=router
+```
+
+Restart counts should stabilise; new OOMKill events should stop appearing. Watch over a representative window (24h+) before declaring it fixed — config reloads are bursty, and the previous pattern may take a day to fully not-recur.
+
+### Right-sizing instead of removing the limits
+
+When the cluster runs strict resource governance (every workload must declare a limit), increase the limits rather than removing them. Pick a value with at least 2x headroom over the steady-state working set so the reload spike fits inside it:
+
+```yaml
+resources:
+  requests:
+    cpu: "1"
+    memory: "2Gi"
+  limits:
+    cpu: "4"
+    memory: "8Gi"
+```
+
+The exact numbers depend on the cluster's Ingress count and traffic shape. Use the `process_resident_memory_bytes` HAProxy metric as the input to right-sizing:
+
+```bash
+# From a Prometheus that scrapes the router:
+process_resident_memory_bytes{job="router"}
+```
+
+Take the maximum over a 7-day window, double it, round up to a YAML-friendly value — that is the floor of a safe `limits.memory`.
+
+## Diagnostic Steps
+
+1. Confirm the router's recent terminations are OOM-driven, not crashes:
+
+   ```bash
+   ALB_NS=<alb-or-ingress-namespace>
+   kubectl -n "$ALB_NS" get pod -l app.kubernetes.io/name=router \
+     -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[?(@.name=="router")].lastState.terminated.reason}{"\n"}{end}'
+   ```
+
+2. Inspect the deployment's current resources block to confirm a limit is in fact set:
+
+   ```bash
+   kubectl -n "$ALB_NS" get deployment router-default \
+     -o jsonpath='{.spec.template.spec.containers[?(@.name=="router")].resources}' | jq
+   ```
+
+3. Look at the OOM event from the kernel side on the affected node — it captures the cgroup the OOM-killer fired on and the RSS at the moment of kill:
+
+   ```bash
+   kubectl debug node/<node> -it --profile=sysadmin --image=<utility-image> \
+     -- chroot /host dmesg -T | grep -iE 'oom|killed process' | tail -30
+   ```
+
+4. After the patch, watch HAProxy's resident memory to confirm the working set fits within whatever the new ceiling is (or, if you removed the limit, that it stabilises rather than growing without bound):
+
+   ```text
+   process_resident_memory_bytes{job="router"}
+   ```
+
+   A stable value over 24h with no further `OOMKilled` events is the success signal.

--- a/docs/en/solutions/ALB_HAProxy_router_pods_OOMKilled_with_high_restart_count_remove_the_deployment_limits.md
+++ b/docs/en/solutions/ALB_HAProxy_router_pods_OOMKilled_with_high_restart_count_remove_the_deployment_limits.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# ALB / HAProxy router pods OOMKilled with high restart count — remove the deployment limits
 ## Issue
 
 The platform's edge ingress data-plane pods — the HAProxy-based ALB router pods that serve cluster Ingress traffic — restart frequently with `OOMKilled` as the termination reason. Symptoms:


### PR DESCRIPTION
新增一篇 ACP KB 文章。
