### PR TITLE
[virtualization] VM persistent-state PVC for vTPM/EFI stays on source storage after storage migration

### DIFF
--- a/docs/en/solutions/VM_persistent_state_PVC_for_vTPMEFI_stays_on_source_storage_after_storage_migration.md
+++ b/docs/en/solutions/VM_persistent_state_PVC_for_vTPMEFI_stays_on_source_storage_after_storage_migration.md
@@ -1,0 +1,49 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# VM persistent-state PVC for vTPM/EFI stays on source storage after storage migration
+
+## Issue
+
+On Alauda Container Platform KubeVirt virtualization (HCO operator 1.17.0, KubeVirt v1.7.0-alauda.2, namespace `kubevirt`), a VirtualMachine that enables persistent virtual TPM or persistent EFI/NVRAM gets a small dedicated PersistentVolumeClaim that backs that device state. When the VM's storage is migrated from one backend to another, the VM's main disk PVCs are moved to the new storage class. The small `persistent-state-for-<vm>` PVC, however, remains on the source storage class and is not moved together with the main disks.
+
+## Root Cause
+
+KubeVirt creates the `persistent-state-for-<vm>` PVC to hold a VirtualMachine's vTPM or EFI/NVRAM state, and it does so only when the VM opts in — both `devices.tpm.persistent` and `firmware.bootloader.efi.persistent` default to `false`, so the PVC exists only for VMs that turn on persistent TPM or persistent EFI. The storage class of that state PVC is not derived from the storage class of the VM's other disks. Instead it is governed by a single cluster-wide field, `spec.vmStateStorageClass` on the `hyperconvergeds.hco.kubevirt.io` (group `hco.kubevirt.io/v1beta1`) singleton, described as the storage class used for the PVCs created to preserve VM state such as TPM.
+
+Because that field is a global string on the cluster-wide HyperConverged CR rather than a per-VM setting, a per-VM storage migration that moves a VM's main disks has no scope over the state PVC, leaving it on the source storage class. ACP ships KubeVirt-native VM storage migration through the `virtualmachinestoragemigrations` API (group `migrations.kubevirt.io/v1alpha1`), reconciled by the `migcontroller-kubevirt-hyperconverged` controller running in the `kubevirt` namespace; a migration plan targets a list of virtual machines and migrates their disks, and it carries no field for the cluster-wide VM-state PVC.
+
+## Resolution
+
+There is no direct way to migrate an existing `persistent-state-for-<vm>` PVC for a single VM — the storage-migration plan scope covers main disks, not the state PVC. Changing `spec.vmStateStorageClass` is a cluster-global change that affects all VMs and does not migrate existing persistent-state PVCs.
+
+To place future VM-state PVCs on a chosen storage class, set `spec.vmStateStorageClass` on the HyperConverged singleton in the `kubevirt` namespace. Newly created VMs that enable persistent TPM or persistent EFI then get their persistent-state PVC on that storage class:
+
+```bash
+kubectl patch hyperconverged -n kubevirt kubevirt-hyperconverged \
+ --type merge \
+ -p '{"spec":{"vmStateStorageClass":"<target-storage-class>"}}'
+```
+
+This setting governs only PVCs created after the change; PVCs that already exist are left in place on their current storage class. For a VM whose state PVC must end up on a different backend, recreate the VM's persistent-state PVC under the desired storage class rather than expecting the disk migration to move it.
+
+## Diagnostic Steps
+
+List the VM's PVCs and compare their storage classes after a storage migration. The main disk PVCs appear on the new storage class while the `persistent-state-for-<vm>` PVC remains on the old storage class:
+
+```bash
+kubectl get pvc -n <namespace>
+```
+
+Confirm the cluster-wide setting that governs new VM-state PVCs by reading the HyperConverged singleton; an empty value means new VM-state PVCs fall back to the cluster default storage class:
+
+```bash
+kubectl get hyperconverged -n kubevirt kubevirt-hyperconverged \
+ -o jsonpath='{.spec.vmStateStorageClass}'
+```

--- a/docs/en/solutions/vTPMEFI_persistent_state_PVC_stays_on_the_source_storage_during_VM_storage_migration.md
+++ b/docs/en/solutions/vTPMEFI_persistent_state_PVC_stays_on_the_source_storage_during_VM_storage_migration.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# vTPM/EFI persistent-state PVC stays on the source storage during VM storage migration
 ## Issue
 
 A VM is migrated from one storage backend to another using the storage-migration flow. The main disks (root, data) move to the new StorageClass as expected, but a small (~10 MiB) PVC named like `persistent-state-for-<vm>` is left behind on the source storage. The migration reports success even though that one volume did not move.

