### PR TITLE
[devops] ResolutionRequest reconciles every ten hours and why that is harmless

### DIFF
--- a/docs/en/solutions/ResolutionRequest_reconciles_every_ten_hours_and_why_that_is_harmless.md
+++ b/docs/en/solutions/ResolutionRequest_reconciles_every_ten_hours_and_why_that_is_harmless.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# ResolutionRequest reconciles every ten hours — and why that is harmless
 ## Overview
 
 A long-lived PipelineRun has a `ResolutionRequest` resource attached — that is the object the remote resolver creates to resolve a Pipeline reference (a git URL, a bundle, a hub reference) into the actual Pipeline definition. Operators sometimes notice the resolver pod waking up against very old `ResolutionRequest` objects on a regular cadence, and ask whether that interval can be raised (for example to 24 hours) to cut log noise.

--- a/docs/en/solutions/ResolutionRequest_reconciles_every_ten_hours_and_why_that_is_harmless.md
+++ b/docs/en/solutions/ResolutionRequest_reconciles_every_ten_hours_and_why_that_is_harmless.md
@@ -1,0 +1,80 @@
+---
+kind:
+   - Information
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Overview
+
+A long-lived PipelineRun has a `ResolutionRequest` resource attached — that is the object the remote resolver creates to resolve a Pipeline reference (a git URL, a bundle, a hub reference) into the actual Pipeline definition. Operators sometimes notice the resolver pod waking up against very old `ResolutionRequest` objects on a regular cadence, and ask whether that interval can be raised (for example to 24 hours) to cut log noise.
+
+This article explains why the resolver re-reconciles old objects, why the interval is not user-tunable like the Pipelines controller's `default-resync-period`, and why the answer in practice is "leave it alone".
+
+## The behaviour
+
+The ResolutionRequest reconciler runs inside each remote resolver pod (git, hub, bundles, cluster, etc., shipped together with the Pipelines runtime). Like every Knative-style controller it sets a *resync period* — a wall-clock interval after which the controller re-walks all objects of its kind even if nothing has changed. For the resolver pods that period is fixed at the framework default (around ten hours) and is **not** exposed as a flag the way the Pipelines controller's resync interval is. Setting it to 24 hours from outside is therefore not possible without modifying the resolver image.
+
+The wake-up is what shows up in operator monitoring: every ten hours, the resolver iterates its existing `ResolutionRequest` objects — including ones from PipelineRuns that finished days or weeks ago.
+
+## Why the resync is a NO-OP for completed requests
+
+The reconciler short-circuits as the very first thing it does. The shape of the entry point in the resolver is:
+
+```go
+// ReconcileKind processes updates to ResolutionRequests, sets status
+// fields on it, and returns any errors experienced along the way.
+func (r *Reconciler) ReconcileKind(
+        ctx context.Context, rr *v1beta1.ResolutionRequest,
+) reconciler.Event {
+    if rr == nil {
+        return nil
+    }
+    if rr.IsDone() {
+        return nil
+    }
+    // ...real work only happens for in-flight requests...
+}
+```
+
+`IsDone()` is true once the request has either resolved successfully or recorded a terminal failure. Every old `ResolutionRequest` from a finished run satisfies that condition. So when the ten-hour resync fires:
+
+- A no-op return for every completed request.
+- No git fetch, no hub call, no bundle pull. No external traffic, no rate-limit pressure.
+- A handful of CPU cycles per object on the resolver pod and an entry in its activity log.
+
+The only `ResolutionRequest` objects that do real work in a resync are the ones whose original reconcile *missed* — never reached `Done` because the controller died, the pod restarted, or a transient API error left the request unfinished. The resync is precisely the failsafe that closes those gaps.
+
+## What this means in practice
+
+- There is no need to lower the cadence to 24 hours. The cost of the ten-hour pass is dominated by the in-flight requests, of which there are usually zero or close to zero on a steady cluster.
+- Log noise from the resolver waking up can be filtered with a log-collector rule rather than by changing the controller behaviour. The events are predictable and harmless.
+- If the resolver is genuinely doing work every cycle (real git/bundle fetches every ten hours), the issue is **not** the resync — it is `ResolutionRequest` objects that never reach `Done`. Investigate those objects directly:
+
+  ```bash
+  kubectl get resolutionrequest -A \
+    -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,DONE:.status.conditions[?(@.type=="Succeeded")].status,REASON:.status.conditions[?(@.type=="Succeeded")].reason
+  ```
+
+  Anything where the `Succeeded` condition is missing, `Unknown`, or has been `False` for hours is a candidate for the failsafe path. Either fix the underlying resolver problem (git auth, hub reachability, bundle digest mismatch) or delete the stale `ResolutionRequest` and let the PipelineRun re-create it.
+
+## Cleaning up stale ResolutionRequests
+
+`ResolutionRequest` objects are owner-referenced from their PipelineRun, so deleting the PipelineRun deletes them. A retention policy on PipelineRuns (via the Pipelines pruning controller or a CronJob) keeps the resolver's working set small and removes the resync log noise as a side effect:
+
+```bash
+# delete completed PipelineRuns older than 30 days; ResolutionRequests follow
+kubectl get pr -A -o json \
+  | jq -r '.items[]
+      | select(.status.completionTime?
+               and (.status.completionTime | fromdateiso8601 < (now - 30*24*3600)))
+      | "\(.metadata.namespace) \(.metadata.name)"' \
+  | xargs -L1 kubectl -n
+```
+
+(Use the cluster's existing retention mechanism if there is one — the snippet above is illustrative.)
+
+## Bottom line
+
+The ten-hour resync on `ResolutionRequest` is a framework-level failsafe that returns immediately for completed requests. Raising it to 24 hours would only make the failsafe slower; it would not save any meaningful work, because there is no work to save in the steady state. Operators who want to suppress the wake-up logs should filter at the log layer or shrink the working set with a PipelineRun retention policy.

--- a/docs/en/solutions/ResolutionRequest_reconciles_every_ten_hours_and_why_that_is_harmless.md
+++ b/docs/en/solutions/ResolutionRequest_reconciles_every_ten_hours_and_why_that_is_harmless.md
@@ -1,0 +1,57 @@
+---
+kind:
+   - Information
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# ResolutionRequest reconciles every ten hours and why that is harmless
+
+## Issue
+
+On Alauda Container Platform (kube `v1.34.5-1`) with the Alauda DevOps Pipelines operator installed (tektoncd-operator `v4.2.0`, TektonConfig `v0.76.0-c46274a` Ready), a `ResolutionRequest` (`resolution.tekton.dev/v1beta1`) that was completed days or weeks ago still shows up in the remote-resolvers controller log being reconciled roughly every ten hours, even when the `PipelineRun` that owns it is long-finished. The natural question is whether that periodic wake-up does anything — and whether the interval can be raised (for example to 24 hours) to quieten it.
+
+## Root Cause
+
+The ten-hour cadence is not a `ResolutionRequest`-specific setting. The Tekton remote-resolvers controller is built on the knative `controller` framework, whose `DefaultResyncPeriod` is the literal constant `10 * time.Hour`; the resolvers binary `cmd/resolvers/main.go` does not call `controller.WithResyncPeriod`, so its informer inherits that framework default verbatim and re-lists every `ResolutionRequest` on that interval. Because the cadence lives in the framework default and is not surfaced as an env var, container flag, or ConfigMap key on the resolvers `Deployment`, there is no first-class knob exposed by the controller to change the interval per-request or globally — on lab-base the live `deploy/tekton-pipelines-remote-resolvers` carries env names `{ARTIFACT_HUB_API, CONFIG_FEATURE_FLAGS_NAME, CONFIG_LEADERELECTION_NAME, CONFIG_LOGGING_NAME, CONFIG_OBSERVABILITY_NAME, KUBERNETES_MIN_VERSION, METRICS_DOMAIN, PROBES_PORT, SYSTEM_NAMESPACE, TEKTON_HUB_API}` with an empty `args` list, none of which name a resync period.
+
+The reconcile of an already-resolved `ResolutionRequest` is structurally a no-op. The upstream `ReconcileKind` in `pkg/reconciler/resolutionrequest/resolutionrequest.go` returns immediately when `rr.IsDone()` is true (i.e. the `Succeeded` condition is no longer `Unknown`), so once a request has been resolved the periodic wake-up never re-enters the resolver code path — it exists only as a failsafe so the controller can recover any update its informer might have missed.
+
+## Resolution
+
+Leave the ten-hour cadence in place. Because the wake-up of a completed `ResolutionRequest` returns immediately from `ReconcileKind`, the periodic reconcile costs nothing measurable — on lab-base the post-resolution settle reconcile and an annotate-triggered re-reconcile of the same `ResolutionRequest` were observed at `duration=0.000030088` and `duration=0.000122599` (sub-millisecond) respectively, with no API-server write to the object. There is no per-`ResolutionRequest` lifetime knob worth tuning here, and the controller-side knob that would raise the framework default to twenty-four hours is not exposed by the resolvers binary.
+
+To confirm the no-op shape on a specific cluster, force a fresh reconcile of a completed `ResolutionRequest` by annotating it (so the work-queue picks it up without waiting for the ten-hour resync), then read the resolvers controller log for the same `knative.dev/key`; the `Reconcile succeeded` line for that key should report a sub-millisecond `duration` field on the second and subsequent reconciles, which is the live signature of the `IsDone()` short-circuit on this cluster.
+
+## Diagnostic Steps
+
+List the `ResolutionRequest` objects on the cluster and pick one whose `SUCCEEDED` column is `True` — that is one where `IsDone()` is true and the periodic reconcile is a no-op:
+
+```bash
+kubectl get resolutionrequest -A
+```
+
+Read its `Succeeded` condition to confirm the resolver has finished with it:
+
+```bash
+kubectl -n <ns> get resolutionrequest <name> \
+  -o jsonpath='{.status.conditions[*]}{"\n"}'
+```
+
+Tail the remote-resolvers controller log for that request's reconcile entries; entries are keyed by `knative.dev/key=<ns>/<rr-name>` and carry a `duration` field in seconds:
+
+```bash
+kubectl -n tekton-pipelines logs deploy/tekton-pipelines-remote-resolvers --tail=200 \
+  | grep '<ns>/<rr-name>'
+```
+
+Force a fresh reconcile without waiting ten hours by annotating the request (any annotation change re-queues it); the next log entry for the same key should show a sub-millisecond `duration`, which is the live observable signature of the `IsDone()` short-circuit:
+
+```bash
+kubectl -n <ns> annotate resolutionrequest <name> \
+  kb.resync/poke="$(date +%s)" --overwrite
+```
+
+If the `duration` field for that key is sub-millisecond and the request's `resourceVersion` and `Succeeded` condition do not change across the wake-up, the periodic ten-hour resync is doing exactly what the upstream code prescribes — running the framework's failsafe re-list and exiting without work — and no tuning is required.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
