### PR TITLE
[configure] Diagnosing a node that reports NotReady on Alauda Container Platform

### DIFF
--- a/docs/en/solutions/Diagnosing_a_node_that_reports_NotReady_on_Alauda_Container_Platform.md
+++ b/docs/en/solutions/Diagnosing_a_node_that_reports_NotReady_on_Alauda_Container_Platform.md
@@ -1,0 +1,64 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+
+# Diagnosing a node that reports NotReady on Alauda Container Platform
+
+## Issue
+
+A node (`core/v1` Node) shows status `NotReady` in the cluster. The Ready condition on a healthy node is sourced from the kubelet on that node host: on an observed Ready node (kubelet `v1.34.5`) the condition carries reason `KubeletReady` with the message `kubelet is posting ready status`. The same kubelet-posted status also drives the companion node conditions reported with reasons `KubeletHasSufficientMemory`, `KubeletHasNoDiskPressure`, `KubeletHasSufficientPID`, and `KubeletReady`. The kubelet's heartbeat is observable as the live `renewTime` on the node's `Lease` in `kube-node-lease`, which advances about every 10 seconds on a healthy node. When the kubelet stops posting status, that heartbeat stops advancing; after the configured `--node-monitor-grace-period` (50 seconds on this cluster) of missed heartbeats, the node-lifecycle controller transitions the Ready condition away from `True` and the node is reported `NotReady`.
+
+```bash
+kubectl get nodes
+kubectl describe node <node-name>
+```
+
+## Root Cause
+
+Because the Ready condition depends on the kubelet successfully posting status, a `NotReady` node usually points back to the kubelet on that node host. On the inspected worker nodes (kubelet `v1.34.5`, Ubuntu 22.04.1 LTS, `containerd://2.2.1-5`) the kubelet runs as a host `systemd` unit — `kubelet.service`, the Kubernetes Node Agent — observed `active (running)`, serving on port `10250`, and acting as the source component for node-level events. A common cause of `NotReady` is that this kubelet service on the node host is not running, so no status is posted. A second common cause is that the kubelet is running but cannot reach the API server endpoint (the in-cluster `kubernetes` Service endpoint, observed at `192.168.135.152:6443`, `https`), so its status updates do not arrive.
+
+## Resolution
+
+When a node is `NotReady`, confirm the kubelet on that node host is running and, if it is, that it can reach the API server endpoint; restoring either path lets the kubelet resume posting status and the node return to Ready.
+
+Check the kubelet service state on the node host (the kubelet is a host `systemd` unit, observed `active (running)` on the healthy worker nodes). When the kubelet is not running, restoring the service is what lets it resume posting status:
+
+```bash
+systemctl status kubelet
+journalctl -u kubelet -n 200 --no-pager
+```
+
+If the kubelet is running, confirm it can reach the API server endpoint on the cluster (the kubelet must be able to connect to the API server to post status). From the node host, the apiserver liveness endpoint responded `ok` over `https`, confirming the network path the kubelet uses to post status:
+
+```bash
+curl -k --max-time 5 https://192.168.135.152:6443/livez
+```
+
+## Diagnostic Steps
+
+Inspect the node's reported conditions; on a healthy node the Ready condition is `KubeletReady` with message `kubelet is posting ready status`. The live heartbeat is the node's `Lease` `renewTime` in `kube-node-lease`, which advances about every 10 seconds while the kubelet posts; a `renewTime` that stops advancing for longer than `--node-monitor-grace-period` (50 seconds on this cluster) is what drives the node to `NotReady`.
+
+```bash
+kubectl get node <node-name> \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\n"}{end}'
+kubectl get lease <node-name> -n kube-node-lease \
+  -o jsonpath='renew={.spec.renewTime} dur={.spec.leaseDurationSeconds}{"\n"}'
+```
+
+On the node host, confirm the kubelet service is up; on the inspected worker nodes `systemctl is-active kubelet` returned `active`, with `journalctl -u kubelet` showing live log lines from the running kubelet.
+
+```bash
+systemctl is-active kubelet
+journalctl -u kubelet -n 50 --no-pager
+```
+
+From the node host, verify connectivity to the API server endpoint so the kubelet can post status; the apiserver liveness endpoint returns `ok` over `https` when the path is healthy.
+
+```bash
+curl -k --max-time 5 https://192.168.135.152:6443/livez
+```

--- a/docs/en/solutions/Troubleshooting_nodes_stuck_in_NotReady.md
+++ b/docs/en/solutions/Troubleshooting_nodes_stuck_in_NotReady.md
@@ -6,6 +6,8 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Troubleshooting nodes stuck in NotReady
 ## Issue
 
 A node reports `Status: NotReady` in `kubectl get nodes`. Pods scheduled on the node go into `Unknown` or `Terminating`; new pods cannot be placed on it; existing workloads on the node may keep running for a while but become invisible to the cluster.

