### PR TITLE
audit r2: 2 篇 merged 文章 cpaas-monitoring → cpaas-system

### DIFF
--- a/docs/en/solutions/Sending_namespace_scoped_Prometheus_alerts_to_email_via_AlertmanagerConfig.md
+++ b/docs/en/solutions/Sending_namespace_scoped_Prometheus_alerts_to_email_via_AlertmanagerConfig.md
@@ -9,7 +9,6 @@ id: KB260500021
 ---
 
 # Sending namespace-scoped Prometheus alerts to email via AlertmanagerConfig
-
 ## Issue
 
 A namespace owner has authored a `PrometheusRule` in their own namespace and the rule is firing — `kubectl get prometheusrule` shows the alert in `Firing` state and the user-workload Alertmanager web UI lists it. But the configured email recipient never sees a notification. The cluster's platform-side Alertmanager only forwards alerts whose routing tree has been wired up; alerts from a workload namespace need their own routing tree, exposed through the namespace-scoped `AlertmanagerConfig` CRD that the Prometheus operator stack supports for user-workload monitoring.
@@ -27,13 +26,15 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cluster-monitoring-config
-  namespace: cpaas-monitoring
+  namespace: cpaas-system
 data:
   config.yaml: |
     enableUserWorkload: true
     alertmanagerMain: {}
     prometheusK8s: {}
 ```
+
+Note: ACP's monitoring stack runs in `cpaas-system` (the platform's `kube-prometheus` chart). On clusters where the user-workload Prometheus is packaged differently, substitute the namespace and ConfigMap name accordingly — `kubectl get prometheus -A` lists the actual instances.
 
 Apply, then confirm the user-workload Prometheus and Alertmanager StatefulSets are scheduled:
 

--- a/docs/en/solutions/Understanding_Kubernetes_event_TTL_and_how_to_retain_events_longer.md
+++ b/docs/en/solutions/Understanding_Kubernetes_event_TTL_and_how_to_retain_events_longer.md
@@ -9,7 +9,6 @@ id: KB260500001
 ---
 
 # Understanding Kubernetes event TTL and how to retain events longer
-
 ## Overview
 
 Kubernetes records every meaningful state change as an `Event` object. An event holds context about who created or mutated a resource, what controller acted on it, and why; together they are the primary breadcrumb trail for debugging scheduling, image pulls, probe failures, OOMs, and reconciliation loops. Because every reconciliation cycle of every controller can emit one or more events, the event volume far outpaces ordinary resource churn — often by an order of magnitude on a busy cluster.
@@ -173,9 +172,12 @@ If leader elections are firing more than once an hour, fix the etcd health (disk
 For a deeper look at event volume over time, the apiserver `apiserver_request_total{resource="events"}` counter shows how many event writes the apiserver is taking — useful to size `--event-ttl` against expected steady-state load:
 
 ```bash
-kubectl -n cpaas-monitoring exec deploy/prometheus-cluster-monitoring -- \
-  promtool query instant http://localhost:9090 \
-  'sum by (verb) (rate(apiserver_request_total{resource="events"}[5m]))'
+# On ACP the Prometheus pod is a StatefulSet replica named
+# prometheus-kube-prometheus-0-0 in cpaas-system; the prometheus
+# container is distroless and has no shell/promtool — query through
+# the apiserver proxy instead.
+kubectl get --raw \
+  '/api/v1/namespaces/cpaas-system/services/kube-prometheus:9090/proxy/api/v1/query?query=sum+by+(verb)+(rate(apiserver_request_total%7Bresource%3D%22events%22%7D%5B5m%5D))'
 ```
 
 If event-creation rate × `--event-ttl` exceeds available etcd headroom, raising the TTL is the wrong fix — fan out to the log store via eventrouter instead.


### PR DESCRIPTION
## Summary

第二轮 re-audit 已 merged 文章时找到 2 篇引用了不存在的 `cpaas-monitoring` ns（ACP 平台 Prometheus 在 `cpaas-system` 里，名为 `kube-prometheus`；用户负载 Prometheus 没有单独 deployment）。

| 关联 merged PR | 文件 | 修正 |
|---|---|---|
| #595 | `Understanding_Kubernetes_event_TTL_and_how_to_retain_events_longer.md` | `kubectl -n cpaas-monitoring exec deploy/prometheus-cluster-monitoring -- promtool query` 改走 apiserver proxy（prometheus 容器是 distroless，没 promtool/curl） |
| #600 | `Sending_namespace_scoped_Prometheus_alerts_to_email_via_AlertmanagerConfig.md` | ConfigMap 的 namespace `cpaas-monitoring` → `cpaas-system` + 说明 ACP 监控栈位置 |

## Why

承接 #747（第一轮 9 篇 merged 修复）和 GOLD/SOLID 36 篇 OPEN 修复，按"实际抄 article body 命令到集群跑"标准继续覆盖。这 2 篇之前因为 grep 没扫到 chroot/registry 三件套漏过去了；本轮针对 `cpaas-monitoring` / 自定义 namespace 假设单独扫了一遍。

## Test plan

- [x] 每篇改动后过 `publish.py _outbound_gate`（无品牌/源追溯）
- [x] frontmatter `id: KBxxxxxx` 通过 `publish.existing_target_id_on_main` 保留（修复了第一轮 #747 暴露的 systemic bug）
- [ ] reviewer：抄一两条新写法（apiserver proxy `query` 路径）到 ACP 集群跑一遍，确认输出符合文章描述

🤖 Generated with [Claude Code](https://claude.com/claude-code)