--- a/docs/en/solutions/vTPMEFI_persistent_state_PVC_stays_on_the_source_storage_during_VM_storage_migration.md
+++ b/docs/en/solutions/vTPMEFI_persistent_state_PVC_stays_on_the_source_storage_during_VM_storage_migration.md
@@ -1,0 +1,92 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A VM is migrated from one storage backend to another using the storage-migration flow. The main disks (root, data) move to the new StorageClass as expected, but a small (~10 MiB) PVC named like `persistent-state-for-<vm>` is left behind on the source storage. The migration reports success even though that one volume did not move.
+
+`kubectl get pvc -n <ns>` shows the main disks bound on the new StorageClass and the `persistent-state-for-<vm>` PVC still bound on the old one.
+
+## Root Cause
+
+`persistent-state-for-<vm>` is the PVC the virtualization stack creates automatically when a VM has a persistent vTPM device or persistent EFI/NVRAM. Its job is to hold the small amount of state that has to survive across reboots — vTPM key blobs, NVRAM variables — separately from the OS disk.
+
+The StorageClass for that PVC is **not** taken from the VM's other disks. It is taken from a single cluster-wide field, `vmStateStorageClass`, on the cluster-level virtualization configuration CR. Because the StorageClass is selected globally and not from the VM spec, the storage-migration controller has nothing per-VM to rewrite — the PVC's StorageClass is, from its point of view, an unrelated cluster setting. So it migrates everything that *is* per-VM and leaves `persistent-state-for-*` where it was.
+
+This is by design today; per-VM migration of vTPM/EFI state is tracked as a future enhancement.
+
+## Resolution
+
+There is no per-VM migration path for the persistent-state PVC at the moment. Pick the workaround that matches the goal.
+
+### Goal: every *new* VM lands its persistent state on the new StorageClass
+
+Update the cluster virtualization CR so future VMs use the new class. Find the CR (its exact kind/name depends on which virtualization operator is installed; the field name is the same):
+
+```bash
+kubectl get hyperconverged -A
+# or:
+kubectl get kubevirt -A
+```
+
+Then patch `vmStateStorageClass`:
+
+```bash
+kubectl -n <virt-namespace> patch <kind>/<name> --type=merge -p '
+spec:
+  vmStateStorageClass: <new-storage-class>
+'
+```
+
+After the patch, every newly-created VM that enables persistent vTPM or persistent EFI will provision its `persistent-state-for-<vm>` PVC on `<new-storage-class>`. Existing PVCs are not touched.
+
+### Goal: an *existing* VM's persistent state ends up on the new StorageClass
+
+Two-step migration — disks first, then a compute-side migration that recreates the VM:
+
+1. Run the storage migration of the VM's data disks to the new StorageClass as usual.
+2. After the global `vmStateStorageClass` has been flipped, recreate the VM (delete and re-add via the same VirtualMachine manifest, or rebuild the VM from a snapshot/template). On re-creation the persistent-state PVC is provisioned fresh against the new `vmStateStorageClass`. The vTPM blob/NVRAM is regenerated; treat this as a TPM ownership change for any guest that depends on TPM-sealed secrets (BitLocker keys, sealed credentials), and have the recovery key handy.
+
+If the guest cannot tolerate a TPM/NVRAM reset, leave the persistent-state PVC on the source storage until the per-VM migration capability is shipped — the small footprint (10 MiB per VM) generally does not block decommissioning the rest of the source pool.
+
+## Diagnostic Steps
+
+1. List the PVCs bound to the migrated VM and check their `spec.storageClassName`:
+
+   ```bash
+   kubectl get pvc -n <ns> -l kubevirt.io/created-by=<vm-uid> \
+     -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,SIZE:.status.capacity.storage
+   ```
+
+   The expected output looks like:
+
+   ```text
+   NAME                                  SC          SIZE
+   <vm>-rootdisk                         new-class   60Gi
+   <vm>-datadisk                         new-class   100Gi
+   persistent-state-for-<vm>             old-class   10Mi
+   ```
+
+2. Confirm that VM has a persistent vTPM or persistent EFI device — that is the trigger that creates the persistent-state PVC:
+
+   ```bash
+   kubectl get vm <vm> -n <ns> -o yaml \
+     | yq '.spec.template.spec.domain.devices, .spec.template.spec.domain.firmware'
+   ```
+
+   Look for `tpm: { persistent: true }` or `firmware.bootloader.efi.persistent: true`.
+
+3. Read the current cluster-wide `vmStateStorageClass`:
+
+   ```bash
+   kubectl get <kind>/<name> -n <virt-namespace> -o yaml | yq '.spec.vmStateStorageClass'
+   ```
+
+   That value is the StorageClass any *new* persistent-state PVC will use.
+
+4. After flipping `vmStateStorageClass`, create a throw-away test VM with a persistent vTPM and verify its `persistent-state-for-*` PVC binds on the new class — that proves the global change took effect before you start delete/recreate cycles on production VMs.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
