### PR TITLE
docs: add H1 titles to 30 merged solution articles

### DIFF
--- a/docs/en/solutions/Approving_a_CertificateSigningRequest_via_the_Kubernetes_API.md
+++ b/docs/en/solutions/Approving_a_CertificateSigningRequest_via_the_Kubernetes_API.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Approving a CertificateSigningRequest via the Kubernetes API
+
 ## Issue
 
 A CertificateSigningRequest (CSR) needs to be approved programmatically — for example from a CI job, a webhook handler, or an automation controller — and shelling out to `kubectl certificate approve` is not a viable option. The standard `kubectl` admin verb is missing in some build environments, the toolchain only carries an HTTP client, or the workflow needs to attach extra auditable metadata to the approval call.

--- a/docs/en/solutions/Auto_Approve_Pending_Node_CSRs_with_a_Scheduled_Job.md
+++ b/docs/en/solutions/Auto_Approve_Pending_Node_CSRs_with_a_Scheduled_Job.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Auto-Approve Pending Node CSRs with a Scheduled Job
+
 ## Issue
 
 Node kubelets periodically submit CertificateSigningRequests (CSRs) to renew their client and serving certificates. When the controller responsible for approving them is not running, or when CSRs arrive from workloads faster than an operator can process manually, new nodes stall in `NotReady` and existing nodes fail `kubectl logs`, `kubectl exec`, and `kubectl port-forward` with TLS errors. Manual approval through `kubectl certificate approve` does not scale and is error-prone during incidents.

--- a/docs/en/solutions/Automating_etcd_Snapshot_Backups_on_the_Control_Plane.md
+++ b/docs/en/solutions/Automating_etcd_Snapshot_Backups_on_the_Control_Plane.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Automating etcd Snapshot Backups on the Control Plane
+
 ## Overview
 
 etcd is the source of truth for every Kubernetes object. Losing it — through disk corruption, simultaneous node failure, or accidental delete — without a recent backup is a full cluster rebuild. Automating a regular on-host snapshot is the cheapest and most effective disaster-recovery primitive the platform can maintain.

--- a/docs/en/solutions/Backend_Performance_Requirements_for_etcd.md
+++ b/docs/en/solutions/Backend_Performance_Requirements_for_etcd.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500008
 ---
+
+# Backend Performance Requirements for etcd
+
 ## Issue
 
 etcd performance degrades due to insufficient storage or network backend capabilities, producing log messages similar to the following:

--- a/docs/en/solutions/Can_an_etcd_snapshot_be_used_to_restore_state_on_a_different_cluster.md
+++ b/docs/en/solutions/Can_an_etcd_snapshot_be_used_to_restore_state_on_a_different_cluster.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500010
 ---
+
+# Can an etcd snapshot be used to restore state on a different cluster?
+
 ## Overview
 
 An etcd snapshot has been captured from a running cluster. The operator wants to know whether that snapshot can be restored into a freshly provisioned, separately installed cluster — effectively using etcd backup as a cross-cluster migration tool for workloads, PVs, and cluster-scoped state.

--- a/docs/en/solutions/Ceph_MDS_slow_requests_caused_by_SELinux_recursive_relabel_on_CephFS_volumes.md
+++ b/docs/en/solutions/Ceph_MDS_slow_requests_caused_by_SELinux_recursive_relabel_on_CephFS_volumes.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Ceph MDS slow requests caused by SELinux recursive relabel on CephFS volumes
+
 ## Issue
 
 Pods that mount a CephFS PersistentVolume take a very long time to become Ready, and the MDS in the ACP Ceph storage stack records `slow request` warnings for `setxattr` on `security.selinux`. Representative entries from the MDS:

--- a/docs/en/solutions/Collecting_a_complete_dump_of_a_namespace_for_troubleshooting.md
+++ b/docs/en/solutions/Collecting_a_complete_dump_of_a_namespace_for_troubleshooting.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500002
 ---