--- a/docs/en/solutions/Troubleshooting_nodes_stuck_in_NotReady.md
+++ b/docs/en/solutions/Troubleshooting_nodes_stuck_in_NotReady.md
@@ -1,0 +1,132 @@
+---
+kind:
+   - Troubleshooting
+products:
+   - Alauda Container Platform
+ProductsVersion:
+   - 4.1.0,4.2.x
+---
+## Issue
+
+A node reports `Status: NotReady` in `kubectl get nodes`. Pods scheduled on the node go into `Unknown` or `Terminating`; new pods cannot be placed on it; existing workloads on the node may keep running for a while but become invisible to the cluster.
+
+The same surface symptom (`NotReady`) covers very different underlying problems. The two most common roots are:
+
+- The `kubelet` process on the node is **not running** at all (crashed, stopped, or its dependency — the container runtime — is down).
+- The `kubelet` process is running but **cannot reach the API server**, so it cannot post status heartbeats and the apiserver downgrades the node after the configured grace window.
+
+This article walks through how to distinguish the two, and how to fix each.
+
+## Resolution
+
+### 1. Confirm the node is genuinely NotReady
+
+From a control-plane host, look at the node and the conditions block:
+
+```bash
+kubectl get node <node>
+kubectl describe node <node> | sed -n '/Conditions:/,/Addresses:/p'
+```
+
+The output shows one row per condition; the relevant ones are `Ready`, `MemoryPressure`, `DiskPressure`, `PIDPressure`, `NetworkUnavailable`. If `Ready=Unknown`, the kubelet is not posting heartbeats — focus on connectivity (step 4). If `Ready=False` with a specific message, the kubelet is reporting the failure itself — focus on the kubelet (step 2 and 3).
+
+### 2. Inspect the kubelet on the node
+
+Open a shell on the affected node — either over SSH, or via a privileged debug pod with a host shell:
+
+```bash
+kubectl debug node/<node> -it --profile=sysadmin --image=<utility-image>
+chroot /host
+```
+
+Then check the kubelet unit:
+
+```bash
+systemctl status kubelet
+journalctl -u kubelet -n 200 --no-pager
+```
+
+If the unit is `inactive` or repeatedly restarting:
+
+- Look for `failed to start container manager` or `failed to start kubelet` errors with the runtime endpoint mentioned — that points at the container runtime (step 3).
+- Look for `runtime is unable to ...` or `node not found` messages — that points at apiserver connectivity (step 4).
+- Look for `out of memory` / `killed` messages — the node ran out of resources; clean up before restarting kubelet.
+
+If the unit is healthy, restart it once to clear transient state:
+
+```bash
+systemctl restart kubelet
+journalctl -u kubelet -f
+```
+
+### 3. Inspect the container runtime
+
+The kubelet depends on a CRI runtime (typically `cri-o` or `containerd`). If the runtime is down, the kubelet refuses to declare the node Ready:
+
+```bash
+systemctl status crio       # or: systemctl status containerd
+journalctl -u crio -n 200   # or: journalctl -u containerd -n 200
+crictl info | head -40
+```
+
+A failing runtime is usually one of:
+
+- Disk pressure: `/var/lib/containers/` (cri-o) or `/var/lib/containerd/` is full.
+- A leaked container blocking startup: clean it with `crictl rm -f <id>`.
+- A configuration drift: confirm `/etc/crio/crio.conf` (or `/etc/containerd/config.toml`) matches the rest of the fleet.
+
+After restoring the runtime, the kubelet usually recovers on its own; if not, restart it explicitly.
+
+### 4. Confirm kubelet-to-apiserver connectivity
+
+Even when the kubelet is running, the node only reports `Ready` if it can post heartbeats to the apiserver. From the affected node:
+
+```bash
+# From the node, hit the apiserver URL the kubelet uses
+curl -k --resolve api.<cluster-domain>:6443:<vip> \
+     https://api.<cluster-domain>:6443/livez
+```
+
+Failures here mean a network problem between the node and the control plane: cluster VIP, route, MTU, firewall, or TLS expiry. Resolve the underlying network issue, then watch the kubelet log come unblocked. If the kubelet client certificate has expired (look for `x509: certificate has expired or is not yet valid` in the kubelet log), rotate it via the cluster's certificate-rotation mechanism before the kubelet can re-register.
+
+### 5. Verify the node returns to Ready
+
+Once the underlying cause is addressed, watch the node from a control-plane host:
+
+```bash
+kubectl get node <node> -w
+```
+
+The node should transition `NotReady` → `Ready` within one or two heartbeat intervals (a few tens of seconds). If it does not, repeat steps 2–4 with the latest logs — multiple failures often stack (for example, a runtime that came back but with a stale image cache that breaks the next pod sandbox).
+
+## Diagnostic Steps
+
+1. List nodes and their last-heartbeat times:
+
+   ```bash
+   kubectl get nodes -o wide
+   kubectl get node <node> -o jsonpath='{.status.conditions[?(@.type=="Ready")]}{"\n"}'
+   ```
+
+2. Capture the apiserver's view of the node's recent events:
+
+   ```bash
+   kubectl describe node <node> | sed -n '/Events:/,$p'
+   ```
+
+3. From the node itself, capture kubelet and runtime state for the symptomatic window:
+
+   ```bash
+   journalctl -u kubelet --since "30 minutes ago"
+   journalctl -u crio    --since "30 minutes ago"   # or containerd
+   ```
+
+4. If suspecting connectivity, trace the path from node to apiserver:
+
+   ```bash
+   ip route get <apiserver-vip>
+   ss -tnp | grep <apiserver-port>
+   curl -kv --max-time 5 https://<apiserver-vip>:6443/livez
+   ```
+
+5. If the same node keeps flipping `Ready ↔ NotReady`, look at memory and PID pressure on the node — kubelet evicts itself from Ready when the node crosses the eviction thresholds, so a node that flaps is sometimes simply oversubscribed.


### PR DESCRIPTION
新增一篇 ACP KB 文章。
