### PR TITLE
[virtualization] Refreshing virt-launcher-bound device definitions on KubeVirt VMs after an ACP virtualization update

### DIFF
--- a/docs/en/solutions/Live_migration_fails_on_VMs_that_pin_Virtio_video_via_a_hook_sidecar_after_a_virt_launcher_upgrade.md
+++ b/docs/en/solutions/Live_migration_fails_on_VMs_that_pin_Virtio_video_via_a_hook_sidecar_after_a_virt_launcher_upgrade.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Live migration fails on VMs that pin Virtio video via a hook sidecar after a virt-launcher upgrade
 ## Issue
 
 After the cluster's virtualization runtime is rolled forward to a new patch version, **live migration** stops working for a subset of VMs. The common factor among the failing VMs is that they use a *hook sidecar* to set the guest's display device to the Virtio video driver (rather than letting the runtime pick the default).

--- a/docs/en/solutions/Live_migration_fails_on_VMs_that_pin_Virtio_video_via_a_hook_sidecar_after_a_virt_launcher_upgrade.md
+++ b/docs/en/solutions/Live_migration_fails_on_VMs_that_pin_Virtio_video_via_a_hook_sidecar_after_a_virt_launcher_upgrade.md
@@ -1,0 +1,129 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+After the cluster's virtualization runtime is rolled forward to a new patch version, **live migration** stops working for a subset of VMs. The common factor among the failing VMs is that they use a *hook sidecar* to set the guest's display device to the Virtio video driver (rather than letting the runtime pick the default).
+
+`virt-launcher` on the destination side records a QEMU migration-load failure that points at the video device:
+
+```text
+{"component":"virt-launcher","level":"error",
+ "msg":"internal error: QEMU unexpectedly closed the monitor...
+  qemu-kvm: get_pci_config_device: Bad config data..."}
+{"component":"virt-launcher","level":"info",
+ "msg":"qemu-kvm: Failed to load PCIDevice:config"}
+{"component":"virt-launcher","level":"info",
+ "msg":"qemu-kvm: Failed to load virtio-gpu:virtio"}
+{"component":"virt-launcher","level":"info",
+ "msg":"qemu-kvm: error while loading state for instance 0x0 of device '0000:00:01.0/virtio-gpu'"}
+{"component":"virt-launcher","level":"info",
+ "msg":"qemu-kvm: load of migration failed: Invalid argument"}
+```
+
+The source side keeps running fine; the destination side rejects the incoming migration stream because the source's PCI device shape does not match what the new virt-launcher image produces.
+
+## Root Cause
+
+The new virt-launcher image ships a QEMU package set that re-introduces the `virtio-vga` device variant (the package containing the device implementation was missing in the previous patch and is back in this one). The source VM was started against the *previous* image, which fell back to `virtio-gpu-pci`. The destination, running the *new* image, generates `virtio-vga` instead — because libvirt now sees the device as available and selects it.
+
+QEMU's live-migration protocol streams the device state of every PCI device on the source VM into the equivalent device on the destination. The destination rejects the stream when the device class on the source does not match the device class on the destination — which is exactly what happens here:
+
+| version | display device libvirt picks | source vs destination |
+|---|---|---|
+| previous | `virtio-gpu-pci` | what the source VM is running with |
+| current | `virtio-vga` | what the destination virt-launcher will instantiate |
+
+The QEMU monitor reports `Bad config data` and `Failed to load PCIDevice:config` because the migration stream contains a `virtio-gpu-pci` state and the destination is trying to apply it to a `virtio-vga` device. The two PCI shapes are not state-compatible across the live wire.
+
+VMs that **don't** use the hook sidecar to pin Virtio video pick whatever default the runtime offers and have a consistent device class on both sides — they migrate normally. Only the hook-sidecar VMs are caught in the cross-version asymmetry.
+
+## Resolution
+
+Reset the source side to use the new device class. The migration stream is generated from the running QEMU process, so the only way to change the source's device class is to **cold-restart** (Stop and Start, not just Restart) the affected VMs. After a cold restart, the source VM is running on the new virt-launcher image and instantiates `virtio-vga`; from then on, both sides agree and live migration works again.
+
+### 1. Identify the affected VMs
+
+Any VM with a hook sidecar that pins Virtio video is a candidate:
+
+```bash
+kubectl get vm -A -o json \
+  | jq -r '.items[]
+            | select(.spec.template.metadata.annotations["hooks.kubevirt.io/hookSidecars"] != null)
+            | "\(.metadata.namespace)/\(.metadata.name)"'
+```
+
+If you want to be conservative, treat every hook-sidecar VM as affected. If you want to be precise, additionally inspect each candidate's hook annotation and keep only those whose payload sets the display device to `virtio` / `virtio-vga`.
+
+### 2. Cold-restart each VM
+
+A live restart (the runtime's `restart` action) is **not** enough — it migrates the state to a new pod, preserving the device shape. Use stop-then-start:
+
+```bash
+kubectl virt stop -n <ns> <vm>            # waits for graceful shutdown
+kubectl virt start -n <ns> <vm>
+```
+
+If the cluster's `kubectl` does not have the `virt` plugin, the equivalent is to scale the VM's `running:` field down and back up:
+
+```bash
+kubectl patch vm -n <ns> <vm> --type merge -p '{"spec":{"running":false}}'
+# wait until VMI is gone
+kubectl wait --for=delete vmi/<vm> -n <ns> --timeout=10m
+kubectl patch vm -n <ns> <vm> --type merge -p '{"spec":{"running":true}}'
+```
+
+Coordinate with the workload owner — a cold restart is a few seconds of downtime per VM.
+
+### 3. Verify a live migration works
+
+Pick one of the freshly-restarted VMs and trigger a live migration to another node:
+
+```bash
+kubectl create -f - <<EOF
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstanceMigration
+metadata:
+  generateName: <vm>-test-
+  namespace: <ns>
+spec:
+  vmiName: <vm>
+EOF
+kubectl get vmim -n <ns> -w
+```
+
+A `Succeeded` migration without `Bad config data` errors in the destination virt-launcher log proves the device shape is now consistent end-to-end.
+
+### Avoiding the same trap on the next upgrade
+
+When the runtime release notes call out a change to the QEMU device package set, plan a cold-restart wave for any VM that pins device shapes through a hook sidecar. The routine "live migrate everything off a node before draining" is what surfaced the issue here — the live migration cannot bridge the device-shape gap. A scheduled cold-restart maintenance window before the rollout is cheaper than chasing failed migrations after.
+
+## Diagnostic Steps
+
+1. Confirm the failure shape is the device-state mismatch and not a generic networking / RDMA migration issue. The signature in the destination virt-launcher log is the trio:
+
+   ```text
+   Failed to load PCIDevice:config
+   Failed to load virtio-gpu:virtio
+   error while loading state for instance 0x0 of device '0000:00:01.0/virtio-gpu'
+   ```
+
+   All three referencing `virtio-gpu` (the source-side class) is what diagnoses this case.
+
+2. Compare the device line in the source VM's QEMU command line against the destination's. From a debug shell into both virt-launcher pods:
+
+   ```bash
+   kubectl exec -n <ns> <virt-launcher-source>      -- cat /var/run/kubevirt-private/.../qemu.cmd | grep -E 'vga|virtio-(gpu|vga)'
+   kubectl exec -n <ns> <virt-launcher-destination> -- cat /var/run/kubevirt-private/.../qemu.cmd | grep -E 'vga|virtio-(gpu|vga)'
+   ```
+
+   `virtio-gpu-pci` on one side and `virtio-vga` on the other proves the asymmetry.
+
+3. After cold-restarting a VM, re-read the source-side QEMU command line and confirm it now lists `virtio-vga`. If it still says `virtio-gpu-pci`, the VM did not actually go through Stop/Start — most likely the platform's automation did a graceful restart that re-used the device template; redo the cycle as `running:false` → wait for VMI to disappear → `running:true`.
+
+4. If a small subset of VMs has a hard requirement for `virtio-gpu-pci` (some image overlays do), you can pin the device by hand in the VM template. Edit the VM CR's `spec.template.spec.domain.devices.video` (or equivalent) to specify `virtio-gpu-pci` explicitly; that overrides libvirt's auto-selection on the new image and keeps the source/destination consistent without needing the hook sidecar at all.

--- a/docs/en/solutions/Refreshing_virt_launcher_bound_device_definitions_on_KubeVirt_VMs_after_an_ACP_virtualization_update.md
+++ b/docs/en/solutions/Refreshing_virt_launcher_bound_device_definitions_on_KubeVirt_VMs_after_an_ACP_virtualization_update.md
@@ -1,0 +1,71 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Refreshing virt-launcher-bound device definitions on KubeVirt VMs after an ACP virtualization update
+
+## Issue
+
+On Alauda Container Platform, virtualization is provided by the upstream KubeVirt distribution installed into the `kubevirt` namespace through the OperatorBundle `kubevirt-hyperconverged-operator.v4.3.5`; the cluster runs the HyperConverged custom resource and a deployed `KubeVirt` custom resource that owns the `virt-controller` / `virt-api` / `virt-handler` / `virt-launcher` workloads. The observed KubeVirt build on this environment is `v1.7.0-alauda.2`, and the `virt-controller` Deployment is started with the `--launcher-image` argument pinned to a single virt-launcher image tag (`3rdparty/kubevirt/virt-launcher:v1.7.0-alauda.2`); every new VirtualMachineInstance launched while that Deployment is in its current state spawns a virt-launcher pod from that exact image tag.
+
+A VirtualMachine whose template carries the `hooks.kubevirt.io/hookSidecars` annotation relies on libvirtd inside the virt-launcher container to select a virtio-family display device; the device choice is bound to the contents of the virt-launcher container image at the moment the VirtualMachineInstance is created. Because the image used for a running VirtualMachineInstance is fixed at VMI creation time, an already-running VMI continues to use the device definition that was generated against the virt-launcher image present at that earlier time, even after the cluster's virt-controller is now configured to launch new VMIs from a different virt-launcher image tag.
+
+## Root Cause
+
+The display-device packaging that libvirtd resolves against lives inside the virt-launcher container image; the configured device for a given VirtualMachineInstance follows the virt-launcher image that was current when that VMI was created. Because virt-controller is launched with a single `--launcher-image` argument that all new VMIs inherit, the source of truth for the device definition shifts as soon as that argument is updated to a different tag — but only for VMIs created from that point onward.
+
+KubeVirt live migration on this cluster is enabled — the `KubeVirt` resource carries an active `spec.configuration.migrations` block (`parallelMigrationsPerCluster: 5`, `completionTimeoutPerGiB: 150`) and the `VideoConfig` feature gate is present in the configured feature-gate list, so virtio video device selection is in scope for the running build. A KubeVirt live migration streams device state from the source virt-launcher pod to the destination virt-launcher pod, and the destination pod must instantiate a PCI device of the same type for the incoming state to map onto matching hardware. When the source virt-launcher pod was created from an earlier virt-launcher image and a fresh destination virt-launcher pod is started from the currently configured image, the two pods can carry different display-device packaging, leaving the destination unable to load the streamed state cleanly.
+
+## Resolution
+
+Cold-restarting affected VirtualMachines (stop, then start) re-creates the VirtualMachineInstance from the virt-launcher image that virt-controller is currently configured to use — `--launcher-image: registry.alauda.cn:60080/3rdparty/kubevirt/virt-launcher:v1.7.0-alauda.2` in the present state of this cluster — so the device definition for the new VMI is generated against the currently shipped virt-launcher contents.
+
+After the cold restart, the source and destination virt-launcher pods for any subsequent live migration are both produced from the same `--launcher-image` tag, which keeps the device packaging consistent across the migration endpoints.
+
+```bash
+# Inspect the virt-launcher image tag the controller currently uses
+kubectl -n kubevirt get deploy virt-controller \
+  -o jsonpath='{.spec.template.spec.containers[*].args}'
+
+# Stop and start an affected VM to regenerate its VMI from the current image
+kubectl -n <vm-namespace> patch virtualmachine <vm-name> \
+  --type=merge -p '{"spec":{"runStrategy":"Halted"}}'
+kubectl -n <vm-namespace> patch virtualmachine <vm-name> \
+  --type=merge -p '{"spec":{"runStrategy":"Always"}}'
+```
+
+## Diagnostic Steps
+
+Affected VirtualMachines are those that carry the hook-sidecar annotation used to drive virtio display-device selection. List them by selecting on `spec.template.metadata.annotations` for the `hooks.kubevirt.io/hookSidecars` key.
+
+```bash
+# Find VMs that use the hookSidecars annotation (cluster-wide)
+kubectl get vm -A -o json | jq -r '
+  .items[]
+  | select(.spec.template.metadata.annotations
+           | has("hooks.kubevirt.io/hookSidecars"))
+  | "\(.metadata.namespace)/\(.metadata.name)"'
+```
+
+Confirm the KubeVirt build and virt-launcher image tag currently in effect, so that any VMI created from this point matches that pinned tag:
+
+```bash
+kubectl -n kubevirt get kubevirt kubevirt-kubevirt-hyperconverged \
+  -o jsonpath='{.status.observedKubeVirtVersion}'
+kubectl -n kubevirt get deploy virt-controller \
+  -o jsonpath='{.spec.template.spec.containers[*].args}'
+```
+
+Confirm that the live-migration controller is configured and that the relevant feature gate is enabled before scheduling migrations of the regenerated VirtualMachineInstances:
+
+```bash
+kubectl -n kubevirt get kubevirt kubevirt-kubevirt-hyperconverged \
+  -o jsonpath='{.spec.configuration.migrations}'
+kubectl -n kubevirt get kubevirt kubevirt-kubevirt-hyperconverged \
+  -o jsonpath='{.spec.configuration.developerConfiguration.featureGates}'
+```


### PR DESCRIPTION
新增一篇 ACP KB 文章。