+
+# Collecting a complete dump of a namespace for troubleshooting
+
 ## Issue
 
 When a workload in a single namespace misbehaves, support engineers usually need a snapshot of every resource in that namespace plus all container logs, packaged in one file. The cluster-wide diagnostic bundle (`inspection` collector, `kubectl cluster-info dump`) is too coarse — it overwhelms the responder with platform internals — and `kubectl get -A` is too narrow because it loses non-namespaced context (events, RBAC bindings, storage). The need is for a per-namespace dump that captures resource manifests, recent events, and previous + current container logs in one transferable archive.

--- a/docs/en/solutions/Configuring_Container_and_Image_Garbage_Collection_on_the_kubelet.md
+++ b/docs/en/solutions/Configuring_Container_and_Image_Garbage_Collection_on_the_kubelet.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500005
 ---
+
+# Configuring Container and Image Garbage Collection on the kubelet
+
 ## Overview
 
 The kubelet on every worker node continuously reclaims resources from the local container runtime. Two related mechanisms drive this:

--- a/docs/en/solutions/Configuring_chrony_NTP_on_Cluster_Nodes.md
+++ b/docs/en/solutions/Configuring_chrony_NTP_on_Cluster_Nodes.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500013
 ---
+
+# Configuring chrony / NTP on Cluster Nodes
+
 ## Issue
 
 Cluster nodes need to synchronise their clocks against a specific NTP server set — often an internal time source inside a restricted network, or a hardened NTP pool with Network Time Security (NTS). The default chrony configuration that ships on each node points at public time servers, which is either not reachable (air-gapped / egress-controlled environments), not acceptable by policy, or not trusted (no NTS).

--- a/docs/en/solutions/CoreDNS_pods_crashloop_with_Wrong_argument_count_parsing_error.md
+++ b/docs/en/solutions/CoreDNS_pods_crashloop_with_Wrong_argument_count_parsing_error.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# CoreDNS pods crashloop with "Wrong argument count" parsing error
+
 ## Issue
 
 DNS pods enter `CrashLoopBackOff`. The pod log includes a Corefile

--- a/docs/en/solutions/Deploy_a_Throwaway_SMTP_Sink_to_Test_Alertmanager_Email_Receiver_Configuration.md
+++ b/docs/en/solutions/Deploy_a_Throwaway_SMTP_Sink_to_Test_Alertmanager_Email_Receiver_Configuration.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Deploy a Throwaway SMTP Sink to Test Alertmanager Email Receiver Configuration
+
 ## Issue
 
 When wiring up an Alertmanager email receiver (`smtp_smarthost`, `smtp_auth_username`, `smtp_from`, `smtp_require_tls`, etc.) the actual delivery path runs through corporate relays, anti-spam filters, and TLS chains that may quarantine, silently drop, or rate-limit the test alert. A failed delivery in any of those layers makes it hard to tell whether the misconfiguration is in Alertmanager, in the relay, or in the recipient mailbox. A disposable in-cluster SMTP sink lets the operator verify the Alertmanager pipeline end-to-end before swapping the smarthost back to the production relay.

--- a/docs/en/solutions/Exposing_cert_manager_Metrics_to_Namespace_Scoped_Users_via_User_Workload_Monitoring.md
+++ b/docs/en/solutions/Exposing_cert_manager_Metrics_to_Namespace_Scoped_Users_via_User_Workload_Monitoring.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500004
 ---
+
+# Exposing cert-manager Metrics to Namespace-Scoped Users via User Workload Monitoring
+
 ## Issue
 
 A namespace-scoped user, granted access only to a single project, cannot view the `certmanager_certificate_expiration_timestamp_seconds` metric (or any other cert-manager metric) even though User Workload Monitoring is enabled on the cluster. The same query works for a cluster-monitoring user.

--- a/docs/en/solutions/Generate_a_New_kubeconfig_for_ACP_Cluster_Access.md
+++ b/docs/en/solutions/Generate_a_New_kubeconfig_for_ACP_Cluster_Access.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Generate a New kubeconfig for ACP Cluster Access
+
 ## Issue
 
 A platform administrator needs a fresh `kubeconfig` for an Alauda Container Platform cluster — for handing access to a new automation system, replacing a leaked file, or rotating a long-lived credential. Directly revoking the contents of an existing kubeconfig is risky because the same file may be shared by system components, CI jobs, or other administrators; instead the supported workflow is to mint a new credential and retire the old one in a controlled fashion.

