### PR TITLE
docs(vmware-migration): add TCP 443/902 port requirements

### DIFF
--- a/docs/en/solutions/How_to_Migrate_VirtualMachine_From_VMware.md
+++ b/docs/en/solutions/How_to_Migrate_VirtualMachine_From_VMware.md
@@ -33,6 +33,7 @@ ESXi Version: >= 6.7.0
   - The ESXi hostname must be resolvable (via DNS or CoreDNS override).
   - The SSH service must be enabled on the ESXi host.
   - VMware Tools must be installed in the guest VM.
+  - Network connectivity: TCP ports **443** and **902** must be open on the VMware side to allow access from KubeVirt (ACP cluster nodes). Port 443 is used for the vCenter/ESXi API (SDK, NBDSSL disk transport) and port 902 is used for NBD disk transport to ESXi.
 - **Mechanism Note**: Forklift builds migration pods using ESXi hostnames to construct the `V2V_libvirtURL` and connects via `esx://` over SSH to retrieve disk images.
 
 ## Terminology

--- a/docs/zh/solutions/How_to_Migrate_VirtualMachine_From_VMware.md
+++ b/docs/zh/solutions/How_to_Migrate_VirtualMachine_From_VMware.md
@@ -6,7 +6,7 @@ products:
 ProductsVersion:
   - 4.2.x
 id: KB260100011
-sourceSHA: 5b1dc55fae4516a6851fd14d0f3a264348f5c8ef1c8d0d6c0bf62626147f70fa
+sourceSHA: 5475b2fa63cd603660007fb15debd934d52bcb854a295cbf51702e4dd190ddaf
 ---
 
 # 将 VMware 虚拟机迁移到 Alauda 容器平台虚拟化
@@ -34,6 +34,7 @@ ESXi 版本：>= 6.7.0
   - ESXi 主机名必须可解析（通过 DNS 或 CoreDNS 覆盖）。
   - ESXi 主机上必须启用 SSH 服务。
   - 客户端虚拟机中必须安装 VMware Tools。
+  - 网络连通性：VMware 侧必须开放 TCP 端口 **443** 和 **902**，以允许来自 KubeVirt（ACP 集群节点）的访问。443 用于 vCenter/ESXi API（SDK、磁盘传输 NBDSSL），902 用于 ESXi 的 NBD 磁盘传输。
 - **机制说明**：Forklift 使用 ESXi 主机名构建迁移 Pod，以构造 `V2V_libvirtURL`，并通过 SSH 以 `esx://` 连接以检索磁盘映像。
 
 ## 术语


### PR DESCRIPTION
## Summary
- 在 VMware 迁移文档（中英文）的 Prerequisites 部分补充网络连通性要求：VMware 侧需开放 TCP 443 与 902
- 443 用于 vCenter/ESXi API（SDK、NBDSSL 磁盘传输），902 用于 ESXi 的 NBD 磁盘传输

## Test plan
- [ ] 渲染检查中英文文档新增条目格式正确
- [ ] 校对 sourceSHA 一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated VMware-to-ACP migration guides (English and Chinese) to include a new network connectivity prerequisite: TCP ports 443 and 902 must be opened between VMware and KubeVirt cluster nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->