### PR TITLE
[observability] Custom matchers with whitespace trigger Alertmanager UTF-8 parser fallback warning

### DIFF
--- a/docs/en/solutions/Alertmanager_027_crashloops_with_this_input_is_incompatible_UTF_8_matchers_parser.md
+++ b/docs/en/solutions/Alertmanager_027_crashloops_with_this_input_is_incompatible_UTF_8_matchers_parser.md
@@ -1,0 +1,115 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Alertmanager 0.27 crashloops with "this input is incompatible" — UTF-8 matchers parser
+## Issue
+
+After the cluster's monitoring stack rolls Alertmanager forward to the 0.27.x line, the Alertmanager pod (`alertmanager-kube-prometheus-0` or whatever the local naming convention is) goes into a crash loop. The startup log carries a parser error of the form:
+
+```text
+level=warn msg="Alertmanager is moving to a new parser for labels and matchers,
+  and this input is incompatible. Alertmanager has instead parsed the input
+  using the classic matchers parser as a fallback."
+input="region=production EU"
+err="18:20: unexpected EU: expected a comma or close brace"
+suggestion="region=\"production EU\""
+```
+
+…sometimes followed by a hard validation failure such as `undefined receiver "frontend-team" used in route` that prevents Alertmanager from starting at all.
+
+The same configuration ran fine on the previous Alertmanager line and was deployed unchanged.
+
+## Root Cause
+
+Alertmanager 0.27 introduces a new parser for label names and matcher values that follows the Prometheus UTF-8 spec — label and matcher tokens may now contain characters outside the classic `[a-zA-Z_][a-zA-Z0-9_]*` set, but only when properly quoted. The new parser is strict; older configurations that relied on the lenient pre-0.27 behaviour can fail to round-trip.
+
+Two specific shapes are common:
+
+- **Unquoted multi-word values**: a route `match` or a silence with `region=production EU` was accepted by the old parser; the new parser stops at the space and reports `unexpected EU: expected a comma or close brace`. The fix is to double-quote the value: `region="production EU"`.
+- **Dotted label names**: labels like `host.name=value` or `kubernetes.pod.name=foo`. Under the new rules the dot is a UTF-8 special character and the *name* must be quoted: `"host.name"="value"`.
+
+When the parser fails, Alertmanager falls back to the classic parser to keep the pod up — but if the same configuration also has a *separate* validation problem (an undefined receiver, a duplicated route, a malformed inhibit rule), that fallback path does not save it and the pod crashloops on the secondary error.
+
+The crashloop is therefore the visible symptom of *two* compounded issues: a parser incompatibility that surfaces as warnings, and a pre-existing config error that the fallback parser cannot tolerate.
+
+## Resolution
+
+The fix is to make the configuration valid under the new UTF-8 matcher parser, then fix any unrelated validation errors. The quickest reliable way is to validate locally with `amtool` from the same Alertmanager version, *before* trying to deploy.
+
+### 1. Export the running configuration
+
+```bash
+NS=<monitoring-namespace>
+POD=alertmanager-kube-prometheus-0
+kubectl exec -n "$NS" "$POD" -- \
+  amtool config show --alertmanager.url http://localhost:9093 \
+  > alertmanager-running.yml
+```
+
+### 2. Validate against the same Alertmanager version
+
+Pull the Alertmanager 0.27.x image (whatever digest the cluster's monitoring stack ships) and run `amtool check-config` against the exported file. This is the same parser the live pod is running, so anything it complains about is what the live pod will complain about:
+
+```bash
+podman pull <alertmanager-0.27.x-image>
+podman run -ti --rm \
+  --entrypoint /usr/bin/amtool \
+  -v "$(pwd)/alertmanager-running.yml:/tmp/running.yml:z" \
+  <alertmanager-0.27.x-image> \
+  check-config /tmp/running.yml
+```
+
+Read every warning. The "is moving to a new parser… input is incompatible" warning carries the exact suggestion to apply (`region="production EU"`, `"host.name"="value"`, etc.) — paste those suggestions back into the matcher.
+
+### 3. Fix the unrelated errors `amtool` reports
+
+`amtool` will also flag undefined receivers, duplicate route children, and malformed inhibit rules — the same errors that knock the pod out of fallback parsing. Resolve each one:
+
+- `undefined receiver "frontend-team"` — define the receiver in the `receivers:` list, or rename the route's `receiver:` field to one that exists.
+- Routes that no longer match anything → delete or merge with siblings.
+- Inhibit rules with empty `equal:` lists → either populate or remove.
+
+### 4. Re-apply through whatever shipped the configuration in the first place
+
+If the configuration is owned by an `AlertmanagerConfig` CR (or the per-namespace equivalent), update the CR and let the operator render the merged config. If it is owned by a plain Secret named `kube-prometheus-alertmanager`, update the Secret and let the rollout pick it up:
+
+```bash
+kubectl create secret generic kube-prometheus-alertmanager \
+  -n "$NS" \
+  --from-file=alertmanager.yaml=alertmanager-running.yml \
+  --dry-run=client -o yaml \
+  | kubectl apply -f -
+kubectl -n "$NS" rollout restart statefulset kube-prometheus-alertmanager
+```
+
+### 5. Watch the pod come up clean
+
+```bash
+kubectl logs -n "$NS" "$POD" --tail=100 -f \
+  | grep -E 'matchers|parser|started|listen'
+```
+
+Healthy startup logs the listen address with no parser warnings.
+
+## Diagnostic Steps
+
+1. Confirm the failure is the matchers-parser one and not, e.g., a config-mounting problem. The fingerprint phrase is `Alertmanager is moving to a new parser for labels and matchers`. If that is in the logs, the parser is involved; if it is not, look elsewhere (image pull, volume mount, peer connectivity).
+
+2. Walk every matcher in the configuration and count those that contain characters outside `[a-zA-Z_0-9-]` and are not double-quoted:
+
+   ```bash
+   grep -nE 'match(_re)?:' alertmanager-running.yml
+   grep -nE 'matchers:' -A 10 alertmanager-running.yml
+   ```
+
+   Each match without quotes around values that contain spaces, dots, or other UTF-8 specials is a candidate for the warning.
+
+3. Validate the corrected file *with the same image version* the cluster runs — there is no point validating against a different binary. The 0.27.x line is the strict one; older `amtool` will pass configs the live pod will reject.
+
+4. If the cluster has a templating layer (Helm, Kustomize, CR-based Alertmanager configuration) producing the YAML, fix the **template**, not the rendered output. Otherwise the next reconcile will overwrite the manual fix and the pod will crash again. The amtool-validated YAML is your truth source for what the template needs to emit.

--- a/docs/en/solutions/Custom_matchers_with_whitespace_trigger_Alertmanager_UTF_8_parser_fallback_warning.md
+++ b/docs/en/solutions/Custom_matchers_with_whitespace_trigger_Alertmanager_UTF_8_parser_fallback_warning.md
@@ -1,0 +1,78 @@
+---
+kind:
+   - KnownIssue
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Custom matchers with whitespace trigger Alertmanager UTF-8 parser fallback warning
+
+## Issue
+
+On Alauda Container Platform the Prometheus monitoring stack ships an Alertmanager binary built from upstream `v0.32.1`, packaged as `registry.alauda.cn:60080/3rdparty/prometheus/alertmanager:v0.32.1-v4.3.4` and run by the `cpaas-system/kube-prometheus` Alertmanager CR. Because this version is well above `0.27`, the binary uses the new UTF-8-capable matchers parser introduced upstream in `0.27`, which is strict about how matcher values are quoted.
+
+When the configured route tree contains a `matchers:` list entry whose value carries whitespace (or other special characters) but is not double-quoted — for example `region=production EU` — the parser cannot consume the value as a single token, falls back to the classic matchers parser, and emits a `parse.go:176` WARN line that identifies the offending input. On the `v0.32.1` build the line is emitted by the alertmanager container in its standard `slog` format with the `source=parse.go:176` field:
+
+```text
+time=2026-05-29T14:56:00.665Z level=WARN source=parse.go:176 msg="Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the classic matchers parser as a fallback. To make this input compatible with the UTF-8 matchers parser please make sure all regular expressions and values are double-quoted and backslashes are escaped. If you are still seeing this message please open an issue." input="region=production EU" origin=config err="18:20: unexpected EU: expected a comma or close brace" suggestion="region=\"production EU\""
+```
+
+Each warning line carries four identifying fields: `input=` (the exact offending matcher string), `origin=config`, `err=` (a column position and a short reason such as `unexpected EU: expected a comma or close brace`), and `suggestion=` (the corrected matcher with the value already double-quoted).
+
+The `parse.go:176` line is a WARN, not a fatal error: Alertmanager keeps running on the offending config because the parser falls back to the classic matchers parser rather than rejecting the load. In a lab reproduction the probe pod with the matcher above loaded the configuration and reached `Phase=Running` with `restartCount=0`, and the dispatcher and gossip cluster started normally — the upstream signal on `v0.27`-`v0.32+` for this class of input is a parser warning plus a classic-parser fallback, not a process crash.
+
+## Root Cause
+
+When the UTF-8 matchers parser receives a matcher string it cannot parse, it does not fail the configuration. Instead it re-parses the string with the classic matchers parser and accepts the result, then logs the `parse.go:176` warning so the operator can fix the input before the next behavior change. The fallback path is announced by an adjacent DEBUG line on the same load — `source=parse.go:154 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input=... origin=config` (visible at `--log.level=debug`) — and the WARN at `parse.go:176` is the operator-visible signal that the fallback actually ran.
+
+The warning is keyed to the alertmanager binary version, not to any configuration edit: the `v0.32.1` binary checks every matcher string against the UTF-8 parser on every config load, so a misshapen `matchers:` entry warns on the first load and on every reload thereafter until the value is rewritten.
+
+For the article's literal input `region=production EU` the parser stops at column 20 because the bare word `EU` after the whitespace cannot be a value or a comma-separated continuation; the `err=` field reports `18:20: unexpected EU: expected a comma or close brace` and the `suggestion=` field shows the syntactically correct form `region="production EU"`.
+
+## Resolution
+
+For each non-compliant `matchers:` list entry, wrap the value in double quotes (and escape any embedded backslashes). Using the example from the warning text, the original entry:
+
+```yaml
+route:
+  routes:
+  - matchers:
+    - region=production EU
+    receiver: default
+```
+
+is rewritten to the parser-compliant form:
+
+```yaml
+route:
+  routes:
+  - matchers:
+    - region="production EU"
+    receiver: default
+```
+
+After this change the same `v0.32.1` Alertmanager loads the configuration with no `parse.go:176` WARN line and without invoking the classic-parser fallback at all — the `parse.go:154` DEBUG line still announces that the two-pass parser engaged, but the value now parses cleanly on the first pass through the UTF-8 parser and no fallback runs.
+
+Applying the double-quoted fix produces no behavior change for already-compliant inputs and clears the warning for the non-compliant ones; the same `v0.32.1` binary then loads the route tree cleanly.
+
+## Diagnostic Steps
+
+Read the live alertmanager container log and filter for the `parse.go:176` warning to enumerate which matchers are tripping the fallback:
+
+```bash
+kubectl -n cpaas-system logs alertmanager-kube-prometheus-0 -c alertmanager --tail=2000 \
+  | grep 'source=parse.go:176'
+```
+
+If the grep returns no lines, every matcher currently loaded by Alertmanager is UTF-8-parser-compliant and no action is needed. If lines are returned, each line's `input=` field identifies the exact offending matcher and the `suggestion=` field gives the corrected double-quoted form to copy back into the configuration.
+
+To validate a planned configuration before rolling it out, run `amtool` from inside the Alertmanager container — it ships in the same image at the same version (`amtool, version 0.32.1`) and reproduces the parser warning during `check-config`, so a misshapen matcher can be caught without rotating the pod:
+
+```bash
+kubectl -n cpaas-system exec alertmanager-kube-prometheus-0 -c alertmanager -- \
+  /bin/amtool check-config /etc/alertmanager/config_out/alertmanager.env.yaml
+```
+
+A `SUCCESS` line with no preceding `parse.go:176 WARN` indicates the configuration is fully compliant with the UTF-8 matchers parser; a `SUCCESS` line preceded by one or more `parse.go:176 WARN` lines means the configuration is currently accepted only because of the classic-parser fallback and must be updated before the next Alertmanager upgrade.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