--- a/docs/en/solutions/Generating_an_emergency_admin_kubeconfig_via_CertificateSigningRequest.md
+++ b/docs/en/solutions/Generating_an_emergency_admin_kubeconfig_via_CertificateSigningRequest.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Generating an emergency admin kubeconfig via CertificateSigningRequest
+
 ## Issue
 
 The original administrator kubeconfig produced at install time can be lost, leaked, or fail with `x509: certificate signed by unknown authority` after a control-plane CA rotation. When that happens — and the operator no longer has any working cluster-admin path through the OIDC / OAuth identity provider — the cluster still has to be reachable.

--- a/docs/en/solutions/Identifying_Which_Client_Deleted_a_Node_Object_Using_Kubernetes_Audit_Logs.md
+++ b/docs/en/solutions/Identifying_Which_Client_Deleted_a_Node_Object_Using_Kubernetes_Audit_Logs.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500003
 ---
+
+# Identifying Which Client Deleted a Node Object Using Kubernetes Audit Logs
+
 ## Issue
 
 A worker node disappears from the cluster shortly after it joined, or vanishes during steady-state operation. `kubectl get nodes` no longer lists it, the kubelet on the host is healthy and continues to make heartbeat calls (which now create the node again under the same name and the cycle repeats), and there is no obvious controller status condition that explains the deletion.

--- a/docs/en/solutions/Issuing_TLS_Certificates_for_In_Cluster_Services_with_cert_manager.md
+++ b/docs/en/solutions/Issuing_TLS_Certificates_for_In_Cluster_Services_with_cert_manager.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500007
 ---
+
+# Issuing TLS Certificates for In-Cluster Services with cert-manager
+
 ## Overview
 
 Applications running in the cluster increasingly require TLS for service-to-service traffic: mesh sidecars, user-facing gateways, database drivers with `sslmode=verify-full`, and compliance-driven policies that disallow plaintext between pods. Operators want this to be automatic — certificates issued per service, rotated before expiry, and trustable by other workloads without hand-distributing CA bundles.

--- a/docs/en/solutions/Merge_Multiple_Image_Pull_Secrets_Into_a_Single_Kubernetes_Docker_Config_Secret.md
+++ b/docs/en/solutions/Merge_Multiple_Image_Pull_Secrets_Into_a_Single_Kubernetes_Docker_Config_Secret.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Merge Multiple Image Pull Secrets Into a Single Kubernetes Docker-Config Secret
+
 ## Issue
 
 A workload needs to pull container images from more than one private registry (for example a public mirror, a vendor registry, and a team-internal Harbor). Each registry exposes its own credentials in a separate `~/.docker/config.json`-style file. Kubernetes accepts only one `imagePullSecrets` entry at a time per ServiceAccount default, and even when several are listed, supplying many secrets adds operational noise.

--- a/docs/en/solutions/MutatingAdmissionWebhook_Timeout_During_Pod_Creation.md
+++ b/docs/en/solutions/MutatingAdmissionWebhook_Timeout_During_Pod_Creation.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# MutatingAdmissionWebhook Timeout During Pod Creation
+
 ## Issue
 
 The Kubernetes API server reports that a MutatingAdmissionWebhook fails to complete its mutation within the 13-second deadline:

--- a/docs/en/solutions/Namespace_Stuck_in_Terminating_Due_to_Lingering_Finalizers.md
+++ b/docs/en/solutions/Namespace_Stuck_in_Terminating_Due_to_Lingering_Finalizers.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500012
 ---
+
+# Namespace Stuck in Terminating Due to Lingering Finalizers
+
 ## Issue
 
 A namespace has been deleted but remains visible in `kubectl get ns` with the phase `Terminating`. The usual follow-up command lists no workload resources in the namespace, yet the namespace object itself refuses to go away:

--- a/docs/en/solutions/Navigating_Kubernetes_API_deprecations_and_removals.md
+++ b/docs/en/solutions/Navigating_Kubernetes_API_deprecations_and_removals.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500011
 ---
+
+# Navigating Kubernetes API deprecations and removals
+
 ## Overview
 
 Kubernetes follows a strict API versioning policy. Every beta API (`v1beta1`, `v2beta1`, and so on) is guaranteed to be supported for nine months or three Kubernetes releases — whichever is longer — after it is marked deprecated, and is then free to be removed from the server entirely. When that removal happens, any workload, controller, tool or pipeline that still talks to the old version stops working.

--- a/docs/en/solutions/Newly_added_node_stays_NotReady_with_No_CNI_configuration_file.md
+++ b/docs/en/solutions/Newly_added_node_stays_NotReady_with_No_CNI_configuration_file.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Newly added node stays NotReady with "No CNI configuration file
+
 ## Issue
 
 A new worker is added to the cluster but the node never transitions from `NotReady` to `Ready`. The kubelet on the affected node reports:

--- a/docs/en/solutions/Pod_fails_to_mount_Ceph_RBD_volume_with_is_still_being_used.md
+++ b/docs/en/solutions/Pod_fails_to_mount_Ceph_RBD_volume_with_is_still_being_used.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500009
 ---
+
+# Pod fails to mount Ceph RBD volume with "is still being used
+
 ## Issue
 
 A pod backed by a ReadWriteOnce Ceph RBD PVC fails to start. The kubelet reports:

--- a/docs/en/solutions/Protecting_Identity_Infrastructure_From_DNS_Burst_Storms_in_Cloud_Native_Clusters.md
+++ b/docs/en/solutions/Protecting_Identity_Infrastructure_From_DNS_Burst_Storms_in_Cloud_Native_Clusters.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500006
 ---
+
+# Protecting Identity Infrastructure From DNS Burst Storms in Cloud-Native Clusters
+
 ## Overview
 
 Migrating workloads from a small fleet of virtual machines to a high-density Kubernetes cluster changes the shape of the DNS traffic an upstream identity / DNS service has to absorb. A steady, low-rate stream of recursive queries is replaced by parallel bursts: a single Deployment that scales out by a few hundred pods, or a node that drains and reschedules its workload, can issue thousands of resolution requests within milliseconds.

--- a/docs/en/solutions/Sending_namespace_scoped_Prometheus_alerts_to_email_via_AlertmanagerConfig.md
+++ b/docs/en/solutions/Sending_namespace_scoped_Prometheus_alerts_to_email_via_AlertmanagerConfig.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Sending namespace-scoped Prometheus alerts to email via AlertmanagerConfig
+
 ## Issue
 
 A namespace owner has authored a `PrometheusRule` in their own namespace and the rule is firing — `kubectl get prometheusrule` shows the alert in `Firing` state and the user-workload Alertmanager web UI lists it. But the configured email recipient never sees a notification. The cluster's platform-side Alertmanager only forwards alerts whose routing tree has been wired up; alerts from a workload namespace need their own routing tree, exposed through the namespace-scoped `AlertmanagerConfig` CRD that the Prometheus operator stack supports for user-workload monitoring.

--- a/docs/en/solutions/Understanding_Kubernetes_event_TTL_and_how_to_retain_events_longer.md
+++ b/docs/en/solutions/Understanding_Kubernetes_event_TTL_and_how_to_retain_events_longer.md
@@ -7,6 +7,9 @@ ProductsVersion:
    - 4.1.0,4.2.x
 id: KB260500001
 ---
+
+# Understanding Kubernetes event TTL and how to retain events longer
+
 ## Overview
 
 Kubernetes records every meaningful state change as an `Event` object. An event holds context about who created or mutated a resource, what controller acted on it, and why; together they are the primary breadcrumb trail for debugging scheduling, image pulls, probe failures, OOMs, and reconciliation loops. Because every reconciliation cycle of every controller can emit one or more events, the event volume far outpaces ordinary resource churn — often by an order of magnitude on a busy cluster.

--- a/docs/en/solutions/Updating_a_NetworkAttachmentDefinitions_specconfig_JSON_Safely.md
+++ b/docs/en/solutions/Updating_a_NetworkAttachmentDefinitions_specconfig_JSON_Safely.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Updating a NetworkAttachmentDefinition's `spec.config` JSON Safely
+
 ## Issue
 
 A `NetworkAttachmentDefinition` (NAD) needs to have one of its configuration parameters changed — for example, switching the CNI plugin `type` from `bridge` to `cnv-bridge` so VMs on ACP Virtualization can share the same underlying host bridge through KubeVirt's MAC-spoof / VLAN-preservation extensions, or adjusting a VLAN tag, MTU, or IPAM block without recreating the NAD object.

--- a/docs/en/solutions/Velero_includedNamespaces_Does_Not_Support_Wildcards_or_Regex.md
+++ b/docs/en/solutions/Velero_includedNamespaces_Does_Not_Support_Wildcards_or_Regex.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Velero includedNamespaces Does Not Support Wildcards or Regex
+
 ## Issue
 
 A backup or restore on the ACP backup surface (`configure/backup`, which packages the upstream Velero project) is declared with a glob pattern in `spec.includedNamespaces`:

--- a/docs/en/solutions/Why_authenticated_users_can_view_the_KubeVirt_OS_images_namespace.md
+++ b/docs/en/solutions/Why_authenticated_users_can_view_the_KubeVirt_OS_images_namespace.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# Why authenticated users can view the KubeVirt OS-images namespace
+
 ## Overview
 
 A standard rule of multi-tenant clusters is that namespaces are isolated by default — an authenticated user without explicit permission cannot list resources in a namespace they do not own. KubeVirt-based virtualization stacks intentionally break that rule for one specific namespace: the namespace that holds the curated OS boot-source images (the DataVolumes / DataSources / PVCs cloned to back new VMs).

--- a/docs/en/solutions/cert_manager_Fails_with_x509_invalid_certificate_policies_When_Parsing_a_Server_Certificate.md
+++ b/docs/en/solutions/cert_manager_Fails_with_x509_invalid_certificate_policies_When_Parsing_a_Server_Certificate.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# cert-manager Fails with "x509: invalid certificate policies" When Parsing a Server Certificate
+
 ## Issue
 
 `cert-manager` reports it cannot parse the certificate served by an `Issuer` endpoint (ACME server, CA webhook, remote `https://…` target) and logs an error of the form:

--- a/docs/en/solutions/etcd_rafthttp_reports_clock_difference_against_peer_is_too_high.md
+++ b/docs/en/solutions/etcd_rafthttp_reports_clock_difference_against_peer_is_too_high.md
@@ -6,6 +6,9 @@ products:
 ProductsVersion:
    - 4.1.0,4.2.x
 ---
+
+# etcd rafthttp reports clock difference against peer is too high
+
 ## Issue
 
 The etcd pods on the control-plane nodes log repeated warnings of the form:


### PR DESCRIPTION
## Summary

The 30 solution articles already merged from prior incremental batches don't have a top-level H1 heading between their frontmatter and body. The rest of `docs/en/solutions/` (articles authored directly into the repo) does — readers see a human-readable title, GitHub previews and rendered markdown surface the title rather than the snake_case filename.

This PR adds an H1 (taken from the article's canonical `title` field) to each of the 30 files. Spaces, hyphens and quotation marks are preserved — i.e. the heading reads `# Auto-Approve Pending Node CSRs with a Scheduled Job`, not the underscore form.

## Files touched

30 under `docs/en/solutions/`. Diff is purely additive: 3 lines per file (blank line, `# Title`, blank line) right after the closing `---` of the frontmatter. No body content is changed.

## Test plan

- [ ] Skim a handful of touched files and confirm the H1 reads naturally
- [ ] Render preview on GitHub shows the H1 instead of the filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added 30+ troubleshooting guides and operational solutions covering Kubernetes API operations, certificate management, cluster diagnostics, node management, etcd optimization, container networking, monitoring and alerting, DNS resilience, and API deprecation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->