### PR TITLE
docs: add Redis solution articles ported from internal Confluence

### DIFF
--- a/docs/en/solutions/ecosystem/redis/Backup_Restore_Template_Compatibility.md
+++ b/docs/en/solutions/ecosystem/redis/Backup_Restore_Template_Compatibility.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # Backup and Restore Compatibility With Parameter Templates

--- a/docs/en/solutions/ecosystem/redis/Backup_Restore_Template_Compatibility.md
+++ b/docs/en/solutions/ecosystem/redis/Backup_Restore_Template_Compatibility.md
@@ -1,0 +1,111 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# Backup and Restore Compatibility With Parameter Templates
+
+## Introduction
+
+Alauda Cache Service for Redis OSS supports two backup destinations and three persistence parameter templates. The combinations do not all interoperate — in particular, restoring an RDB-only backup into an instance configured with the AOF template will not load any data, because Redis prefers AOF on startup when both are available.
+
+This article describes the compatibility matrices and provides a manual workaround for the AOF restore case until the operator supports automatic format conversion.
+
+## Backup Destinations
+
+The platform supports two backup methods:
+
+- **PVC-based backup.** Files are copied to a `PersistentVolumeClaim` and managed alongside the source instance.
+- **S3-based backup.** Files are uploaded to an external S3-compatible object store managed by the platform Backup Center.
+
+## Compatibility Matrices
+
+### PVC Backup — Data Format by Redis Version and Template
+
+| Redis version | RDB template | AOF template (5/6) | Diskless template (5/6) |
+| --- | --- | --- | --- |
+| 5.0 | RDB | RDB / AOF | RDB |
+| 6.0 | RDB | RDB / AOF | RDB |
+| 7.2 | RDB | RDB | RDB |
+
+### S3 Backup — Data Format by Redis Version and Template
+
+| Redis version | RDB template | AOF template (5/6) | Diskless template (5/6) |
+| --- | --- | --- | --- |
+| 5.0 | RDB | RDB | RDB |
+| 6.0 | RDB | RDB | RDB |
+| 7.2 | RDB | RDB | RDB |
+
+:::note
+S3 backups always store the dataset in **RDB** format regardless of which parameter template is in use on the source instance. PVC backups capture both files (RDB and AOF) when the AOF template is used on Redis 5.0 or 6.0.
+:::
+
+### How Redis Loads Data on Startup
+
+Redis decides what to load based on the active configuration:
+
+| Configuration | RDB | AOF |
+| --- | :---: | :---: |
+| `save` enabled (RDB only) | Loaded | — |
+| `appendonly yes` (AOF only) | — | Loaded |
+| Both `save` and `appendonly yes` | — | Loaded |
+| Neither configured | Loaded | — |
+
+The implication is that **when AOF is enabled, Redis loads the AOF file and ignores the RDB file**.
+
+## The AOF Restore Problem
+
+Combining the two tables above shows the problematic case:
+
+> **Restoring an RDB-only backup into an instance configured with the AOF parameter template results in no data being loaded.**
+
+This happens because:
+
+1. The backup contains only `dump.rdb`.
+2. The new instance starts with `appendonly yes`, so Redis looks for `appendonly.aof` and ignores the RDB file.
+3. With no AOF file present, Redis starts with an empty dataset.
+
+## Workaround
+
+Until the operator supports automatic RDB-to-AOF conversion at restore time, use the following two-step procedure to restore an RDB backup into an AOF-enabled instance:
+
+### 1. Create the Restore Instance With AOF Disabled
+
+When you create the new Redis instance for the restore, override the parameter template to set `appendonly: "no"`. This allows Redis to load `dump.rdb` on startup.
+
+For example, on a `RedisFailover` resource:
+
+```yaml
+spec:
+  redis:
+    customConfig:
+      appendonly: "no"
+    restore:
+      backupName: <backup-name>
+```
+
+### 2. Wait for Ready, Then Re-Enable AOF
+
+Once the instance reaches the `Ready` state and you have verified that the data has been loaded, switch `appendonly` back to `yes`.
+
+```yaml
+spec:
+  redis:
+    customConfig:
+      appendonly: "yes"
+```
+
+When `appendonly` is toggled at runtime, Redis writes a fresh AOF file from the in-memory dataset without restarting the process. Once the AOF file is generated, durability returns to AOF behavior.
+
+:::tip
+Verify the data is loaded (using `DBSIZE` and a few sample keys) **before** flipping `appendonly` back to `yes`. After the switch, the in-memory dataset is what gets persisted into the new AOF file.
+:::
+
+## Important Considerations
+
+- **Always treat RDB as the universal backup format.** Every backup destination supports RDB, so plan recovery procedures around RDB even when the source instance uses AOF.
+- **No data loss during the toggle.** Switching `appendonly` from `no` to `yes` does not restart Redis and does not flush the dataset.
+- **Plan downtime for AOF rewrite.** When AOF is re-enabled, Redis writes the entire dataset to disk. On large datasets this can briefly increase disk and CPU usage.
+- **Future improvement.** A future release of the operator will perform format conversion automatically so this workaround will no longer be necessary.

--- a/docs/en/solutions/ecosystem/redis/How_to_Add_Custom_Redis_Commands.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Add_Custom_Redis_Commands.md
@@ -3,6 +3,8 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
 ---
 
 # How to Add Custom Commands to a Redis Instance

--- a/docs/en/solutions/ecosystem/redis/How_to_Add_Custom_Redis_Commands.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Add_Custom_Redis_Commands.md
@@ -1,0 +1,78 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# How to Add Custom Commands to a Redis Instance
+
+## Introduction
+
+By default, Alauda Cache Service for Redis OSS disables some Redis commands that are considered dangerous (for example, `KEYS`, `FLUSHDB`, `FLUSHALL`, `CONFIG`). When an application requires one of these commands and fails to start because the command is unavailable, you can enable specific commands on the Redis instance.
+
+:::tip Use ACL on the current operator
+On **redis-operator 3.15+ with Redis 6.0+** (the default since 3.18), the supported way to enable previously-disabled commands is the **default user's ACL rule**, not `customConfig`. See [How to Manage Dangerous Redis Commands](./How_to_Manage_Dangerous_Redis_Commands.md) for the ACL procedure (Method 1). The `rename-command` / `customConfig` approach below is for **legacy operator versions (`<= 3.15`) or Redis `< 6.0`**.
+:::
+
+This guide describes two equivalent ways to add commands on legacy versions: via the web console UI and by editing the Redis custom resource directly.
+
+:::info Applicable Version
+This guide (rename-command via customConfig): redis-operator `> 3.10.3` and `<= 3.15`. For `>= 3.18` use ACL instead.
+:::
+
+:::warning
+Editing `customConfig` (in either method below) triggers a **rolling restart of the Redis data pods** — the change is not hot-reloaded. Schedule the change in a maintenance window if your workload cannot tolerate a brief disconnect.
+:::
+
+## Prerequisites
+
+- A running Redis instance managed by the Redis Operator.
+- Permission to edit the instance from the web console or via `kubectl`.
+
+## Procedure
+
+### Option 1: Edit via the Web Console
+
+1. Navigate to the Redis instance details page.
+2. Open the **Parameter Configuration** (or equivalent) section.
+3. Locate the disabled-commands list and remove (or add to the allowlist) the commands required by your application.
+4. Save the change.
+
+The operator reconciles the instance and restarts the relevant pods.
+
+### Option 2: Edit the Redis Custom Resource
+
+Edit the Redis CR directly:
+
+```bash
+kubectl -n <namespace> edit redis <instance-name>
+```
+
+The operator's default config disables commands by mapping them to the empty string via `rename-command`. To re-enable a previously-disabled command, rename it to itself; to disable a new one, map it to the empty string.
+
+```yaml
+apiVersion: middleware.alauda.io/v1
+kind: Redis
+metadata:
+  name: <instance-name>
+  namespace: <namespace>
+spec:
+  customConfig:
+    # Re-enable flushall (renames flushall to flushall, overriding the default disable);
+    # rename debug to a hard-to-guess alias; disable set entirely.
+    rename-command: 'flushall flushall debug abc123 set ""'
+```
+
+Save the file. The operator picks up the change and restarts the Redis pods.
+
+:::note
+Each entry in `rename-command` is a `<original> <replacement>` pair, separated by spaces. Use `""` as the replacement to fully disable a command. Multiple entries in a single string are supported.
+:::
+
+## Important Considerations
+
+- Both methods cause the Redis pods to restart. Schedule the change in a maintenance window if your workload cannot tolerate a brief disconnect.
+- Enabling dangerous commands (such as `FLUSHALL`, `KEYS`, or `CONFIG`) increases operational risk. Re-disable them once your application no longer requires them.
+- On **operator 3.15+ with Redis 6.0+** prefer ACL — see the cross-reference at the top of this page. `rename-command` is retained for older instances.
+- The exact custom-config keys and UI labels may differ slightly between Operator versions; consult the Operator documentation that matches your installed version for the precise key names.

--- a/docs/en/solutions/ecosystem/redis/How_to_Cleanup_Invalid_Cluster_Nodes.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Cleanup_Invalid_Cluster_Nodes.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # Cleanup Invalid Redis Cluster Nodes

--- a/docs/en/solutions/ecosystem/redis/How_to_Cleanup_Invalid_Cluster_Nodes.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Cleanup_Invalid_Cluster_Nodes.md
@@ -1,0 +1,114 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# Cleanup Invalid Redis Cluster Nodes
+
+## Introduction
+
+In environments where pod IPs change after a restart - notably when using a CNI such as **Calico** that does not preserve pod IPs - a Redis Cluster may accumulate orphaned node entries. Each surviving node still tracks the cluster's previous topology by node ID and IP, and these stale entries are not always cleaned up automatically.
+
+Symptoms include:
+
+- The `/data/nodes.conf` file inside a Redis pod contains entries with `fail` status.
+- `CLUSTER NODES` lists entries with `fail` status whose IPs no longer belong to any current pod.
+
+This guide explains how to identify and remove those orphaned entries.
+
+:::note Auto-cleanup on current operator
+On **redis-operator 3.18+** the controller reconciles cluster membership during pod restarts and cleans up most stale entries automatically. The manual procedure below is intended as a **fallback** for cases where the orphan persists (for example, multiple simultaneous IP recycles or an operator outage during recovery). On legacy operator versions (`<= 3.16`) this is the routine recovery path.
+:::
+
+:::tip Related
+For removing a single failed node where the IP and node ID are known, see [Manually Remove Failed Redis Cluster Nodes](./How_to_Manually_Remove_Failed_Cluster_Nodes.md).
+:::
+
+## Prerequisites
+
+1. `kubectl` access to the namespace running the Redis Cluster.
+2. The Redis password.
+3. `redis-cli` access either inside a Redis pod or from a host that can reach all Redis pods.
+
+## Procedure
+
+### 1. Identify Stale Entries
+
+For each Redis pod in the StatefulSet, list the cluster topology:
+
+```bash
+kubectl -n <namespace> exec -it <redis-pod> -- \
+  redis-cli -a '<password>' cluster nodes
+```
+
+Build a list of the **current** pod IPs:
+
+```bash
+kubectl -n <namespace> get pod -l <selector-for-redis> -o wide
+```
+
+Apply the following decision rules to each entry returned by `CLUSTER NODES`:
+
+| Entry state | Action |
+|------------|--------|
+| Status is healthy and IP belongs to a current pod | Keep |
+| Status is `fail` or `pfail`, and IP is **not** the IP of any current pod | **Remove** with `CLUSTER FORGET` |
+| Status is abnormal but IP **does** match a current pod | Do **not** forget. Investigate the pod first. |
+| Status is `disconnected` and there is no IP recorded | **Remove** with `CLUSTER FORGET` |
+
+### 2. Remove the Stale Entries
+
+For every stale entry, run `CLUSTER FORGET` on every healthy node:
+
+```bash
+redis-cli -h <healthy-node-ip> -a '<password>' cluster forget <stale-node-id>
+```
+
+The `<stale-node-id>` is the first column of the `CLUSTER NODES` output for the entry to be removed.
+
+:::warning Run on All Healthy Nodes Within 60 Seconds
+Cluster nodes gossip their topology to each other. If you only forget a node on some peers, the surviving peers will re-announce it and the entry will reappear. `CLUSTER FORGET` blacklists the target for 60 seconds; you must execute it against all healthy nodes within that window.
+:::
+
+A simple shell loop covers this. From a host that can reach all pods:
+
+```bash
+HEALTHY_IPS=(<ip-1> <ip-2> <ip-3> <ip-4> <ip-5>)
+STALE_ID=<stale-node-id>
+PASSWORD=<password>
+
+for ip in "${HEALTHY_IPS[@]}"; do
+  redis-cli -h "$ip" -a "$PASSWORD" cluster forget "$STALE_ID"
+done
+```
+
+Repeat for each stale node ID.
+
+### 3. Verify
+
+After cleanup, confirm the cluster state:
+
+```bash
+redis-cli -h <node-ip> -a '<password>' cluster info
+redis-cli -h <node-ip> -a '<password>' cluster nodes
+```
+
+`cluster_state:ok` and a `cluster_known_nodes` count that matches the actual pod count indicate the cleanup is complete. The `nodes.conf` file inside each pod should also no longer reference the removed IDs.
+
+## Important Considerations
+
+### Do Not Forget Entries Whose IP Belongs to a Live Pod
+
+If an abnormal entry's IP matches a current pod, the right fix is to investigate that pod (CNI issue, network partition, replication lag) rather than forget the node. Forgetting it would split the live pod from the cluster's view temporarily.
+
+### Apply To Healthy Nodes Only
+
+Always invoke `CLUSTER FORGET` from a healthy node's perspective. Sending the command to the failing node itself does nothing useful and risks confusing the cluster.
+
+### Why This Happens With Calico
+
+Calico assigns a fresh IP from its pool when a pod restarts. The previous IP enters Calico's recycle pool but the cluster's gossip view still references the old IP under the old node ID. Until the entry is forgotten cluster-wide, it lingers as a stale `fail` record.
+
+For environments where this becomes routine, consider using a CNI plugin that supports IP preservation across pod restarts (for example Kube-OVN with persistent pod IPs).

--- a/docs/en/solutions/ecosystem/redis/How_to_Configure_Redis_MaxMemory.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Configure_Redis_MaxMemory.md
@@ -1,0 +1,92 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# How to Configure Redis MaxMemory
+
+## Introduction
+
+By default, the Redis Operator sets the Redis `maxmemory` directive to approximately **80%** of the container memory limit. The remaining 20% acts as a safety margin so the container is not OOM-killed by spikes in non-data memory usage (replication buffers, COW during persistence, client buffers, etc.).
+
+For a Redis instance configured with 1 CPU and 2 GiB memory, this typically results in a `maxmemory` of around 1.6 GiB, as visible from `INFO memory`:
+
+```
+maxmemory:1717986918
+maxmemory_human:1.60G
+```
+
+In some cases you may need to override this default — for example, to free more memory for the safety margin on smaller pods, or to dedicate more memory to data on larger pods. This guide describes how to override the operator's default calculation.
+
+:::info Applicable Version
+redis-operator 3.12 and later (the technique is also valid on current versions of the operator)
+:::
+
+## Prerequisites
+
+- A running Redis instance managed by the Redis Operator.
+- Permission to edit the instance via the web console or `kubectl`.
+
+## Procedure
+
+There are two ways to change `maxmemory` on a running instance.
+
+### Option 1: Runtime Override (Temporary)
+
+Connect to the Redis pod and use `CONFIG SET`:
+
+```bash
+redis-cli -h <host> -p 6379 -a <password> CONFIG SET maxmemory <bytes>
+```
+
+For example, set `maxmemory` to 1 GiB:
+
+```bash
+redis-cli CONFIG SET maxmemory 1073741824
+```
+
+:::warning
+This change is **temporary**. It is lost when the pod restarts because the operator regenerates the Redis configuration from the CR on each reconcile.
+:::
+
+### Option 2: Persistent Override via `customConfig` (Recommended)
+
+Add a `maxmemory` entry under `spec.customConfig` of the Redis CR. This change is persisted by the operator and survives pod restarts.
+
+#### Edit via the Web Console
+
+1. Navigate to the Redis instance details page.
+2. Open the **Parameter Configuration** (or equivalent) section.
+3. Add or update the `maxmemory` parameter with the desired value.
+4. Save the change.
+
+#### Edit the CR Directly
+
+```bash
+kubectl -n <namespace> edit redis <instance-name>
+```
+
+Add `maxmemory` under `spec.customConfig`:
+
+```yaml
+apiVersion: middleware.alauda.io/v1
+kind: Redis
+metadata:
+  name: <instance-name>
+  namespace: <namespace>
+spec:
+  customConfig:
+    maxmemory: "1073741824"   # 1 GiB, expressed in bytes (or "1gb" if your operator version supports unit suffixes)
+    # ... other custom-config entries
+```
+
+The operator reconciles the change on the running pods. The new `maxmemory` is applied immediately without requiring a pod restart on supported versions; older operator releases may restart the pod.
+
+## Important Considerations
+
+- Always leave headroom for non-data memory. Setting `maxmemory` equal to the container's memory limit will cause the container to be OOM-killed under load.
+- The recommended ratio is roughly 70–80% of the container memory limit for `maxmemory`. Adjust based on your replication, persistence, and connection load.
+- When you change the container `resources.limits.memory`, also re-evaluate your `maxmemory` setting.
+- Use `INFO memory` from `redis-cli` to verify the actual `maxmemory` and `used_memory` after the change.

--- a/docs/en/solutions/ecosystem/redis/How_to_Configure_Redis_MaxMemory.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Configure_Redis_MaxMemory.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # How to Configure Redis MaxMemory

--- a/docs/en/solutions/ecosystem/redis/How_to_Connect_to_Redis_Sentinel_with_Navicat.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Connect_to_Redis_Sentinel_with_Navicat.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # Connect to a Redis Sentinel Cluster with Navicat

--- a/docs/en/solutions/ecosystem/redis/How_to_Connect_to_Redis_Sentinel_with_Navicat.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Connect_to_Redis_Sentinel_with_Navicat.md
@@ -1,0 +1,76 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# Connect to a Redis Sentinel Cluster with Navicat
+
+## Introduction
+
+This guide describes how to use the Navicat client to connect to an Alauda Cache Service for Redis OSS instance running in Sentinel mode. The procedure covers connection settings, sentinel authentication options, and timeout configuration.
+
+:::info Sentinel Password Support
+- On platform versions **<= 3.16**, Sentinel password authentication is **not** supported. The Sentinel side must be configured as `None`.
+- On platform versions **>= 3.18**, Sentinel password authentication **is** supported. Use `Password` if a Sentinel password has been configured for the instance; otherwise use `None`.
+:::
+
+## Prerequisites
+
+- The Redis Sentinel instance must have **NodePort** external access enabled.
+- The host running Navicat must be able to reach the NodePort IP and port of every Sentinel node in the instance.
+- A copy of Navicat (Premium or Navicat for Redis) installed on your workstation.
+- The Redis password and, if applicable on platform >= 3.18, the Sentinel password.
+
+## Procedure
+
+### 1. Open Navicat and Create a New Redis Connection
+
+In Navicat, choose **Connection** > **Redis** to open the new connection dialog.
+
+### 2. Configure the General Tab
+
+On the **General** tab, configure the Sentinel and group sections.
+
+#### Sentinel Section
+
+- **Type**: `Sentinel`
+- **Sentinel Host**: A NodePort-reachable address of one of the Sentinel nodes.
+- **Sentinel Port**: The matching NodePort for that Sentinel node.
+- **Sentinel Authentication**:
+  - On platform **<= 3.16**, select `None` (Sentinel password is not supported).
+  - On platform **>= 3.18**:
+    - Select `None` if no Sentinel password has been configured for the instance.
+    - Select `Password` and enter the Sentinel password if one has been configured.
+
+#### Group Section
+
+- **Group Name**: `mymaster` (the default master name on Alauda Redis Sentinel).
+- **Group Authentication**: `Password`
+- **Group Password**: The Redis password for the instance.
+
+### 3. Configure the Sentinel Tab
+
+On the **Sentinel** tab, enable **Use additional sentinels** and add the remaining Sentinel node addresses (host + NodePort) so that Navicat can fail over if the primary Sentinel becomes unavailable.
+
+### 4. Configure the Advanced Tab
+
+On the **Advanced** tab, set a non-zero **Connection Timeout**. Otherwise Navicat reports the following error:
+
+```
+With sentinel, connection timeout and socket timeout cannot be 0
+```
+
+A connection timeout of a few seconds (for example, 10 seconds) is sufficient for most environments.
+
+### 5. Test the Connection
+
+Click **Test Connection**. A success dialog confirms that Navicat can reach the Sentinels, resolve the current primary, and authenticate against it. Save the connection.
+
+## Important Considerations
+
+- **NodePort reachability** — Navicat must reach **every** Sentinel node, not just one. If the workstation can only see a subset of nodes, failover behavior in Navicat will be unreliable.
+- **Sentinel password version gate** — Configuring a Sentinel password on a platform version **<= 3.16** is not supported and will result in connection failures from any client, not only Navicat.
+- **Group name** — Always `mymaster` on the standard Alauda Redis Sentinel deployment unless the instance has been customized.
+- **Timeout requirement** — Sentinel-mode Navicat connections require a non-zero connection timeout; the default value of `0` is rejected with the error shown above.

--- a/docs/en/solutions/ecosystem/redis/How_to_Deploy_RedisInsight_Web_Console.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Deploy_RedisInsight_Web_Console.md
@@ -1,0 +1,232 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# How to Deploy the RedisInsight Web Console
+
+## Introduction
+
+RedisInsight is a graphical user interface for interacting with Redis databases. It supports key browsing, CRUD operations on standard data structures, JSON editing, slow log analysis, Pub/Sub, bulk operations, and a Workbench for advanced commands. This guide explains how to deploy RedisInsight 2.58 in a Kubernetes cluster and connect it to Sentinel and Cluster mode Redis instances.
+
+:::warning
+RedisInsight does not include built-in authentication or authorization. Once the service is exposed, anyone who can reach the URL can connect and operate on attached Redis instances. Restrict access at the network or load balancer layer.
+:::
+
+## Prerequisites
+
+- A Kubernetes cluster with `kubectl` access.
+- A working `StorageClass` for persistent storage.
+- The RedisInsight image available in your image registry. Pull `redis/redisinsight:2.58` from Docker Hub (`https://hub.docker.com/r/redis/redisinsight`) and push it to your private registry.
+
+## Procedure
+
+### 1. Prepare the Image
+
+Pull and push the RedisInsight image to your registry. Replace the `image` field in the deployment YAML with the registry-specific path if needed.
+
+### 2. Apply the Deployment YAML
+
+Save the following manifest as `redis-insight.yaml`. Adjust the `storageClassName` and resource limits as appropriate for your environment.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: redis-insight
+  name: redis-insight-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: <your-storage-class>
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: redis-insight
+  name: redis-insight
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis-insight
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis-insight
+    spec:
+      containers:
+        - env:
+            - name: RI_APP_PORT
+              value: "5540"
+            - name: RI_APP_HOST
+              value: "0.0.0.0"
+            - name: RI_ENCRYPTION_KEY
+              value: ""
+            - name: RI_LOG_LEVEL
+              value: info
+            - name: RI_FILES_LOGGER
+              value: "false"
+            - name: RI_STDOUT_LOGGER
+              value: "true"
+            - name: RI_PROXY_PATH
+              value: ""
+          image: redis/redisinsight:2.58
+          imagePullPolicy: IfNotPresent
+          name: web
+          ports:
+            - name: http
+              containerPort: 5540
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            httpGet:
+              path: /api/health/
+              port: http
+            timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: http
+            timeoutSeconds: 5
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            runAsNonRoot: true
+            runAsGroup: 1000
+          volumeMounts:
+            - mountPath: /data
+              name: redis-insight-data
+      restartPolicy: Always
+      securityContext:
+        fsGroup: 1000
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: redis-insight-data
+          persistentVolumeClaim:
+            claimName: redis-insight-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: redis-insight
+  name: redis-insight
+spec:
+  ports:
+    - name: http
+      port: 5540
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: redis-insight
+  type: NodePort
+```
+
+:::note
+The container, Pod port, and Service port are all set to **5540** (the RedisInsight default since 2.x). `targetPort: http` resolves to the named container port, so all three values stay aligned.
+:::
+
+Deploy the resources:
+
+```bash
+kubectl -n <namespace> create -f redis-insight.yaml
+```
+
+### 3. Environment Variable Reference
+
+The RedisInsight image supports the following environment variables:
+
+| Name | Description | Default |
+|------|-------------|---------|
+| `RI_APP_PORT` | Port that RedisInsight listens on | `5540` |
+| `RI_APP_HOST` | Address that RedisInsight listens on | `0.0.0.0` |
+| `RI_SERVER_TLS_KEY` | TLS private key | (empty) |
+| `RI_SERVER_TLS_CERT` | TLS certificate for the TLS key | (empty) |
+| `RI_ENCRYPTION_KEY` | Encryption key for sensitive data stored locally (database passwords, Workbench history, etc.) | (empty) |
+| `RI_LOG_LEVEL` | Log level | `info` |
+| `RI_FILES_LOGGER` | Write logs to files | `true` |
+| `RI_STDOUT_LOGGER` | Write logs to stdout | `true` |
+| `RI_PROXY_PATH` | Sub-path when running behind a reverse proxy | (empty) |
+
+## Accessing RedisInsight
+
+### Via NodePort
+
+The provided manifest exposes RedisInsight as a `NodePort` Service. Compute an externally reachable URL:
+
+```bash
+namespace="<namespace>"
+echo "http://$(kubectl -n $namespace get pods -l app.kubernetes.io/name=redis-insight -o jsonpath='{.items[0].status.hostIP}'):$(kubectl -n $namespace get svc redis-insight -o jsonpath='{.spec.ports[0].nodePort}')"
+```
+
+### Via Load Balancer (ALB)
+
+In **Container Platform > Networking > Load Balancers**, create a rule that forwards traffic to the `redis-insight` Service. Access RedisInsight using the load balancer's address.
+
+## Connecting to Redis
+
+After opening the RedisInsight URL and accepting the EULA, use **Add Redis Database**.
+
+### Sentinel Mode
+
+1. Enter the Sentinel address (cluster-internal address if RedisInsight is co-located with Redis, otherwise the external address). Leaving the password empty is acceptable: Sentinel password support is available starting from operator version 3.18.
+2. Configure the replica connection: set **Database Alias**, **Password**, and **Database Index** as required.
+3. Select the group(s) to add the instance to.
+4. Return to the home page from the top-left logo. The new instance appears in the list. Click an entry to inspect and edit data.
+
+### Cluster Mode
+
+1. Enter the address of any cluster node (cluster-internal or external).
+2. RedisInsight automatically detects Cluster mode and adds the instance to the list.
+3. Click the instance entry to inspect and edit data.
+
+## Data Operations
+
+- **Browse**: Click an instance to view its keys. Use filters to narrow results.
+- **Edit**: Select a key to view its value in the right pane and edit in place.
+- **Bulk Operations**: From the instance detail view, open **Workbench** in the left navigation to run multiple commands at once.
+
+## Uninstall
+
+To remove the RedisInsight deployment:
+
+```bash
+# Delete the Deployment
+kubectl -n <namespace> delete deployment redis-insight
+# Delete the Service
+kubectl -n <namespace> delete svc redis-insight
+# Delete the PersistentVolumeClaim
+kubectl -n <namespace> delete pvc redis-insight-data
+```
+
+## Important Considerations
+
+- **No built-in authentication**: Restrict network access to RedisInsight via the cluster firewall, ingress authentication, or a VPN. Treat RedisInsight as a privileged management tool.
+- **Storage class availability**: Confirm the `storageClassName` exists in the cluster before applying the manifest. Substitute another storage class if needed.
+- **Resource sizing**: The default limits (1 CPU / 1 GiB) suit small to medium environments. Increase them if you expect many concurrent users or large datasets.
+- **Image source**: For air-gapped environments, ensure the RedisInsight image is mirrored to your internal registry before deployment.
+- **Reference**: The procedures above are based on RedisInsight 2.58. UI elements may differ slightly in other versions. See the [official RedisInsight documentation](https://redis.io/docs/latest/develop/connect/insight/) for the latest guidance.

--- a/docs/en/solutions/ecosystem/redis/How_to_Deploy_RedisInsight_Web_Console.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Deploy_RedisInsight_Web_Console.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # How to Deploy the RedisInsight Web Console

--- a/docs/en/solutions/ecosystem/redis/How_to_Deploy_Redis_Proxy_with_RedisProxyOperator.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Deploy_Redis_Proxy_with_RedisProxyOperator.md
@@ -3,6 +3,8 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 4.x
 ---
 
 # Deploy a Redis Proxy with RedisProxyOperator

--- a/docs/en/solutions/ecosystem/redis/How_to_Deploy_Redis_Proxy_with_RedisProxyOperator.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Deploy_Redis_Proxy_with_RedisProxyOperator.md
@@ -1,0 +1,150 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# Deploy a Redis Proxy with RedisProxyOperator
+
+:::info Applicable Versions
+This guide applies to Alauda Cache Service for Redis OSS **3.18 and later**. The previous in-tree Predixy proxy (which only supported Cluster mode) was deprecated in 3.18 and replaced by the standalone `redis-proxy-operator`.
+:::
+
+## Introduction
+
+Some applications cannot adopt the standard Redis Sentinel or Cluster client libraries and instead expect to talk to Redis through a single endpoint. Typical cases include:
+
+- Legacy applications written for a single Redis instance.
+- Legacy applications written for a primary/replica pair.
+- Applications that previously used a third-party Redis proxy (front end), with a primary/replica, Sentinel, or Cluster topology behind it.
+
+To support these workloads, Alauda provides `redis-proxy-operator`, a standalone operator that deploys a Predixy-based proxy in front of an existing Redis instance. Predixy was selected after a community Redis proxy review based on functionality and adoption; known issues have been patched in this distribution.
+
+The new operator supports:
+
+1. **Sentinel-mode proxy**
+2. **Cluster-mode proxy**
+3. **Form-based proxy deployment** from the platform UI
+
+## Prerequisites
+
+- An ACP cluster with the standard application services platform installed.
+- An Alauda Cache Service for Redis OSS instance (Sentinel or Cluster mode) already deployed and in `Ready` state.
+- The `redis-proxy-operator` Violet package downloaded from Alauda Cloud and uploaded to the target business cluster.
+- A Redis password Secret in the same namespace as the Redis instance, containing a `password` field that matches the Redis instance password.
+
+### Compatible Versions
+
+| Compatible Platform Version | redis-proxy-operator Image |
+| --- | --- |
+| >= 3.18 | `build-harbor.alauda.cn/middleware/redis-proxy-operator-bundle:v3.18.1` |
+
+## Procedure
+
+### 1. Disable the Old In-Tree Proxy
+
+Before deploying the new standalone proxy, disable the in-tree proxy on any cluster-mode Redis instance.
+
+:::warning Migration Notes
+- The Service created by the legacy `redisProxy` was not exposed via NodePort by default. If a NodePort was added manually, **record the allocated port** before deletion so you can reuse it on the new instance for a transparent cutover.
+- The legacy operator gave the proxy CR the same name as the Redis instance. To preserve the same external access name, give the new Proxy CR the same name as the Redis instance.
+:::
+
+#### On 3.18.x
+
+Edit the Redis instance YAML and set:
+
+```yaml
+spec:
+  redisProxy:
+    enable: false
+```
+
+Save to apply.
+
+#### On Versions Earlier Than 3.18
+
+In the instance update page, expand **Advanced Configuration** and turn off the **Standalone Mode** switch, then save.
+
+### 2. Upload the Operator Package with Violet
+
+Use the `violet` CLI to push the operator bundle to the platform's app store:
+
+```bash
+violet push \
+  --platform-address <ACP-address> \
+  --clusters <cluster-name> \
+  --platform-username <username> \
+  --platform-password '<password>' \
+  <path-to-redis-proxy-operator-bundle.tgz>
+
+# Example
+violet push \
+  --platform-address https://192.168.129.215 \
+  --clusters business-1 \
+  --platform-username admin \
+  --platform-password 'abc123' \
+  ./redis-proxy-operator-3.18.1-acp3.18-20250214.tgz
+```
+
+### 3. Deploy the Operator
+
+1. Navigate to **Administrator** > **Marketplace** > **OperatorHub**.
+2. Locate **RedisProxyOperator** and click **Deploy**.
+3. The default deployment configuration is sufficient for most cases. The operator pod requests `500m` CPU and `500Mi` memory by default.
+
+### 4. Create a Proxy Instance
+
+1. Go to **Administrator** > **Marketplace** > **Deployed Operators** and open **redis-proxy-operator**.
+2. Open the **Resource Instances** tab and click **Create Instance**.
+3. In the dialog, click **Create Instance** under **Proxy**.
+4. Fill in the proxy parameters. Pay attention to the following:
+   - **Name** — If you are migrating from the legacy proxy, set this to the **Redis instance name** so client applications can switch over without code changes.
+   - **Namespace** — Must match the namespace of the target Redis instance.
+   - **NodePort** — If the legacy proxy used a fixed NodePort, set the same port here for a seamless cutover.
+   - **Password Secret** — Select a Secret that contains a `password` field matching the Redis instance password.
+
+:::warning Password Secret Format
+The referenced Secret **must** contain a `password` key. The proxy will fail to start if the field is missing or does not match the Redis instance password.
+:::
+
+### 5. Connect to the Proxy
+
+After the Proxy is deployed, the operator generates a Service named `<proxy-cr-name>-proxy`. For example, a Proxy named `redis-cluster-proxy` produces a Service named `redis-cluster-proxy-proxy`.
+
+For NodePort access, connect using any cluster node IP and the allocated NodePort. You can view the Service details in the container platform UI.
+
+:::warning ALB Not Recommended
+Do not place an ALB in front of the proxy. Predixy itself adds 20–30% overhead; layering ALB on top brings total overhead to 50% or more.
+:::
+
+## Supported Commands
+
+The proxy currently supports a subset of Redis 7.2 commands. The table below lists supported and unsupported commands by command group.
+
+| Group | Supported | Unsupported |
+| --- | --- | --- |
+| Connection Management | `auth` (proxy), `ping` (proxy), `echo` (proxy), `quit` (proxy), `select` | `client`, `hello`, `reset` |
+| Generic | `copy`, `del`, `dump`, `exists`, `expire`, `expireat`, `expiretime`, `move`, `persist`, `pexpire`, `pexpireat`, `pexpiretime`, `pttl`, `randomkey`, `rename`, `renamenx`, `restore`, `scan`, `sort`, `sort_ro`, `touch`, `ttl`, `type`, `unlink` | `keys`, `migrate`, `object`, `wait`, `waitof` |
+| Bitmap | `bitcount`, `bitfield`, `bitfield_ro`, `bitop`, `bitops`, `getbit`, `setbit` |  |
+| String | `append`, `decr`, `decrby`, `get`, `getdel`, `getex`, `getrange`, `getset`, `incr`, `incrby`, `incrbyfloat`, `lcs`, `mget`, `mset`, `msetnx`, `psetex`, `set`, `setex`, `setnx`, `setrange`, `strlen` | `substr` |
+| List | `blpop`, `brpop`, `brpoplpush`, `lindex`, `linsert`, `llen`, `lmove`, `lmpop`, `lpop`, `lpos`, `lpush`, `lpushx`, `lrange`, `lrem`, `lset`, `ltrim`, `rpop`, `rpoplpush`, `rpush`, `rpushx` | `blmove`, `blmpop` |
+| Set | `sadd`, `scard`, `sdiff`, `sdiffstore`, `sinter`, `sintercard`, `sinterstore`, `sismember`, `smembers`, `smismember`, `smove`, `spop`, `srandmember`, `srem`, `sscan`, `sunion`, `sunionstore` |  |
+| Sorted Set | `zadd`, `zcard`, `zcount`, `zdiff`, `zdiffstore`, `zincrby`, `zinter`, `zintercard`, `zinterstore`, `zlexcount`, `zmpop`, `zmscore`, `zpopmax`, `zpopmin`, `zrandmember`, `zrange`, `zrangebylex`, `zrangebyscore`, `zrangestore`, `zrank`, `zrem`, `zremrangebylex`, `zremrangebyrank`, `zremrangebyscore`, `zrevrange`, `zrevrangebylex`, `zrevrangebyscore`, `zrevrank`, `zscan`, `zscore`, `zunion`, `zunionstore` | `bzmpop`, `bzpopmax`, `bzpopmin` |
+| Hash | `hdel`, `hexists`, `hexpire`, `hexpireat`, `hexpiretime`, `hget`, `hgetall`, `hincrby`, `hincrbyfloat`, `hkeys`, `hlen`, `hmget`, `hmset`, `hscan`, `hset`, `hsetnx`, `hstrlen`, `hvals` |  |
+| Geospatial | `geoadd`, `geodist`, `geohash`, `geopos`, `georadius`, `georadius_ro`, `georadiusbymember`, `georadiusbymember_ro`, `geosearch`, `geosearchstore` |  |
+| HyperLogLog | `pfadd`, `pfcount`, `pfmerge` | `pfdebug`, `pfselftest` |
+| Scripting | `eval`, `eval_ro`, `evalsha`, `evalsha_ro`, `script load` | `script kill`, `script flush`, `script exists`, `script debug` |
+| Pub/Sub | `psubscribe`, `publish`, `pubsub`, `punsubscribe`, `subscribe`, `unsubscribe` | `spublish`, `ssubscribe`, `sunsubscribe` |
+| Stream |  | `xacl`, `xadd`, `xautoclaim`, `xclaim`, `xdel`, `xgroup`, `xinfo`, `xlen`, `xpending`, `xrange`, `xread`, `xreadgroup`, `xrevrange`, `xsetid`, `xtrim` |
+| Transaction (not supported in Cluster mode) | `discard`, `exec`, `multi`, `unwatch`, `watch` |  |
+| Server Management | `command` (proxy), `config` (proxy), `info` (proxy) | `acl`, `bgrewrite`, `bgsave`, `command`, `config`, `dbsize`, `failover`, `flushall`, `flushdb`, `info`, `lastsave`, `latency`, `lolwut`, `memory`, `module`, `monitor`, `psync`, `replconf`, `replicaof`, `role`, `save`, `shutdown`, `slaveof`, `slowlog`, `swapdb`, `sync`, `time` |
+
+## Important Considerations
+
+- **Performance overhead** — The proxy itself adds roughly 20–30% latency overhead compared with direct Redis access. Plan capacity accordingly.
+- **Transactions in Cluster mode** — `MULTI`/`EXEC` and friends are **not** supported when the proxy fronts a Cluster instance.
+- **Streams** — None of the `X*` stream commands are supported by the proxy.
+- **Service naming** — The proxy Service is always `<proxy-cr-name>-proxy`. Keep the Proxy CR name aligned with the legacy proxy or Redis instance name to enable transparent client cutover.
+- **Password Secret** — The Secret referenced by the Proxy CR must contain a `password` key whose value matches the Redis instance password.

--- a/docs/en/solutions/ecosystem/redis/How_to_Fix_Sentinel_Multi_Instance_Merge.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Fix_Sentinel_Multi_Instance_Merge.md
@@ -3,6 +3,8 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
 ---
 
 # How to Recover Sentinel Instances That Have Merged Due to IP Recycling

--- a/docs/en/solutions/ecosystem/redis/How_to_Fix_Sentinel_Multi_Instance_Merge.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Fix_Sentinel_Multi_Instance_Merge.md
@@ -1,0 +1,99 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# How to Recover Sentinel Instances That Have Merged Due to IP Recycling
+
+:::warning Most users on the current operator can skip this document
+If you are running **redis-operator 3.18+ with Redis 6.0 or later** (the default for new instances), you are **not affected** by this failure mode. Redis 6 introduced built-in user authentication that prevents cross-instance authentication even when pod IPs collide.
+
+Read this document only if (a) you operate **legacy instances on Redis 4.x/5.x**, or (b) you are on operator **<= 3.16** for unrelated reasons.
+:::
+
+## Introduction
+
+This guide explains how to recover from a rare but disruptive failure mode in which two independent Redis Sentinel-mode instances merge into a single cluster after pod restarts cause IP addresses to be recycled across instances. The Replica nodes from one instance attach to the other, and the Sentinel quorums from both instances see all six data nodes, producing a single 4-replica / 6-Sentinel "super-cluster".
+
+:::info Applicable Version
+- redis-operator `<= 3.14` (all Redis versions)
+- redis-operator `>= 3.16` running Redis `4.x` or `5.x`
+
+Redis 6.0 and later — including all instances created on operator 3.18+ with the default version — are immune.
+:::
+
+:::note
+This document uses "Primary" and "Replica" to refer to the main Redis node and its replicas, respectively, replacing the previously used "Master"/"Slave" terminology.
+:::
+
+## Background
+
+Redis Sentinel and Cluster modes use IPs (not DNS) to discover and form their quorum. This avoids dependency on DNS but exposes the system to IP recycling. The merge sequence is:
+
+1. After a pod restart, an instance's data pod is assigned an IP that previously belonged to a pod from a *different* Redis instance.
+2. The new pod boots and discovers the Primary advertised by the cluster it is now reachable on, then registers itself as a Replica there.
+3. Concurrently, the Sentinel pods of the original instance keep probing the lost IP. When the IP becomes reachable again, Sentinel re-attaches it as a Replica — but the IP now belongs to a pod from the other instance.
+4. Once the operator's reconciliation tries to repair the multi-Primary state, both instances converge into a single merged cluster.
+
+Two preconditions are required:
+
+- **Identical passwords** on both instances. Authentication succeeds across instance boundaries.
+- **A network plugin that recycles pod IPs**. This is most commonly observed in Calico-based environments; Kube-OVN with stable IPs largely avoids the issue.
+
+## Recovery Procedure
+
+The recovery procedure differs between operator versions. Identify your operator version before proceeding.
+
+:::warning
+Recovery removes redundant Replicas and may lose data that was only present on Replicas of one instance. Identify which copy of the data is authoritative **before** running the procedure.
+:::
+
+### Recovery on redis-operator 3.12 and 3.14
+
+1. **Stop the redis-operator** so it does not keep re-applying the merged topology while you repair the cluster.
+
+2. **Delete the Sentinel pods of the affected instance(s)**. Sentinel pods are named with the `rfs-` prefix:
+
+   ```bash
+   kubectl -n <namespace> delete pod -l app.kubernetes.io/component=sentinel,redissentinels.databases.spotahome.com/name=<instance-name>
+   ```
+
+3. **Inspect each data pod's role**. Data pods are named with the `rfr-` prefix:
+
+   ```bash
+   kubectl -n <namespace> exec -it <rfr-pod> -- redis-cli -a <password> ROLE
+   ```
+
+4. **Promote the correct Primary**. On every pod that reports `slave`, run:
+
+   ```bash
+   redis-cli -a <password> SLAVEOF NO ONE
+   ```
+
+   :::warning
+   Only one data copy should remain authoritative. Confirm with the application owner which Replica holds the correct data **before** running `SLAVEOF NO ONE`. All other data copies will be reset by the operator after restart.
+   :::
+
+5. **Restart the redis-operator**. The operator will rebuild the Sentinel quorum and the Primary/Replica topology automatically.
+
+6. **Once the instances are healthy, change the password on at least one of the affected instances** so that the two instances no longer share credentials. This prevents recurrence:
+
+   ```bash
+   kubectl -n <namespace> create secret generic <new-password-secret> \
+     --from-literal=password=<new-password>
+   ```
+
+   Then update `spec.passwordSecret` on the Redis CR to reference the new Secret.
+
+### Behavior on redis-operator 3.16 and later (with Redis 4 or 5)
+
+Starting from 3.16, the operator includes post-incident reconciliation logic that breaks the merged cluster automatically. **However, recovery is destructive — data that exists only on the merged side may be lost.** Set distinct passwords on each instance to avoid the problem entirely.
+
+## Important Considerations
+
+- **Mitigation, not prevention on Redis 4 / 5**: The only reliable prevention on Redis 4.x / 5.x is to ensure that no two Sentinel-mode instances in the same network share the same password.
+- **Upgrade path**: If feasible, upgrade affected instances to Redis 6.0 or later. Redis 6 has built-in users, so cross-instance authentication is rejected even when IPs collide.
+- **Network plugin**: If you operate at scale on Calico, plan password segregation per instance. Kube-OVN with persistent pod IPs reduces but does not fully eliminate the risk.
+- **Detection**: Monitor for `redis_connected_slaves` greater than the configured Replica count, and alert on Sentinel pods discovering more Primaries than the operator declared.

--- a/docs/en/solutions/ecosystem/redis/How_to_Manage_Dangerous_Redis_Commands.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Manage_Dangerous_Redis_Commands.md
@@ -1,0 +1,191 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# How to Manage Dangerous Redis Commands
+
+## Introduction
+
+This guide describes how to enable or disable dangerous Redis commands (such as `flushall`, `flushdb`, `keys`) on Alauda Cache Service for Redis OSS.
+
+:::info For users on the current operator (3.18+)
+Use **Method 1 (ACL Rules)** exclusively. The operator ships Redis 6.0+ where ACL is the canonical mechanism. Methods 2–4 are documented only for completeness on legacy operators (`<= 3.16`) and are not relevant to current deployments.
+:::
+
+## Method 1: Configure via ACL Rules (Recommended)
+
+:::info Applicable versions
+- Operator: `>= 3.15`
+- Redis: `>= 6.0`
+- Architectures: Sentinel, Cluster
+:::
+
+Starting from operator version 3.15, Redis user management is supported (Redis 6.0+ only). For Redis versions below 6.0, use [Method 3: Configure via Standard Parameters](#method-3-configure-via-standard-parameters-rename-command).
+
+By default, dangerous commands are disabled for the `default` user. You can customize ACL rules through **Instance** > **User Management** to enable or disable command permissions.
+
+### Default User Permissions
+
+```text
+# Redis 6.0 default user permissions
++@all -acl -flushall -flushdb -keys ~*
+
+# Redis 7.0 default user permissions
++@all -acl -flushall -flushdb -keys ~* &*
+```
+
+### ACL Rule Reference
+
+| Rule | Meaning |
+|------|---------|
+| `+@all` | Enable all commands |
+| `-@all` | Disable all commands |
+| `-acl` | Disable the `acl` command. The operator enforces this rule and it cannot be removed. |
+| `-flushall`, `-flushdb`, `-keys` | Disable the corresponding commands |
+| `~*` | Allow operations on all keys (`*` is a glob wildcard, e.g. `~test*` allows access to keys with the `test` prefix) |
+| `&*` | Allow operations on all Pub/Sub channels |
+
+To enable a specific command (for example, `keys`), remove the `-keys` entry from the ACL rule.
+
+### Rule Order Matters
+
+The order of ACL directives matters. The following rule grants access to **all** commands, including `flushall` and `flushdb`, because `+@all` overrides the earlier deny rules:
+
+```text
+-flushall -flushdb +@all ~*
+```
+
+To correctly disable specific commands, place the deny rules **after** the allow rules:
+
+```text
++@all ~* -flushall -flushdb
+```
+
+For more details, see the [Redis ACL community documentation](https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/#acl-rules).
+
+---
+
+## Legacy Methods (operator `<= 3.16`)
+
+The methods below are kept for users still running legacy operator releases. **Skip this section if you are on operator `3.18+`.**
+
+## Method 2: Run Dangerous Commands Temporarily as `operator`
+
+:::info Applicable versions
+- Operator: `>= 3.12.1` and `< 3.18` (the `/account/password` file was removed in 3.18)
+- Sentinel/Cluster mode requires operator `>= 3.15`
+- Redis: `>= 6.0`
+:::
+
+When dangerous commands are disabled for the `default` user, the built-in `operator` account can be used for one-off administrative tasks (for example, data migration or cleanup):
+
+```bash
+# Enter the redis-cli interactive shell as the operator user
+redis-cli -a $(cat /account/password) --user operator
+```
+
+:::warning
+The `operator` user has full privileges and can execute any command. Use it only for explicitly required administrative tasks.
+:::
+
+## Method 3: Configure via Standard Parameters (`rename-command`)
+
+:::info Applicable versions
+- Operator: `> 3.10.3` and `<= 3.15`
+- Architectures: Sentinel, Cluster
+:::
+
+In this version range, `flushall` and `flushdb` are disabled by default. Additional commands can be disabled or renamed by configuring the `rename-command` parameter.
+
+### Disable or Rename Commands
+
+| Action | Key | Value | Description |
+|--------|-----|-------|-------------|
+| Disable a command | `rename-command` | `set ""` | Disables the `set` command |
+| Rename a command | `rename-command` | `set abc123` | Renames `set` to `abc123` |
+| Combined configuration | `rename-command` | `flushall flushall debug abc123 set ""` | (1) Restores `flushall`, (2) renames `debug` to `abc123`, (3) disables `set` |
+
+:::warning
+Modifying the `rename-command` parameter triggers an instance restart.
+:::
+
+### Re-enable a Built-In Disabled Command
+
+To restore an originally disabled command (for example, `flushall`), rename the command to itself:
+
+| Action | Key | Value | Description |
+|--------|-----|-------|-------------|
+| Re-enable `flushall` | `rename-command` | `flushall flushall` | Renames `flushall` to `flushall`, overriding the built-in disable |
+
+### Workaround for Operator 3.14.0 / 3.14.1 Bug (Redis 6.0)
+
+:::warning Known issue
+Operator versions **3.14.0** and **3.14.1** have a bug where `rename-command` configuration changes do not take effect for Redis 6.0 instances.
+:::
+
+Apply the following manual fix:
+
+1. Edit the instance ACL ConfigMap:
+
+   ```bash
+   kubectl -n <namespace> edit cm drc-acl-<instance-name>
+   ```
+
+2. The ConfigMap content looks like this:
+
+   ```yaml
+   apiVersion: v1
+   data:
+     default: '{"name":"default","role":"Developer","password":{"secretName":"redis-c6-6sd7v"},"rules":[{"categories":["all"],"disallowedCommands":["flushall","flushdb"],"keyPatterns":["*"]}]}'
+     operator: '{"name":"operator","role":"Operator","password":{"secretName":"drc-acl-c6-operator-secret"},"rules":[{"categories":["all"],"disallowedCommands":["keys"],"keyPatterns":["*"]}]}'
+   kind: ConfigMap
+   metadata:
+     name: drc-acl-<instance-name>
+   ```
+
+3. Modify the `disallowedCommands` array in the `default` entry. For example, to remove the `flushall` restriction and add `debug`:
+
+   ```yaml
+   apiVersion: v1
+   data:
+     default: '{"name":"default","role":"Developer","password":{"secretName":"redis-c6-6sd7v"},"rules":[{"categories":["all"],"disallowedCommands":["debug","flushdb"],"keyPatterns":["*"]}]}'
+     operator: '{"name":"operator","role":"Operator","password":{"secretName":"drc-acl-c6-operator-secret"},"rules":[{"categories":["all"],"disallowedCommands":["keys"],"keyPatterns":["*"]}]}'
+   kind: ConfigMap
+   metadata:
+     name: drc-acl-<instance-name>
+   ```
+
+4. Update the `rename-command` parameter in the instance configuration to trigger an instance restart.
+5. Wait for the restart to complete. The new ACL rules will take effect.
+
+## Method 4: Legacy YAML Configuration
+
+:::info Applicable versions
+- Operator: `> 3.8.2` and `<= 3.10.2`
+- Architectures: Sentinel, Cluster
+:::
+
+### Cluster Mode
+
+Disabling dangerous commands is only supported through the proxy. When clients connect via the Redis proxy, commands such as `flushall` and `keys *` are automatically blocked.
+
+### Sentinel Mode
+
+1. Create a new Sentinel instance via the `Redis` CR (`apiVersion: middleware.alauda.io/v1`, `arch: sentinel`).
+2. Add the `customCommandRenames` field to rename `flushall`, `keys`, and other commands.
+3. Edit the corresponding Sentinel ConfigMap (`rfs-<instance-name>`) to set the `rename-command` directives.
+4. Restart the instance for the configuration to take effect.
+
+### Verification
+
+After restarting, connect to the instance and confirm that the renamed or disabled commands are no longer accessible.
+
+## Important Considerations
+
+- Always use **Method 1 (ACL rules)** when running operator 3.15+ with Redis 6.0+. ACL provides finer-grained control and does not require an instance restart for most rule changes.
+- Modifying `rename-command` triggers an instance restart. Plan changes during a maintenance window.
+- The order of ACL rules is significant. Always place deny rules after the broad allow rule.
+- The `operator` user is privileged. Restrict its credentials to authorized administrators only.

--- a/docs/en/solutions/ecosystem/redis/How_to_Manage_Dangerous_Redis_Commands.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Manage_Dangerous_Redis_Commands.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # How to Manage Dangerous Redis Commands

--- a/docs/en/solutions/ecosystem/redis/How_to_Manually_Remove_Failed_Cluster_Nodes.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Manually_Remove_Failed_Cluster_Nodes.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # Manually Remove Failed Redis Cluster Nodes

--- a/docs/en/solutions/ecosystem/redis/How_to_Manually_Remove_Failed_Cluster_Nodes.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Manually_Remove_Failed_Cluster_Nodes.md
@@ -1,0 +1,133 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# Manually Remove Failed Redis Cluster Nodes
+
+## Introduction
+
+When a Redis Cluster node has been permanently removed (for example, after a pod has been deleted or relocated and its IP is no longer in use), the cluster's gossip view may still hold stale entries with `fail` status. To clean these up the operator needs to issue `CLUSTER FORGET` against **every other node** in the cluster, because each node tracks the cluster topology independently.
+
+This guide provides a small helper script that fans the `CLUSTER FORGET` command out across all healthy nodes.
+
+:::tip
+For a related but distinct case - cleaning up orphaned IP-recycling artifacts (e.g. with the Calico CNI), see [Cleanup Invalid Redis Cluster Nodes](./How_to_Cleanup_Invalid_Cluster_Nodes.md).
+:::
+
+## Prerequisites
+
+1. A healthy Redis Cluster with at least one reachable primary node (status not `fail`).
+2. The cluster password (referred to as `<password>` below).
+3. `redis-cli` available on the machine running the script. If not present, install it from your distribution's package repository (for example `yum install -y redis` or use the version bundled in the platform Redis pod image).
+4. Network connectivity from the script host to **every** node in the cluster.
+
+## Procedure
+
+### 1. List Cluster Nodes
+
+Pick any healthy node and list the cluster topology:
+
+```bash
+redis-cli -h <node-ip> -a '<password>' cluster nodes
+```
+
+Sample output:
+
+```text
+e457476882acfaebcc860466da141a32972eace4 10.33.1.33:6379@16379 master - 0 1616656953463 0 connected 10923-16383
+73cb7a3c3c5c1db1a43c7483eacc1fc261757cec 10.33.0.218:6379@16379 slave e457476882acfaebcc860466da141a32972eace4 0 1616656955466 1 connected
+8bba60e0ed2c0cf33395399c2b8951dd0b9c0f57 10.33.0.50:6379@16379 slave 9023b45408c79a0f5e7434dad6547e59ff487b77 0 1616656950455 4 connected
+5f2a6fab812ffb29e59456ff3b987ba68d0af46b 10.33.1.229:6379@16379 myself,slave 0b0e62b3dfdb5c55fd203ef01160c752c60e48bf 0 1616656952000 3 connected
+9023b45408c79a0f5e7434dad6547e59ff487b77 10.33.0.217:6379@16379 master - 0 1616656952460 4 connected 5461-10922
+0b0e62b3dfdb5c55fd203ef01160c752c60e48bf 10.33.0.49:6379@16379 master - 0 1616656954464 5 connected 0-5460
+```
+
+The first column is the node ID. Identify the IDs whose flags include `fail` or `disconnected`.
+
+### 2. Create the Helper Script
+
+Save the following as `forget.sh`:
+
+```bash
+#!/bin/sh
+ANY_NODE=$1
+PASSWORD=$2
+FORGET_NODE_ID=$3
+
+redis-cli -h "${ANY_NODE}" -a "${PASSWORD}" cluster nodes \
+  | grep -v "${FORGET_NODE_ID}" \
+  | awk '{print $2}' \
+  | awk -F: '{print $1}' \
+  | xargs -I {} redis-cli -h {} -a "${PASSWORD}" cluster forget "${FORGET_NODE_ID}"
+```
+
+The script:
+
+1. Lists all known nodes from a single healthy node.
+2. Filters out the node we want to forget (otherwise we would tell the failed node to forget itself).
+3. Extracts the IPs of the remaining nodes.
+4. Sends `CLUSTER FORGET <node-id>` to each of them.
+
+Make it executable:
+
+```bash
+chmod +x forget.sh
+```
+
+### 3. Run the Script Once Per Failed Node
+
+For each node ID in the `fail` state, run:
+
+```bash
+sh forget.sh <healthy-master-ip> <password> <failed-node-id>
+```
+
+For example:
+
+```bash
+sh forget.sh 10.33.0.49 'mypass' e457476882acfaebcc860466da141a32972eace4
+```
+
+`<healthy-master-ip>` must be the IP of a primary that is **not** currently in `fail` state.
+
+### 4. Verify the Cluster
+
+```bash
+redis-cli -h <node-ip> -a '<password>' cluster info
+```
+
+A healthy result looks like:
+
+```text
+cluster_state:ok
+cluster_slots_assigned:16384
+cluster_slots_ok:16384
+cluster_slots_pfail:0
+cluster_slots_fail:0
+cluster_known_nodes:6
+cluster_size:3
+...
+```
+
+`cluster_state:ok`, `cluster_slots_assigned:16384`, and a `cluster_known_nodes` count that matches the live topology indicate the stale entries have been removed across the cluster.
+
+## Important Considerations
+
+### `CLUSTER FORGET` Has a 60-Second Timeout
+
+Each `CLUSTER FORGET` adds the target node to a 60-second blacklist on the node that received the command. If the gossip protocol re-announces the failed node before all peers have forgotten it, the entry will reappear on those peers. Run the script across all nodes within the same minute - the helper above is fast enough to do this in a single execution.
+
+### Don't Forget Live Nodes
+
+If you accidentally invoke `CLUSTER FORGET` against a healthy node ID, that node will be temporarily severed from the cluster's view (it will rejoin after the 60-second blacklist expires). Always validate the target node ID is in `fail` state before running the script.
+
+### Don't Forget the Replica of a Healthy Primary
+
+If the failed node is the primary of a still-healthy shard, removing it without first promoting a replica leaves the shard's slots without a primary. Use `CLUSTER FAILOVER` from the surviving replica before forgetting the old primary.
+
+### When This Procedure Is Not Enough
+
+If the cluster has many stale entries from IP recycling (for example with the Calico CNI), the orphaned records may not all be in `fail` state and may need a different cleanup approach. See [Cleanup Invalid Redis Cluster Nodes](./How_to_Cleanup_Invalid_Cluster_Nodes.md).

--- a/docs/en/solutions/ecosystem/redis/How_to_Migrate_Redis_Across_Clusters.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Migrate_Redis_Across_Clusters.md
@@ -3,6 +3,8 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
 ---
 
 # Migrate Redis Data Across Kubernetes Clusters

--- a/docs/en/solutions/ecosystem/redis/How_to_Migrate_Redis_Across_Clusters.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Migrate_Redis_Across_Clusters.md
@@ -1,0 +1,249 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# Migrate Redis Data Across Kubernetes Clusters
+
+:::info Applicable Versions
+- Platform: **3.8.x – 3.16.x** (image table below stops at 3.16.2)
+:::
+
+## Introduction
+
+This guide explains how to migrate data between Redis instances running in different Kubernetes clusters using the platform's built-in **RedisShake**-based migration feature. The procedure supports the following source/target architecture combinations:
+
+| Architecture | Description |
+| --- | --- |
+| `standalone` | Single-node Redis |
+| `sentinel` | Sentinel-based primary/replica instance |
+| `cluster` | Sharded Redis Cluster |
+
+RedisShake performs continuous replication: as long as the source keeps accepting writes, those writes are propagated to the target. Synchronization does not stop on its own.
+
+## Glossary
+
+| Term | Meaning |
+| --- | --- |
+| Source | The Redis instance whose data is being migrated. |
+| Target | The Redis instance that receives the migrated data. |
+
+## Prerequisites
+
+1. **Capacity check.** Ensure the target has enough memory to hold the source dataset:
+   - Target is sentinel: target memory should be at least **5/4 of source dataset size**.
+   - Target is cluster, source is standalone: target memory should be at least **5/4 of source dataset size**.
+   - Target is cluster, source is cluster: target memory should be at least **5/4 of the largest source shard's dataset size**.
+   - For acceptable performance, allocate **2-8 vCPU** per RedisShake pod (4 vCPU recommended).
+2. **Reduce or pause writes** on the source to lower replication pressure.
+3. **Pick the correct RedisShake image** for your platform version (see the [appendix](#appendix-redisshake-image-by-platform-version)).
+4. **Network connectivity.** The source and target instances must be reachable from the RedisShake pod over a stable IPv4 network.
+5. **Redis version.** The current RedisShake image **does not support Redis 7.x**. Use this method only with Redis 5.x or 6.x source/target instances.
+
+### Known Issues
+
+- On platform versions **3.16.0** and **3.16.1**, when the source is a Sentinel instance, the source instance status may be incorrectly reported as `Processing` even though the instance is healthy. The status reporting is fixed in **3.16.2**.
+
+## Migration Procedure
+
+For every scenario below, you create a single `RedisShake` custom resource. Update the image, source/target addresses, and password Secrets to match your environment, then apply the resource using `kubectl` or the platform UI. To change a configuration after deployment, delete the existing resource and create a new one — in-place edits are not supported.
+
+### 1. Create Password Secrets
+
+If either side is password-protected, create a Kubernetes Secret per side. The Secret must use the data key `password`.
+
+```bash
+kubectl -n <namespace> create secret generic <secret-name> \
+  --from-literal=password=<password>
+```
+
+### 2. Standalone to Sentinel
+
+```yaml
+apiVersion: middle.alauda.cn/v1alpha1
+kind: RedisShake
+metadata:
+  name: standalone-to-sentinel
+spec:
+  image: <redisshake-image>           # See appendix for the right image for your version
+  keyExists: rewrite
+  modelType: sync
+  replicas: 1
+  source:
+    address:
+      - "<source-host>:<source-port>"
+    passwordSecret: <source-password-secret>
+    type: standalone
+  target:
+    address:
+      - "mymaster@<target-host>:<target-port>"
+    passwordSecret: <target-password-secret>
+    type: sentinel
+```
+
+:::warning
+When the **source or target is a Sentinel instance**, the address must be prefixed with `mymaster@`, and the value should be the Sentinel access endpoint. Find it in **Data Services > Instance Detail > Access Method > In-cluster Access / External Access**.
+:::
+
+### 3. Sentinel to Sentinel
+
+```yaml
+apiVersion: middle.alauda.cn/v1alpha1
+kind: RedisShake
+metadata:
+  name: sentinel-to-sentinel
+spec:
+  image: <redisshake-image>
+  keyExists: rewrite
+  modelType: sync
+  replicas: 1
+  source:
+    address:
+      - "mymaster@<source-host>:<source-port>"
+    passwordSecret: <source-password-secret>
+    type: sentinel
+  target:
+    address:
+      - "mymaster@<target-host>:<target-port>"
+    passwordSecret: <target-password-secret>
+    type: sentinel
+```
+
+### 4. Standalone to Cluster
+
+```yaml
+apiVersion: middle.alauda.cn/v1alpha1
+kind: RedisShake
+metadata:
+  name: standalone-to-cluster
+spec:
+  image: <redisshake-image>
+  keyExists: rewrite
+  modelType: sync
+  replicas: 1
+  source:
+    address:
+      - "<source-host>:<source-port>"
+    passwordSecret: <source-password-secret>
+    type: standalone
+  target:
+    address:
+      - "<target-host>:<target-port>"
+    passwordSecret: <target-password-secret>
+    type: cluster
+```
+
+:::note
+For a cluster target, the address can be **any one** of the cluster access endpoints. Find them in **Data Services > Instance Detail > Access Method > In-cluster Access / External Access**.
+:::
+
+### 5. Sentinel to Cluster
+
+```yaml
+apiVersion: middle.alauda.cn/v1alpha1
+kind: RedisShake
+metadata:
+  name: sentinel-to-cluster
+spec:
+  image: <redisshake-image>
+  keyExists: rewrite
+  modelType: sync
+  replicas: 1
+  resumeFromBreakPoint: false
+  source:
+    address:
+      - "mymaster@<source-host>:<source-port>"
+    passwordSecret: <source-password-secret>
+    type: sentinel
+  target:
+    address:
+      - "<target-host>:<target-port>"
+    passwordSecret: <target-password-secret>
+    type: cluster
+```
+
+### 6. Cluster to Cluster
+
+```yaml
+apiVersion: middle.alauda.cn/v1alpha1
+kind: RedisShake
+metadata:
+  name: cluster-to-cluster
+spec:
+  image: <redisshake-image>
+  keyExists: rewrite
+  modelType: sync
+  replicas: 1
+  source:
+    address:
+      - "master@<source-host>:<source-port>"
+    passwordSecret: <source-password-secret>
+    type: cluster
+  target:
+    address:
+      - "<target-host>:<target-port>"
+    passwordSecret: <target-password-secret>
+    type: cluster
+```
+
+:::warning
+- When the **source is a cluster**, prefix the address with `master@`. The target cluster address does **not** need this prefix.
+- For both source and target clusters, any one of the cluster endpoints is sufficient — RedisShake discovers the rest of the topology automatically.
+:::
+
+## Verifying Synchronization
+
+RedisShake performs continuous replication. Even after the initial dataset is copied, replication continues until you delete the `RedisShake` resource. You must therefore verify completion manually.
+
+### Platform Version Below 3.10
+
+There is no monitoring dashboard on these versions. Use a key-count comparison:
+
+1. Run `DBSIZE` on the source. For cluster sources, sum `DBSIZE` across all primaries.
+2. Run `DBSIZE` on the target. For cluster targets, sum across all primaries.
+3. With writes paused on the source, the totals should match when synchronization is complete.
+
+For cluster mode, the following one-liner returns the total key count across all primaries:
+
+```bash
+redis-cli -a <password> --cluster call <host>:<port> dbsize --cluster-only-masters
+```
+
+### Platform Version 3.10.2 and Later
+
+The key-count method still works. In addition, a Grafana dashboard **"Redis Shake Dashboard"** is available under **Platform Management > Operations Center > Monitoring > Grafana > Dashboards**.
+
+#### Sentinel Source
+
+- `SyncProcessPercent` — reaches `100` when the initial sync is complete.
+- `SlaveDelayOffset` — periodic dips to `0` indicate that the target has caught up. Brief spikes from replication ping packets are expected and not data.
+
+#### Cluster Source
+
+- `SyncProcessPercent` — one progress series per source shard. All shards reaching the completion mark indicates initial sync is done.
+- `SlaveDelayOffset` — when the offset reaches `0`, replication is up to date.
+
+## Appendix: RedisShake Image by Platform Version
+
+Use the RedisShake image matching your platform version:
+
+| ACP Version | RedisShake Image |
+| --- | --- |
+| 3.8.1 - 3.8.3 | `build-harbor.alauda.cn/middleware/redis-shake:v3.8.2` |
+| 3.10.1 | `build-harbor.alauda.cn/middleware/redis-shake:v3.8.2` |
+| 3.10.2, 3.10.3 | `build-harbor.alauda.cn/middleware/redis-shake:v3.8.3` |
+| 3.12.1 - 3.12.3 | `build-harbor.alauda.cn/middleware/redis-shake:v3.8.2-5ad6d091` |
+| 3.14.1, 3.14.2 | `build-harbor.alauda.cn/middleware/redis-shake:v3.8.2-063e3b5d` |
+| 3.16.1 | `build-harbor.alauda.cn/middleware/redis-shake:v3.8.2-9bb65a7b` |
+| 3.16.2 | `build-harbor.alauda.cn/middleware/redis-shake:v3.8.2-3777a73b` |
+
+## Important Considerations
+
+- **No Redis 7.x support.** Use a different migration path (for example RDB export/import) for Redis 7.x source or target.
+- **Replication never stops automatically.** Always validate completion before cutover and delete the `RedisShake` resource when migration is finished.
+- **Pause writes during cutover.** A short freeze on the source allows the offset to reach zero before applications are repointed.
+- **CR is immutable.** To change the configuration, delete and recreate the `RedisShake` resource.
+- **Sentinel and cluster address format.** Sentinel addresses require the `mymaster@` prefix; cluster source addresses require the `master@` prefix; cluster target addresses do not.
+- **Network stability.** Persistent network instability between source and target leads to replication restarts and increased lag. Ensure stable connectivity before kicking off migration.

--- a/docs/en/solutions/ecosystem/redis/How_to_Rate_Limit_Redis_Traffic.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Rate_Limit_Redis_Traffic.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # How to Rate Limit Redis Traffic

--- a/docs/en/solutions/ecosystem/redis/How_to_Rate_Limit_Redis_Traffic.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Rate_Limit_Redis_Traffic.md
@@ -1,0 +1,112 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# How to Rate Limit Redis Traffic
+
+## Introduction
+
+This guide explains strategies for controlling Redis traffic to prevent excessive load that could compromise cluster stability. It covers the trade-offs of bandwidth-based rate limiting versus connection-based throttling, and provides practical recommendations for managing Redis traffic in production environments.
+
+## Background
+
+### What Causes Excessive Redis Traffic?
+
+Excessive Redis traffic typically results from one or more of the following:
+
+1. High request volume from applications
+2. Storage and frequent access of BigKeys
+3. Use of dangerous commands that return large amounts of data in a single call
+
+### Why Direct Bandwidth Throttling Is Problematic
+
+:::warning
+Applying bandwidth limits directly to Redis pods can cause cascading failures.
+:::
+
+If you apply bandwidth limits to Redis, traffic spikes will saturate the available bandwidth, leading to:
+
+- Client requests blocking on Redis operations. With API concurrency above 10,000, all 10,000 TCP connections (the default `maxclients`) compete for limited bandwidth, causing slow responses.
+- Widespread TCP request timeouts, which propagate as upstream API timeouts.
+- Disruption of Redis primary-replica replication and cluster heartbeat synchronization, increasing replication lag and undermining high availability.
+
+For these reasons, **bandwidth-based rate limiting is not recommended**. Use connection-based limits and upstream API throttling instead.
+
+## Considerations Before Throttling
+
+In most production workloads, Redis itself rarely becomes the bottleneck:
+
+- Sentinel mode can sustain ~500K QPS, and with read/write splitting, ~1M QPS.
+- For higher throughput, use Cluster mode.
+
+Before adding traffic controls at the Redis layer, evaluate:
+
+- Whether the upstream API tier can sustain the traffic
+- Whether the downstream databases can sustain the traffic
+- Whether throttling should be applied at the gateway or API layer instead
+
+When bandwidth is not the bottleneck, Redis responds promptly even under high concurrency. The presence of BigKeys, however, can disproportionately consume bandwidth. Limiting the maximum client connections is generally more effective than throttling bandwidth: when a burst of traffic exceeds the connection limit, clients receive an immediate error rather than queuing on a slow Redis.
+
+## Procedure
+
+### Method 1: Limit Maximum Client Connections (`maxclients`)
+
+Set the `maxclients` parameter in your Redis instance configuration to control concurrency at the connection level.
+
+- **Default value**: `10000`
+- **Recommended adjustment**: Reduce to `5000` or lower based on your actual concurrency needs.
+
+Update `maxclients` through the instance parameter configuration in your Redis management UI or through the YAML `customConfig` field:
+
+```yaml
+spec:
+  customConfig:
+    maxclients: "5000"
+```
+
+:::tip
+Connection-based limiting is preferred over bandwidth limiting because excess clients fail fast with a clear error rather than experiencing slow timeouts.
+:::
+
+### Method 2: Apply Rate Limiting at the API or Gateway Layer
+
+Implement throttling closer to the client to protect Redis:
+
+1. **API gateway-based throttling**:
+   - Use an API gateway such as Kgateway or Kong to apply rate limit rules per route, consumer, or API key.
+2. **Application-level throttling**:
+   - Implement rate limiting directly within your business APIs (for example, token bucket or leaky bucket algorithms).
+
+### Method 3: Detect and Remediate BigKeys
+
+BigKeys consume disproportionate bandwidth and CPU when accessed. Identify and remediate them:
+
+1. Use the BigKey detection tooling provided by your Redis platform.
+2. Refactor application logic to split BigKeys into smaller structures.
+3. Avoid frequent full reads of large hashes, lists, or sets.
+
+### Method 4: Reduce Use of Dangerous Commands
+
+Certain commands return large datasets in a single call, occupying significant bandwidth and blocking Redis. Avoid or restrict the following:
+
+- `KEYS`
+- `HGETALL`
+- `SMEMBERS`
+
+Replace these with iterative alternatives where possible:
+
+- Use `SCAN` instead of `KEYS`
+- Use `HSCAN` instead of `HGETALL`
+- Use `SSCAN` instead of `SMEMBERS`
+
+You can also disable dangerous commands at the Redis instance level. See the related solution **How to Manage Dangerous Redis Commands**.
+
+## Important Considerations
+
+- Direct bandwidth throttling at the Pod level can cause widespread service degradation. Avoid this approach.
+- Rate limiting is most effective when applied at multiple layers: gateway, API, and Redis connection limits.
+- Monitor BigKeys regularly. A single BigKey accessed frequently can saturate Redis bandwidth even with a low connection count.
+- When tuning `maxclients`, ensure the value still accommodates legitimate peak traffic; setting it too low can cause connection rejections during normal operation.

--- a/docs/en/solutions/ecosystem/redis/How_to_Rate_Limit_Redis_Traffic.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Rate_Limit_Redis_Traffic.md
@@ -42,7 +42,7 @@ For these reasons, **bandwidth-based rate limiting is not recommended**. Use con
 
 In most production workloads, Redis itself rarely becomes the bottleneck:
 
-- Sentinel mode can sustain ~500K QPS, and with read/write splitting, ~1M QPS.
+- Sentinel mode can sustain ~500k QPS, and with read/write splitting, ~1M QPS.
 - For higher throughput, use Cluster mode.
 
 Before adding traffic controls at the Redis layer, evaluate:

--- a/docs/en/solutions/ecosystem/redis/How_to_Recover_From_Cross_Shard_Master_Corruption.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Recover_From_Cross_Shard_Master_Corruption.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # How to Recover From Cross-Shard Primary Corruption in Cluster Mode

--- a/docs/en/solutions/ecosystem/redis/How_to_Recover_From_Cross_Shard_Master_Corruption.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Recover_From_Cross_Shard_Master_Corruption.md
@@ -1,0 +1,101 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# How to Recover From Cross-Shard Primary Corruption in Cluster Mode
+
+## Introduction
+
+This guide describes how to recover a Redis Cluster-mode instance whose state shows healthy at the Redis level but whose pod-to-shard mapping has become inconsistent — typically observed when the platform reports the instance status stuck at "Processing" indefinitely after a password update. The root cause is that a Primary role from one shard's StatefulSet has been adopted by a pod that belongs to a *different* shard's StatefulSet, so the operator cannot complete reconciliation.
+
+:::info Applicable Version
+This is a low-probability defect that can occur on any Cluster-mode Alauda Cache Service for Redis OSS instance. The procedure below is mode-agnostic and works on all current operator versions.
+:::
+
+:::note
+This document uses "Primary" and "Replica" to refer to the main Redis node and its replicas, respectively, replacing the previously used "Master"/"Slave" terminology.
+:::
+
+## Symptoms
+
+- After a password update (or another reconcile-triggering operation) the Redis CR remains stuck in `Processing` and never returns to `Healthy`.
+- `redis-cli --cluster check` reports the cluster as healthy and slots as fully covered.
+- The Primary IP reported by `cluster nodes` for one shard belongs to a pod that is part of a *different* shard's StatefulSet.
+- The operator log shows no errors but does not progress.
+
+## Diagnosis
+
+1. Check cluster health from any data pod:
+
+   ```bash
+   redis-cli -a $REDIS_PASSWORD --cluster check 127.0.0.1:6379
+   ```
+
+   Expected: `[OK] All 16384 slots covered.` Cluster health alone does **not** rule out the misalignment.
+
+2. List pods with their IPs and StatefulSet:
+
+   ```bash
+   kubectl -n <namespace> get pods -o wide
+   ```
+
+3. List the Redis cluster topology and inspect Primary IPs:
+
+   ```bash
+   redis-cli -a $REDIS_PASSWORD CLUSTER NODES
+   ```
+
+4. Cross-reference the Primary IP from step 3 against the pod-to-StatefulSet mapping from step 2. If the pod that holds the Primary role for shard *N* is not part of shard *N*'s StatefulSet (`drc-<instance>-N-*`), the cluster is in the misaligned state described here.
+
+The root cause is suspected to be related to pod IP changes; reproducing it deterministically has not been possible. Operator restarts and pod restarts will not fix it.
+
+## Recovery Procedure
+
+The repair requires two manual steps per affected shard: re-electing the correct Primary on the shard that lost its Primary, then demoting the misplaced pod back to a Replica of its own shard.
+
+:::warning
+- All commands must run from inside the Redis pods or from a workstation with `redis-cli` access to the cluster.
+- The procedure briefly causes the affected shard to perform a controlled failover. Plan the operation during a maintenance window.
+:::
+
+For each shard that is affected:
+
+1. **Identify the players**:
+   - Let `PodA` be the pod that *currently* holds the Primary role but belongs to the wrong StatefulSet.
+   - Let `PodB` be a pod (any of them) in the StatefulSet that *should* own this shard but currently has no Primary.
+   - Record the Redis cluster node ID of `PodB`. You will use it as `<PodBID>` below.
+
+   ```bash
+   # On PodB:
+   redis-cli -a $REDIS_PASSWORD CLUSTER MYID
+   ```
+
+2. **Failover to PodB** so that the correct StatefulSet regains a Primary in the shard:
+
+   ```bash
+   # On PodB:
+   redis-cli -a $REDIS_PASSWORD CLUSTER FAILOVER
+   ```
+
+   Wait until `CLUSTER NODES` reports `PodB` as `master`.
+
+3. **Re-attach PodA as a Replica of `PodB`**:
+
+   ```bash
+   # On PodA:
+   redis-cli -a $REDIS_PASSWORD CLUSTER REPLICATE <PodBID>
+   ```
+
+4. Repeat for any additional misaligned shards.
+
+5. Wait for the operator to reconcile. The Redis CR status should transition out of `Processing` to `Healthy`.
+
+## Important Considerations
+
+- **Always perform a `--cluster check` before the failover** to confirm slot coverage is intact. If slots are missing, see *How to Recover From a Redis Cluster Crash* and the slot-recovery procedure in the *Redis Emergency Response Playbook* before continuing.
+- **Do not delete pods to "force" recovery** — the misaligned topology will persist across pod restarts because Redis Cluster state is held in `nodes.conf` on each node.
+- **Capture diagnostics before recovery**: keep a copy of `kubectl get pods -o wide`, `redis-cli CLUSTER NODES`, and operator logs for post-incident analysis. Root cause is currently undetermined; collected evidence helps trace the underlying trigger.
+- **Password rotation**: if the trigger was a password rotation that hung, retry the rotation only after the cluster reports `Healthy`.

--- a/docs/en/solutions/ecosystem/redis/How_to_Recover_From_Cross_Shard_Master_Corruption.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Recover_From_Cross_Shard_Master_Corruption.md
@@ -71,10 +71,10 @@ For each shard that is affected:
    - Let `PodB` be a pod (any of them) in the StatefulSet that *should* own this shard but currently has no Primary.
    - Record the Redis cluster node ID of `PodB`. You will use it as `<PodBID>` below.
 
-   ```bash
-   # On PodB:
-   redis-cli -a $REDIS_PASSWORD CLUSTER MYID
-   ```
+     ```bash
+     # On PodB:
+     redis-cli -a $REDIS_PASSWORD CLUSTER MYID
+     ```
 
 2. **Failover to PodB** so that the correct StatefulSet regains a Primary in the shard:
 

--- a/docs/en/solutions/ecosystem/redis/How_to_Recover_From_Redis_Cluster_Crash.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Recover_From_Redis_Cluster_Crash.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # How to Recover From a Redis Cluster Crash

--- a/docs/en/solutions/ecosystem/redis/How_to_Recover_From_Redis_Cluster_Crash.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Recover_From_Redis_Cluster_Crash.md
@@ -1,0 +1,109 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# How to Recover From a Redis Cluster Crash
+
+## Introduction
+
+This guide explains how to recover a Redis Cluster-mode pod whose cluster state file (`nodes.conf`) has been deleted or corrupted, leaving the node unable to rejoin its cluster. The most common indicator is a Replica that starts up but never reattaches — its IP and port appear as `0@0` in `CLUSTER NODES` output instead of the expected `IP:6379@16379`.
+
+:::info Applicable Version
+All Cluster-mode versions of Alauda Cache Service for Redis OSS.
+:::
+
+:::note
+This document uses "Primary" and "Replica" to refer to the main Redis node and its replicas, respectively, replacing the previously used "Master"/"Slave" terminology.
+:::
+
+## Symptoms
+
+A Replica pod starts but cannot rejoin the cluster. From any healthy pod, run:
+
+```bash
+redis-cli -a <password> CLUSTER NODES
+```
+
+A healthy node entry looks like:
+
+```text
+<node_id> <IP>:6379@16379 master|slave ...
+```
+
+A node with a deleted/corrupted cluster configuration file looks like:
+
+```text
+<node_id> 0@0 ...
+```
+
+The bad pod also reports it is "not in cluster" and has no slot assignments.
+
+## Recovery Procedure
+
+The recovery resets the node's local cluster state and re-attaches it as a Replica of the appropriate Primary.
+
+:::warning
+- `cluster reset` and `flushall` are destructive: they discard the node's local cluster state and *all data* on that pod. Run them **only on the broken Replica pod**. Never run them on a healthy Primary or on a pod whose data you have not confirmed is replaceable.
+- Confirm that the data on the bad pod is no longer authoritative. Because Cluster mode replicates Primary writes to Replicas, a Replica's data can normally be regenerated from its Primary; this is what makes the procedure safe **only on a Replica**.
+:::
+
+### 1. Confirm the Affected Pod is a Replica
+
+```bash
+kubectl -n <namespace> exec -it <broken-pod> -- redis-cli -a <password> ROLE
+```
+
+The first line of output must be `slave`. If it returns `master`, do **not** continue with this procedure — investigate slot coverage and refer to *How to Recover From Cross-Shard Primary Corruption in Cluster Mode* or the slot-loss procedure in the *Redis Emergency Response Playbook* instead.
+
+### 2. Reset the Node and Clear Its Local Data
+
+Open a shell on the broken Replica pod and run:
+
+```bash
+kubectl -n <namespace> exec -it <broken-pod> -- bash
+
+redis-cli -a <password>
+> CLUSTER RESET
+> FLUSHALL
+> QUIT
+```
+
+After reset, `CLUSTER NODES` from a healthy pod should show the broken node with a real IP and port, but it will still report itself as a standalone (no slots, no Primary).
+
+### 3. Attach the Node as a Replica of the Correct Primary
+
+Identify the Primary that lacks a Replica. From any healthy pod:
+
+```bash
+redis-cli -a <password> CLUSTER NODES | grep master
+```
+
+Pick the Primary whose shard is missing the Replica being recovered, and capture its node ID — referred to below as `<primary-node-id>`.
+
+On the broken pod, attach it as a Replica:
+
+```bash
+redis-cli -a <password>
+> CLUSTER REPLICATE <primary-node-id>
+> QUIT
+```
+
+### 4. Verify
+
+From any healthy pod:
+
+```bash
+redis-cli -a <password> CLUSTER NODES
+```
+
+The recovered pod should now appear as `slave` with the chosen Primary's node ID listed as its master, and its `IP:6379@16379` populated correctly. Wait for the initial sync (`INFO replication` shows `master_sync_in_progress:0`) before treating the recovery as complete.
+
+## Important Considerations
+
+- **Operator reconciliation**: After recovery, the operator should treat the cluster as healthy and stop attempting to redeploy the affected pod. If the operator continues to recreate the pod, capture its log and the Redis CR status before any further action.
+- **Repeated occurrences** of `0@0` in cluster output indicate something is removing or corrupting `nodes.conf`. Common causes include manual edits, host-path PV deletion, or scripts that wipe the data directory. Investigate and remove the trigger before applying this fix repeatedly.
+- **Backup before reset**: If you are unsure whether the broken pod is genuinely a Replica or holds the only copy of some data, take a copy of the pod's data directory before running `CLUSTER RESET` / `FLUSHALL`.
+- **Password handling**: All `redis-cli` invocations require the instance password if one is configured. Use `-a <password>` or set `REDISCLI_AUTH` to avoid leaking the password in process listings.

--- a/docs/en/solutions/ecosystem/redis/How_to_Repair_Redis_Cluster_Slot_Anomalies.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Repair_Redis_Cluster_Slot_Anomalies.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # Repair Redis Cluster Slot Anomalies

--- a/docs/en/solutions/ecosystem/redis/How_to_Repair_Redis_Cluster_Slot_Anomalies.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Repair_Redis_Cluster_Slot_Anomalies.md
@@ -1,0 +1,145 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# Repair Redis Cluster Slot Anomalies
+
+## Introduction
+
+A Redis Cluster distributes its key space across **16384 slots**. When the cluster reports `cluster_state:fail` or when `redis-cli --cluster check` flags missing or misassigned slots, the cluster cannot serve requests for the affected key ranges. This guide covers two common repair scenarios:
+
+1. A primary node has lost a contiguous range of slots.
+2. Slots have been incorrectly assigned to a replica node.
+
+:::note Terminology
+This document uses **primary** and **replica** for the Redis roles formerly known as master and slave. The Redis CLI subcommands (`CLUSTER ADDSLOTS`, `CLUSTER DELSLOTS`, `CLUSTER FAILOVER`) retain their original names.
+:::
+
+## Prerequisites
+
+1. `kubectl` access to the namespace where the Redis Cluster instance runs.
+2. The Redis password (referred to as `<password>` below). It is typically stored in the `<instance-name>-default-credentials` Secret.
+3. A working `redis-cli` inside the pod (the platform image bundles it).
+
+## Procedure
+
+### Scenario 1: Primary Node Has Lost Slots
+
+#### 1. Inspect the cluster
+
+Exec into any Redis pod and run a cluster check:
+
+```bash
+kubectl -n <namespace> exec -it <redis-pod> -- \
+  redis-cli -a '<password>' --cluster check 127.0.0.1:6379
+```
+
+The output will list the distribution of slots per primary. If a primary reports zero or fewer slots than expected, the missing range needs to be re-added. For a 3-shard cluster, the typical default ranges are:
+
+| Shard | Slots |
+|-------|-------|
+| 0 | 0-5461 |
+| 1 | 5462-10922 |
+| 2 | 10923-16383 |
+
+#### 2. Re-add the missing slots on the primary
+
+Exec into the **affected primary's** pod and add each missing slot. For a missing range of `0-5460`:
+
+```bash
+for i in $(seq 0 5460); do
+  redis-cli -a '<password>' -h 127.0.0.1 -p 6379 cluster addslots $i
+done
+```
+
+Adjust the range to match your environment. `CLUSTER ADDSLOTS` only succeeds when the slot is currently unassigned across the cluster; if a slot is held by another node, free it there first with `CLUSTER DELSLOTS`.
+
+#### 3. Verify
+
+Re-run the cluster check:
+
+```bash
+redis-cli -a '<password>' --cluster check 127.0.0.1:6379
+```
+
+The slot count should now total 16384, and `cluster_state` should be `ok`.
+
+### Scenario 2: Replica Has Incorrectly Assigned Slots
+
+In a healthy cluster, only primaries own slots. If a `--cluster check` shows that a replica owns one or more slots while its primary is missing them, the assignment is corrupt and needs to be reverted.
+
+#### 1. Confirm the cluster state
+
+```bash
+redis-cli -h <node-ip> -p <port> -a '<password>' cluster info
+redis-cli -a '<password>' --cluster check 127.0.0.1:6379
+```
+
+Identify the slot(s) owned by the replica and which primary they belong to.
+
+#### 2. Move the slot back to the primary
+
+Exec into the **primary** pod for the affected shard and remove the stale slot ownership:
+
+```bash
+redis-cli -a '<password>' -h 127.0.0.1 -p 6379 CLUSTER DELSLOTS <slot>
+```
+
+Then exec into the **replica** pod that currently owns the slot and remove it there too:
+
+```bash
+redis-cli -a '<password>' -h 127.0.0.1 -p 6379 CLUSTER DELSLOTS <slot>
+```
+
+The slot is now unassigned. Add it back on the primary:
+
+```bash
+# On the primary pod
+redis-cli -a '<password>' -h 127.0.0.1 -p 6379 CLUSTER ADDSLOTS <slot>
+```
+
+#### 3. (If needed) Trigger a controlled failover
+
+If the cluster topology drifted because of the wrong assignment, you can request the replica to take over its primary's role using a manual failover. From the **replica** pod:
+
+```bash
+redis-cli -a '<password>' -h 127.0.0.1 -p 6379 CLUSTER FAILOVER
+```
+
+Use `CLUSTER FAILOVER FORCE` only when the primary is unreachable - it bypasses replication checks and may lose in-flight writes.
+
+#### 4. Verify
+
+```bash
+redis-cli -a '<password>' --cluster check 127.0.0.1:6379
+redis-cli -a '<password>' cluster info
+```
+
+`cluster_state:ok` and `cluster_slots_assigned:16384` confirm the cluster is healthy.
+
+## Important Considerations
+
+### Slot Ownership Is Cluster-Wide
+
+`CLUSTER ADDSLOTS` and `CLUSTER DELSLOTS` operate on the local node's view but are gossiped to peers. After running them, allow a few seconds for the cluster to converge before re-checking.
+
+### Don't Reassign Slots That Hold Live Data
+
+`CLUSTER DELSLOTS` does **not** migrate the keys that live in those slots. If keys exist in a slot you are about to remove, they become unreachable. Use `CLUSTER COUNT-KEYS-IN-SLOT <slot>` first to confirm the slot is empty, or use `redis-cli --cluster reshard` to migrate keys before changing ownership.
+
+### Always Repair From the Primary
+
+Run `ADDSLOTS` on the primary that should own the slot, not the replica. Replicas inherit slot ownership from their primary; manually adding slots on a replica is what causes Scenario 2 in the first place.
+
+### When Repair Is Not Enough
+
+If the cluster has lost so much state that `--cluster check` reports many overlapping slot owners, prefer:
+
+```bash
+redis-cli -a '<password>' --cluster fix 127.0.0.1:6379
+```
+
+This drives the cluster through a guided repair, including key migration. Use the manual `ADDSLOTS` / `DELSLOTS` workflow only for surgical fixes on otherwise healthy clusters.

--- a/docs/en/solutions/ecosystem/redis/How_to_Resolve_Master_Replica_Sync_Failure.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Resolve_Master_Replica_Sync_Failure.md
@@ -1,0 +1,124 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# Resolve Master-Replica Sync Failure
+
+:::info Applies to
+Redis instances in **Sentinel mode** and **Cluster mode**.
+:::
+
+## Introduction
+
+Redis replication relies on two buffers between the primary and the replica:
+
+- **Replication backlog** (`repl-backlog-size`) - shared by all clients on the primary, default `1mb`. Used for partial resynchronization.
+- **Client output buffer** (`client-output-buffer-limit`) - per-connection, including replica connections. The default `slave` setting is `256mb 64mb 60`: a hard cap of 256 MiB, a soft limit of 64 MiB sustained for 60 seconds before the connection is closed.
+
+When either buffer overflows, the replica is disconnected and forced into a full resynchronization, which produces visible errors and replication lag.
+
+:::note redis-operator >= 3.14
+Starting from redis-operator **3.14**, `repl-backlog-size` is auto-calculated by the operator using the formula `maxmemory * 0.01`. On older versions you must size it manually.
+:::
+
+## Prerequisites
+
+1. `kubectl` access to the namespace where the Redis instance runs.
+2. Permission to update the Redis CR (or the underlying ConfigMap that holds the Redis configuration).
+3. Awareness that changing `client-output-buffer-limit` on a running instance will reset open replica connections.
+
+## Identifying the Symptom
+
+### On the Replica
+
+The replica logs report:
+
+```text
+I/O error reading bulk count from MASTER: Resource temporarily unavailable
+```
+
+### On the Primary
+
+The primary logs report:
+
+```text
+... scheduled to be closed ASAP for overcoming of output buffer limits.
+```
+
+Either message indicates the replica's client output buffer on the primary has overflowed.
+
+## Diagnosis: Why the Buffer Overflows
+
+| Cause | How to recognize | Remediation |
+|-------|------------------|-------------|
+| Clients write too fast | Primary CPU sits at ~90% during normal load | Raising the buffer helps short-term, but increasing the instance size or adding shards is the durable fix. |
+| Replica writes too slow | The replica log shows a long RDB load duration during full sync (e.g. 2 GB taking ~3 min). Full sync is bottlenecked by disk. | Switch to the `diskless` parameter template to reduce replica disk I/O. |
+| Big keys | The primary's RDB persistence log shows persistence triggered by very few key updates (much less than ~20k); CPU is not saturated and writes are not heavy. A single large value can saturate the buffer instantly. | Increase the buffer; identify and split big keys in the application layer. |
+
+## Procedure
+
+### 1. (redis-operator < 3.14 only) Size the Replication Backlog
+
+For older operators, set `repl-backlog-size` explicitly. Use roughly `maxmemory * 0.01`:
+
+```yaml
+apiVersion: middleware.alauda.io/v1
+kind: Redis
+metadata:
+  name: <instance-name>
+  namespace: <namespace>
+spec:
+  customConfig:
+    repl-backlog-size: "100mb"   # Example for a 10 GiB instance
+```
+
+For redis-operator **>= 3.14**, this is computed automatically and does not need to be set.
+
+### 2. Increase the Replica Client Output Buffer
+
+The default for the `slave` class is `256mb 64mb 60`. Adjust the **slave portion only**, leaving `normal` and `pubsub` at their defaults. A reasonable first step is to double the limits:
+
+```yaml
+apiVersion: middleware.alauda.io/v1
+kind: Redis
+metadata:
+  name: <instance-name>
+  namespace: <namespace>
+spec:
+  customConfig:
+    client-output-buffer-limit: "normal 0 0 0 slave 516mb 256mb 60 pubsub 33554432 8388608 60"
+```
+
+Apply the change and watch the primary's log. If the `out output buffer limit` errors persist, **double the slave hard and soft limits again** and observe.
+
+### 3. Validate
+
+Check `INFO replication` on the primary:
+
+```bash
+kubectl -n <namespace> exec -it <primary-pod> -- \
+  redis-cli -a '<password>' info replication
+```
+
+A healthy replica entry shows `state=online` and `lag=0` (or single-digit seconds). Errors should no longer appear in the primary or replica logs.
+
+## Important Considerations
+
+### The Buffer Is Per-Connection
+
+`client-output-buffer-limit slave` applies to **each** replica's connection independently. Memory budget on the primary scales with the number of replicas, so very large limits combined with many replicas can pressure the primary's memory.
+
+### Big Keys Are the Real Fix
+
+A single multi-megabyte value (a long list, hash, or set) can fill the buffer in one command. Raising the buffer only postpones the symptom. Use `redis-cli --bigkeys` or `MEMORY USAGE` to find offenders, then remodel the data (split the key, reduce element count) in the application.
+
+### Diskless Replication for Slow Replicas
+
+If the bottleneck is the replica's disk during full sync, switch the operator's parameter template to **diskless**. The primary streams the RDB directly into the replica's memory rather than writing to and reading from disk on both sides.
+
+### Resync Is Disruptive
+
+Whenever the buffer overflows, the next resync may be a full sync (instead of partial). Full syncs spike both primary and replica resource usage; size the buffer such that **partial** resync remains the norm during transient slowdowns.

--- a/docs/en/solutions/ecosystem/redis/How_to_Resolve_Master_Replica_Sync_Failure.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Resolve_Master_Replica_Sync_Failure.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # Resolve Master-Replica Sync Failure

--- a/docs/en/solutions/ecosystem/redis/How_to_Run_Redis_as_Root_User.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Run_Redis_as_Root_User.md
@@ -1,0 +1,70 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# How to Run Redis as the Root User
+
+:::info Applicable versions
+- Operator: `>= 3.10.3` or `>= 3.12.2`
+- Architectures: Sentinel, Cluster
+:::
+
+## Introduction
+
+By default, Alauda Cache Service for Redis OSS runs containers as the non-root user **`UID 999` / `GID 1000`** for security. Certain external storage backends require Redis to run as the root user to mount or write to volumes correctly. This guide explains how to configure the Redis Pod's `securityContext` so the container runs as root, enabling integration with these storage systems.
+
+## Storage Backends That Require Root
+
+| Storage Type | Requires Root | Notes |
+|--------------|---------------|-------|
+| CephFS | — (deprecated) | CephFS integration was discontinued in operator 3.8. Use NFS, EFS, or a CSI-based block-storage class instead. |
+| NFS | Conditional | Required only if the export does not grant `others` read/write permissions. Prefer fixing the export over enabling root. |
+| EFS | Yes | The default AWS EFS Persistent Volume requires the root user. |
+
+If your storage class does not require root access, **do not** enable this option — running as root weakens the container's security posture.
+
+## Procedure
+
+The configuration is identical for Sentinel and Cluster modes. When creating a new Redis instance, switch to YAML view and add `spec.securityContext` to run the container as root.
+
+### Example
+
+```yaml
+apiVersion: middleware.alauda.io/v1
+kind: Redis
+metadata:
+  name: <instance-name>
+  namespace: <namespace>
+spec:
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
+  # ... remaining fields (arch, replicas, resources, persistent, etc.)
+```
+
+Apply the resource:
+
+```bash
+kubectl apply -f <redis-instance>.yaml
+```
+
+After the instance is created, verify the Pods are running as root:
+
+```bash
+kubectl -n <namespace> exec -it <redis-pod> -- id
+# Expected output: uid=0(root) gid=0(root) groups=0(root)
+```
+
+## Important Considerations
+
+:::note
+When you patch `spec.securityContext` on an **existing** instance, the operator updates the underlying StatefulSet immediately, but the running Pods are **not** restarted automatically. To apply the change to running Pods, delete each Pod manually (the StatefulSet controller recreates them with the new security context) or trigger a rolling restart by also bumping a resource field such as CPU/memory.
+:::
+
+- Running as root expands the container's privileges. Apply this configuration only when the underlying storage strictly requires it.
+- For NFS, prefer adjusting the export permissions (granting `others` read/write) over running as root when feasible.
+- Combine this configuration with PodSecurity policies that explicitly allow privileged Pods in the Redis namespace, since most cluster-wide security baselines disallow root containers.

--- a/docs/en/solutions/ecosystem/redis/How_to_Run_Redis_as_Root_User.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Run_Redis_as_Root_User.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # How to Run Redis as the Root User

--- a/docs/en/solutions/ecosystem/redis/How_to_Set_Sentinel_Node_Password.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Set_Sentinel_Node_Password.md
@@ -1,0 +1,79 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# How to Set a Password on Redis Sentinel Nodes
+
+## Introduction
+
+This guide explains how to configure a password on the Sentinel nodes of a Redis Sentinel-mode instance. While Sentinel nodes do not store user data, they can manipulate the topology of the Redis cluster (for example, by triggering failover). Protecting them with a password prevents unauthorized clients from interfering with the cluster.
+
+Native password support on Sentinel was introduced in Redis 5.0.1. Alauda Cache Service for Redis OSS exposes this capability starting from redis-operator 3.18.
+
+:::info Applicable Version
+redis-operator >= 3.18 (Sentinel mode only)
+:::
+
+:::warning
+- Sentinel node credentials are independent of data-node credentials. They are managed as two separate password chains.
+- Changing the Sentinel password causes **all instance pods to restart**.
+- On **redis-operator 3.18**, S3 backup is incompatible with a Sentinel-protected instance. Verify your operator release notes before relying on this combination on later versions.
+:::
+
+## Prerequisites
+
+- redis-operator 3.18 or later is installed in the target cluster.
+- The Redis instance is using Sentinel architecture.
+- You have permission to create Secrets in the target namespace.
+
+## Procedure
+
+### Setting the Sentinel Password at Instance Creation
+
+1. Create a Secret in the same namespace as the Redis instance:
+
+   ```bash
+   kubectl -n <namespace> create secret generic <sentinel-password-secret> \
+     --from-literal=password=<your-password>
+   ```
+
+   :::note
+   The Secret must live in the **same namespace** as the Redis instance. Do **not** reuse the data-node password Secret for the Sentinel password — they must be distinct Secrets.
+   :::
+
+2. On the instance creation page, switch to the YAML tab and add the Sentinel password reference:
+
+   ```yaml
+   spec:
+     sentinel:
+       passwordSecret: "<sentinel-password-secret>"
+   ```
+
+3. Submit the form to create the instance.
+
+### Updating the Sentinel Password
+
+To rotate the Sentinel password:
+
+1. Create a new Secret with the new password:
+
+   ```bash
+   kubectl -n <namespace> create secret generic <new-sentinel-password-secret> \
+     --from-literal=password=<new-password>
+   ```
+
+2. Update `spec.sentinel.passwordSecret` on the Redis CR to reference the new Secret.
+
+:::warning
+- You must rotate to a **new** Secret. Updating the value inside an existing Secret without changing the reference will not be picked up by the operator.
+- All instance pods restart when the Sentinel password is rotated. Plan the operation accordingly.
+:::
+
+## Important Considerations
+
+- Sentinel and data-node passwords are managed independently. Changing one does not affect the other.
+- S3 backup compatibility: confirmed incompatible on **redis-operator 3.18**. Later releases may have lifted this limitation — check your operator's release notes before assuming the restriction still applies.
+- Switching from the form view back to the YAML view in the UI may overwrite manual edits. Make Sentinel password changes via direct CR edits or via the YAML tab without round-tripping through the form.

--- a/docs/en/solutions/ecosystem/redis/How_to_Set_Sentinel_Node_Password.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Set_Sentinel_Node_Password.md
@@ -3,6 +3,8 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 4.x
 ---
 
 # How to Set a Password on Redis Sentinel Nodes

--- a/docs/en/solutions/ecosystem/redis/How_to_Trigger_Manual_Sentinel_Failover.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Trigger_Manual_Sentinel_Failover.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # How to Trigger a Manual Sentinel Failover

--- a/docs/en/solutions/ecosystem/redis/How_to_Trigger_Manual_Sentinel_Failover.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Trigger_Manual_Sentinel_Failover.md
@@ -1,0 +1,82 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# How to Trigger a Manual Sentinel Failover
+
+## Introduction
+
+This guide explains how to manually trigger a Primary/Replica failover on a Redis Sentinel-mode instance using the `SENTINEL FAILOVER` command. Manual failover is useful for verifying that client applications correctly handle Primary changes, validating Sentinel quorum behavior, and performing planned maintenance on the current Primary node.
+
+:::info Applicable Version
+All versions of Alauda Cache Service for Redis OSS that support Sentinel mode.
+:::
+
+:::note
+This document uses the term "Primary" to refer to the main Redis node in a replication setup. This is the current standard terminology, replacing the previously used term "Master".
+:::
+
+## Prerequisites
+
+- A running Redis Sentinel-mode instance with at least one Replica.
+- `kubectl` access to the namespace that hosts the instance, or terminal access to one of the Sentinel pods.
+- The Redis password (if the instance is password-protected). Sentinel command access on the default port (`26379`) does not require the data-node password unless Sentinel authentication is configured.
+
+## Procedure
+
+### 1. Identify the Current Primary
+
+Identify which pod is currently serving as the Primary so that you can confirm the failover afterwards. Use either of the following methods.
+
+**Option A: Use the platform UI**
+
+Open the Redis instance detail page on the platform and view the topology panel. The current Primary node is displayed in the topology view.
+
+**Option B: Use the `INFO replication` command**
+
+Connect to any data node and run:
+
+```bash
+redis-cli -a <your-password> INFO replication
+```
+
+The output `role:master` identifies the current Primary; `role:slave` identifies a Replica. Replicas also report `master_host` and `master_port`, which point to the current Primary.
+
+### 2. Trigger the Failover from a Sentinel Pod
+
+Sentinel pods are typically named with an `rfs-` prefix. Open a shell on any Sentinel pod, then run:
+
+```bash
+redis-cli -p 26379 SENTINEL FAILOVER mymaster
+```
+
+`mymaster` is the default monitored cluster name used by the operator. Do not change it unless your instance was deliberately configured with a different name.
+
+A successful failover response returns `OK`. The actual transition typically completes in under 10 seconds.
+
+:::tip
+You can run `SENTINEL FAILOVER` from any Sentinel pod — the Sentinel quorum will coordinate the election. Successive `SENTINEL FAILOVER` calls within a short window may be rejected with `NOGOODSLAVE` if Sentinel does not consider the cluster ready for another failover.
+:::
+
+### 3. Verify the New Primary
+
+Re-run the verification from step 1. The pod that was previously a Replica should now report `role:master`, and the previous Primary should report `role:slave` and follow the new Primary.
+
+You can also monitor failover events from a Sentinel pod:
+
+```bash
+redis-cli -p 26379 SENTINEL MASTERS
+```
+
+Inspect the `flags` and `ip`/`port` fields to confirm the new Primary.
+
+## Important Considerations
+
+- **Brief unavailability window**: Clients may receive errors during the few seconds it takes for Sentinel to promote the new Primary and for Replicas to reconnect. Use this procedure to validate that your application's reconnect logic behaves correctly.
+- **Quorum requirement**: Sentinel must have a healthy quorum (the majority of Sentinel pods reachable) to perform a failover. If quorum is lost, `SENTINEL FAILOVER` will not succeed.
+- **Cooldown**: Sentinel enforces a failover timeout (default 3 minutes). A second manual failover may be rejected during this period — wait for the timeout to expire or check `SENTINEL MASTERS` output.
+- **Sentinel password**: If you have configured a Sentinel password (see *How to Set a Password on Redis Sentinel Nodes*), pass it with `-a <sentinel-password>` when running `redis-cli` on port `26379`.
+- **Production use**: Manual failover is intended for testing and planned maintenance. Do not use it as a substitute for automated failover during real outages.

--- a/docs/en/solutions/ecosystem/redis/How_to_Troubleshoot_Cluster_Mode_Connection_Errors.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Troubleshoot_Cluster_Mode_Connection_Errors.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # Troubleshoot Redis Cluster Mode Connection Errors

--- a/docs/en/solutions/ecosystem/redis/How_to_Troubleshoot_Cluster_Mode_Connection_Errors.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_Troubleshoot_Cluster_Mode_Connection_Errors.md
@@ -1,0 +1,63 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# Troubleshoot Redis Cluster Mode Connection Errors
+
+## Introduction
+
+Applications that connect to an Alauda Cache Service for Redis OSS instance running in **cluster mode** may fail with errors such as:
+
+| Symptom | What it means |
+|---|---|
+| `ERR SELECT is not allowed in cluster mode` | The client is calling `SELECT n` (database switch). Cluster mode supports only DB `0`. |
+| `MOVED <slot> <host>:6379` | The client connected to one shard but the requested key lives on a different shard. The current connection is not following cluster redirects. |
+| `unable to connect` after seemingly correct configuration | Only one seed node is configured and that node is unreachable, **or** the client uses a non-cluster API. |
+
+All three point to the same underlying cause: **a non-cluster (standalone or sentinel) client is being used to talk to a Redis Cluster.** This document focuses on diagnosing the symptom and switching the client to the cluster API. It does **not** cover how to write a cluster-aware client from scratch — for full client configuration examples, see the public docs:
+
+- [How to Access Cluster Instance](https://docs.alauda.io/redis/5.0/how_to/access/20-cluster.html) (covers Jedis, Lettuce, Redisson, go-redis)
+
+## Prerequisites
+
+- An Alauda Cache Service for Redis OSS instance deployed in **cluster** mode.
+- A client application that fails with one of the symptoms above.
+- The list of cluster node endpoints from the instance's **Access Method** page.
+
+## Diagnosis
+
+### 1. Confirm the instance is in Cluster mode
+
+In the platform UI, open the Redis instance detail page and verify the **Architecture** is `cluster` (not `sentinel` or `standalone`). If the instance is sentinel/standalone, the symptoms above are not the cause — investigate the actual error message instead.
+
+### 2. Check the client library API in use
+
+Inspect the client code or framework configuration:
+
+| Symptom | Look for | Fix |
+|---|---|---|
+| `SELECT not allowed` | `SELECT 1`, `spring.redis.database: 1`, `Jedis#select(int)` | Remove DB-switch calls; cluster mode supports only DB `0`. |
+| `MOVED ...` | `Jedis` (single node), `RedisClient` (Lettuce, single endpoint), `redis.client: standalone` | Switch to the cluster API: `JedisCluster`, `RedisClusterClient`, etc. |
+| Single-host config | `spring.redis.host`, `redis.host` | Replace with a cluster-mode block that lists multiple seed nodes. |
+
+### 3. Check the seed-node list
+
+Cluster mode discovers topology by gossiping with the seed nodes you provide. If only one seed is configured and that pod is rescheduled or restarted, the client may fail at startup. **Always list at least three primary endpoints** so bootstrap survives a single-node outage.
+
+## Resolution
+
+1. Remove every `SELECT n` (or equivalent multi-DB option) from the application.
+2. Switch the client to its **cluster API** — see the public docs linked above for the exact code per library.
+3. Provide **all primary endpoints** (or at minimum three) as the seed node list.
+4. Keep the password identical on every shard — all nodes in a cluster share the same password; use the platform-provisioned default user secret.
+5. Restart the application and tail logs to confirm `MOVED` / `SELECT` errors are gone.
+
+## Important Considerations
+
+- **Standalone clients cannot be made to work with cluster mode** by adding more host entries — the cluster API must be used. There is no equivalent shim.
+- **Pipelining across slots is not supported.** If your application pipelines multiple keys, group them into the same slot using hash tags (`{tag}`) — for example, `user:{42}:profile` and `user:{42}:sessions` both hash on `42`.
+- **External access.** When the client runs outside the Kubernetes cluster, every shard's primary and replica must be reachable. Expose them via NodePort or LoadBalancer and use those addresses in the seed list.
+- **Operator behavior:** the operator does not transform standalone connections into cluster connections. If a `MOVED` error appears, the responsibility is on the client side.

--- a/docs/en/solutions/ecosystem/redis/How_to_View_Redis_Slow_Logs.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_View_Redis_Slow_Logs.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # How to View Redis Slow Logs

--- a/docs/en/solutions/ecosystem/redis/How_to_View_Redis_Slow_Logs.md
+++ b/docs/en/solutions/ecosystem/redis/How_to_View_Redis_Slow_Logs.md
@@ -1,0 +1,108 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# How to View Redis Slow Logs
+
+## Introduction
+
+This guide describes how to inspect, manage, and configure the Redis slow log. The slow log records commands that exceed a configurable execution time threshold, making it a key tool for diagnosing performance issues and identifying inefficient queries.
+
+## Prerequisites
+
+- Access to the Redis instance via `redis-cli` or another Redis client.
+- Authentication credentials (if the instance has password authentication enabled).
+
+## Procedure
+
+### 1. Connect to Redis
+
+Use `redis-cli` to enter the Redis shell:
+
+```bash
+redis-cli -h <redis-host> -p <redis-port> -a <password>
+```
+
+### 2. View the Number of Slow Log Entries
+
+Check how many entries are currently stored in the slow log:
+
+```text
+SLOWLOG LEN
+```
+
+### 3. View Slow Log Entries
+
+Retrieve the most recent slow log entries. The argument specifies how many entries to return:
+
+```text
+SLOWLOG GET <count>
+```
+
+Example output:
+
+```text
+redis 127.0.0.1:6379> SLOWLOG GET 2
+1) 1) (integer) 14            // Unique entry identifier
+   2) (integer) 1309448221    // Unix timestamp of command execution
+   3) (integer) 15            // Execution time in microseconds (15 μs)
+   4) 1) "ping"               // The command and its arguments
+2) 1) (integer) 13
+   2) (integer) 1309448128
+   3) (integer) 30            // Execution time in microseconds (30 μs)
+   4) 1) "slowlog"
+      2) "get"
+      3) "100"
+```
+
+Each entry contains:
+
+| Field | Description |
+|-------|-------------|
+| Index 1 | Unique identifier for the slow log entry |
+| Index 2 | Unix timestamp when the command was executed |
+| Index 3 | Time taken to execute the command (in microseconds) |
+| Index 4 | The command and its arguments |
+
+### 4. Reset the Slow Log
+
+Clear all slow log entries:
+
+```text
+SLOWLOG RESET
+```
+
+## Configuration Parameters
+
+Configure the slow log behavior with the following Redis parameters. These can be set via the instance `customConfig` or with the `CONFIG SET` command at runtime:
+
+| Parameter | Description | Notes |
+|-----------|-------------|-------|
+| `slowlog-log-slower-than` | Minimum execution time (in microseconds) for a command to be recorded as a slow log entry. | Set to `0` to log every command. Set to `-1` to disable slow log recording. |
+| `slowlog-max-len` | Maximum number of entries retained in the slow log. When the limit is reached, the oldest entry is removed. | Default: `0` (no entries retained). Set to a positive value such as `128` or `1024` for production use. |
+
+Example: set the threshold to 1 millisecond (`1000` microseconds) and retain up to 1024 entries:
+
+```text
+CONFIG SET slowlog-log-slower-than 1000   # 1000 microseconds = 1 millisecond
+CONFIG SET slowlog-max-len 1024
+```
+
+To persist these settings across restarts, configure them in the instance `customConfig`:
+
+```yaml
+spec:
+  customConfig:
+    slowlog-log-slower-than: "1000"
+    slowlog-max-len: "1024"
+```
+
+## Important Considerations
+
+- The slow log is stored in memory and is cleared on instance restart unless persisted via your monitoring stack.
+- Setting `slowlog-log-slower-than` to `0` records every command and can have a noticeable performance impact. Use only for short diagnostic windows.
+- Increasing `slowlog-max-len` consumes additional memory. Choose a value appropriate to your instance size.
+- For long-term analysis, periodically scrape `SLOWLOG GET` output and forward it to a centralized logging or APM system.

--- a/docs/en/solutions/ecosystem/redis/Redis_Best_Practices.md
+++ b/docs/en/solutions/ecosystem/redis/Redis_Best_Practices.md
@@ -1,0 +1,263 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# Redis Best Practices
+
+:::info Applicable Versions
+Alauda Container Platform **v3.18+** (the supported operator at the time of this update). Architectural recommendations and sizing guidance below were originally validated on v3.12–v3.14 and remain broadly applicable to current releases. Where specific numbers (parameter template names, container limits, benchmark figures) drift from current operator defaults, prefer the values shipped by your installed operator.
+:::
+
+## Introduction
+
+Redis is a high-performance in-memory data store widely used as a cache, message broker, leaderboard, and more. Containerizing Redis on Kubernetes provides a consistent, portable, and reproducible runtime, but it also introduces new challenges around deployment, configuration, persistence, performance tuning, instance lifecycle management, and application integration.
+
+This document collects the best practices we recommend for running Alauda Cache Service for Redis OSS on Kubernetes. Following these practices helps you achieve durable, highly available, and performant Redis instances while keeping operational overhead manageable.
+
+## Architecture Overview
+
+Alauda Cache Service for Redis OSS provides two managed architectures to fit different workloads.
+
+### Sentinel Mode (Redis Sentinel)
+
+Sentinel mode is a high-availability solution built on Redis primary-replica replication. Redis Sentinel monitors the instance state and automatically promotes a replica to primary when the primary fails.
+
+Key characteristics:
+
+- **Simple to operate.** Easier to deploy and manage than cluster mode.
+- **Highly available.** Automatic failover keeps the service available when a node fails.
+- **Limited scaling.** Only vertical scaling and read scaling via replicas. There is no native horizontal sharding.
+- **Sentinel availability.** Sentinel processes themselves must be made highly available (run at least three Sentinel pods).
+
+### Cluster Mode (Redis Cluster)
+
+Cluster mode is the native horizontally scalable architecture in Redis. Data is sharded across multiple nodes using a hash slot algorithm, allowing the dataset to grow well beyond the memory of any single node.
+
+Key characteristics:
+
+- **High availability.** Replicas can take over for failed primaries automatically.
+- **Horizontal scalability.** Shards (and the nodes that host them) can be added or removed online.
+- **Load balancing.** Reads and writes are distributed across primaries.
+- **Distributed dataset.** Avoids hot spots from large datasets being concentrated on a single node.
+- **Higher complexity.** Sharding, hash slots, data migration, and rebalancing add operational complexity.
+
+### Architecture Selection Matrix
+
+|  | Needs unlimited horizontal scaling | Single-node or small footprint | Large dataset (>8 GB) | High availability |
+| --- | :---: | :---: | :---: | :---: |
+| Cluster mode | Yes | No | Yes | Yes |
+| Sentinel mode | No | Yes | No | Yes |
+
+## Resource Sizing
+
+### Memory
+
+Redis takes periodic snapshots of in-memory data to disk. This snapshotting model is fast, but data written between snapshots may be lost if Redis is killed.
+
+For production deployments, we recommend keeping the memory of each Redis shard under **8 GB**. Two reasons drive this recommendation:
+
+1. **Single-threaded event loop.** Redis processes network I/O and data operations in one thread. As the dataset grows, response time can increase, eventually causing client-visible latency or stalls.
+2. **Persistence and backup overhead.** Larger datasets make RDB/AOF snapshots, replication, and backup/restore operations slower and more expensive.
+
+If a single shard exceeds 8 GB, consider sharding the data with cluster mode instead of growing the shard further.
+
+### CPU
+
+In Kubernetes, you can opt in to dedicated CPU cores using the kubelet's static CPU manager:
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cpuManagerPolicy: static
+```
+
+After updating the kubelet configuration, restart kubelet:
+
+```bash
+systemctl restart kubelet
+```
+
+With `cpuManagerPolicy: static`, pods that request integer CPU values get exclusive cores, which is helpful for CPU-sensitive Redis workloads. Use this selectively — over-allocating exclusive CPUs wastes capacity.
+
+#### Single-threaded vs. multi-threaded sizing
+
+Redis is fundamentally single-threaded for command execution. During persistence Redis uses `fork()` to create a child process that writes the RDB file; the parent continues serving requests on its single thread. Setting the per-shard CPU limit to **2 cores** ensures the foreground thread keeps serving traffic during persistence.
+
+If you enable Redis I/O threads (Redis 6.0+), I/O can be parallelized across additional cores. Keep in mind that only some operations (network I/O, certain Lua paths) benefit from threads — most command execution remains single-threaded. Sizing CPUs above 2 cores helps only for workloads with heavy I/O concurrency.
+
+#### Reference benchmark — single-threaded
+
+The figures below are **historical reference numbers** captured on Redis 6.0 with operator v3.14. They illustrate the shape of single-thread vs I/O-thread scaling; absolute throughput on current hardware and Redis 7.x will be higher. **Re-run `redis-benchmark` against your actual instance before sizing.**
+
+A Redis instance without I/O threads, exercised with `redis-benchmark` (100 concurrent connections, 100,000 requests each, 50% SET / 50% GET):
+
+| CPU cores | Throughput (ops/sec) |
+| --- | --- |
+| 1 | 47,760 |
+| 2 | 50,143 |
+| 4 | 51,443 |
+| 8 | 50,440 |
+
+Beyond 2 cores there is essentially no improvement.
+
+#### Reference benchmark — I/O threads enabled
+
+Same workload, 4 vCPU / 8 GB instance, varying the number of I/O threads:
+
+| Threads | Throughput (ops/sec) |
+| --- | --- |
+| 1 | 51,847 |
+| 2 | 77,374 |
+| 4 | 115,934 |
+| 8 | 138,089 |
+
+I/O threads can substantially raise throughput, but real-world gains depend on workload, payload size, and network. Validate with your own benchmarks.
+
+:::tip
+Pin per-shard CPU at 2 cores by default. Increase it only when you have benchmarked your workload with I/O threads enabled and confirmed the gain.
+:::
+
+### Disk
+
+By default, the operator sets the persistent volume size to twice `maxmemory`. This is a reasonable starting point but does **not** guarantee enough space for every workload. RDB and AOF file sizes depend on actual memory usage and write patterns, not on the `maxmemory` cap.
+
+If memory utilization is high, the persistence files grow correspondingly. Watch your disk usage and either increase the PVC size or adjust the data model (TTLs, more efficient encodings) before disk pressure causes outages.
+
+#### RDB load and save reference
+
+Historical reference data (Redis 6.0, operator v3.14) — measured on an HDD with sequential read 1117 MiB/s and write 772 MiB/s. Use the table to estimate the **shape** of load/save time as a function of dataset size. SSD-backed storage and Redis 7.x both reduce these times substantially; benchmark on your own storage before relying on absolute values:
+
+| RDB size | Load time | Save time |
+| --- | --- | --- |
+| 7.6 GB (8.77 GB used memory) | 52.83 s | 59.77 s |
+| 6.7 GB (7.10 GB used memory) | 27.66 s | 52.72 s |
+| 5.7 GB | 24.05 s | 43.09 s |
+| 4.8 GB | 18.61 s | 36.84 s |
+| 3.8 GB | 14.51 s | 29.86 s |
+| 2.9 GB | 10.78 s | 22.24 s |
+
+Use these numbers to size your pod startup probe delays and `preStop` grace periods. For example, with an RDB around 7.6 GB, allow at least 60 seconds for the pod to load and another 60 seconds before forced termination so Redis can persist its dataset cleanly. Scale these values up as your dataset grows.
+
+## Deployment
+
+### Operator Topology
+
+Redis Operator can be deployed in two modes:
+
+- **Cluster mode.** A single operator manages instances in any namespace.
+- **Namespace mode.** Operator instances are scoped to specific namespaces, useful for strong tenant isolation.
+
+Pick the mode that matches your tenancy model.
+
+### Creating Instances
+
+In **Data Services**, choose **Redis**, select your **project** and **namespace**, then click **Create Redis Instance** and configure for your workload. The current operator ships Redis 6.0 and Redis 7.x; choose the latest version your applications support.
+
+#### Choosing a Parameter Template
+
+The platform ships three families of parameter templates (one per Redis minor version) for the most common workload patterns. The names below use a `<persistence>-<redis-version>-<topology>` convention — for example `rdb-redis-6.0-sentinel`, `aof-redis-7.2-cluster`. Match the Redis version of your instance to the template version.
+
+| Family | Description | `save` | `appendonly` | `repl-backlog-size` | `appendfsync` |
+| --- | --- | --- | --- | --- | --- |
+| `rdb-*` | RDB persistence. Periodic binary snapshots. Suitable when resources are limited but you can tolerate up to a few minutes of data loss. Redis can serve as the source of truth. | `60 10000 300 100 600 1` | `no` | | |
+| `diskless-*` | Persistence disabled. Redis is used purely as a cache, all data lives in memory and is lost on restart. Best for high-throughput, ephemeral workloads. | — | `no` | `50mb` | |
+| `aof-*` | AOF persistence. Every write is appended to a log, then replayed on restart. Suitable for resource-rich workloads where data durability is the priority. | — | `yes` | | `everysec` |
+
+#### Resource Specification Reference
+
+The following table summarizes recommended resource sizing across architectures, persistence modes, and instance sizes. The numbers below were last validated on operator **v3.14**; container limits shipped by current releases (v3.18+) may differ slightly. Treat the values as a starting point and verify against your installed operator's defaults.
+
+| Architecture | Persistence | Template | Instance size | Replicas | Sentinel | Shards | redis-exporter limits | Sentinel container limits | Redis container limits | Backup container | Total resources | Instance storage | Auto backup storage (7 retained) | Manual backup storage (7 retained) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Sentinel | AOF | aof-redis-6.0-sentinel | 2c4g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 2c4g | unlimited (reserve capacity) | 4.5c / 4.8g | sized to write volume | | |
+| Sentinel | AOF | aof-redis-6.0-sentinel | 4c8g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 4c8g | unlimited (reserve capacity) | 8.5c / 8.8g | sized to write volume | | |
+| Sentinel | RDB | rdb-redis-6.0-sentinel | 2c4g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 2c4g | unlimited (reserve capacity) | 4.5c / 4.8g | 8 GB | 28 GB | 28 GB |
+| Sentinel | RDB | rdb-redis-6.0-sentinel | 4c8g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 4c8g | unlimited (reserve capacity) | 8.5c / 8.64g | 16 GB | 56 GB | 56 GB |
+| Sentinel | Diskless | diskless-redis-6.0-sentinel | 2c4g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 2c4g | / | 4.5c / 4.8g | / | 28 GB | 28 GB |
+| Sentinel | Diskless | diskless-redis-6.0-sentinel | 4c8g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 4c8g | / | 8.5c / 8.8g | / | 56 GB | 56 GB |
+| Cluster | AOF | aof-redis-6.0-cluster | 2c4g | / | 3 | / | 100m / 300Mi | / | 2c4g | unlimited (reserve capacity) | 12.6c / 25.8g | sized to write volume | | |
+| Cluster | AOF | aof-redis-6.0-cluster | 4c8g | / | 3 | / | 100m / 300Mi | / | 4c8g | unlimited (reserve capacity) | 24.6c / 49.8g | sized to write volume | | |
+| Cluster | RDB | rdb-redis-6.0-cluster | 2c4g | / | 3 | / | 100m / 300Mi | / | 2c4g | unlimited (reserve capacity) | 12.6c / 25.8g | 24 GB | 84 GB | 84 GB |
+| Cluster | RDB | rdb-redis-6.0-cluster | 4c8g | / | 3 | / | 100m / 300Mi | / | 4c8g | unlimited (reserve capacity) | 24.6c / 49.8g | 48 GB | 168 GB | 168 GB |
+| Cluster | Diskless | diskless-redis-6.0-cluster | 2c4g | / | 3 | / | 100m / 300Mi | / | 2c4g | / | 12.6c / 25.8g | / | 84 GB | 84 GB |
+| Cluster | Diskless | diskless-redis-6.0-cluster | 4c8g | / | 3 | / | 100m / 300Mi | / | 4c8g | / | 24.6c / 49.8g | / | 168 GB | 168 GB |
+
+#### Scheduling and Anti-Affinity
+
+Cluster mode supports three recommended anti-affinity strategies:
+
+- **All-pod hard anti-affinity.** Every Redis pod must run on a different node. Provides the strongest fault isolation but requires at least as many nodes as pods. Deployment fails when nodes are insufficient.
+- **In-shard hard anti-affinity.** Primary and replica of the same shard must run on different nodes; pods from different shards may co-locate. Protects against single-node failures while requiring fewer nodes.
+- **In-shard soft anti-affinity.** Primary and replica should run on different nodes when possible, but may co-locate when resources are tight. Maximizes deployability at the cost of weaker isolation.
+
+| Strategy | Description | Pros | Cons | Self-healing on single failure | Data integrity on node failure |
+| --- | --- | --- | --- | --- | --- |
+| All-pod hard anti-affinity | All pods must be on different nodes | Best HA and load balance | Deployment fails when nodes are scarce | Guaranteed | Intact when failed nodes < replicas |
+| In-shard hard anti-affinity | Primary and replica of same shard must be on different nodes | Strong fault isolation per shard | Deployment fails when nodes are scarce | Possible | Intact when failed nodes < replicas |
+| In-shard soft anti-affinity | Primary and replica should be on different nodes; co-location allowed if needed | Adapts to limited capacity | Weaker isolation when co-located | Possible | Possibly intact |
+
+In sentinel mode, the default scheduling strategy is **in-shard soft anti-affinity** — primary and replica are spread across nodes when possible but may co-locate to allow deployment on smaller clusters. For production sentinel workloads, prefer hard anti-affinity if your node capacity allows.
+
+## Application Integration
+
+### Access Modes
+
+Pick the connection mode that matches your topology.
+
+| Architecture | Access mode | Recommended endpoint | Notes |
+| --- | --- | --- | --- |
+| Sentinel | In-cluster access | Sentinel address | Clients connect to the Sentinel address (default port `26379`) and discover the data nodes through Sentinel. |
+| Sentinel | External access | NodePort on data nodes + NodePort on Sentinel | Sentinel only handles discovery, so the data-node ports must also be exposed. Clients connect to the Sentinel NodePort. |
+| Cluster | In-cluster access | Headless Service (per-node) | Clients use the Service DNS to discover all cluster nodes (default port `6379`). Connections may resolve to any pod, so the client must be cluster-aware to follow `MOVED` redirects. |
+| Cluster | External access (no proxy) | NodePort on each data node | Clients connect directly to the data nodes using multiple NodePorts. Provides resilience without a proxy, but the client must be cluster-aware and configured with multiple endpoints. |
+
+### Client Configuration Example
+
+The reference client used in our internal tests is the `jedis` Java client:
+
+```xml
+<dependency>
+  <groupId>redis.clients</groupId>
+  <artifactId>jedis</artifactId>
+  <version>3.7.0</version>
+</dependency>
+```
+
+When connecting to a Redis Cluster, configure the client in cluster mode and provide all cluster endpoints — for example with Spring Boot:
+
+```yaml
+spring:
+  redis:
+    cluster:
+      nodes: <node-1-host>:<port>,<node-2-host>:<port>,<node-3-host>:<port>
+```
+
+A non-cluster-aware client connecting to a Cluster instance fails with errors such as `ERR SELECT is not allowed in cluster mode` or `MOVED <slot> <host:port>`. See the troubleshooting article for cluster mode connection errors.
+
+## Operations
+
+### Backup
+
+The platform Backup Center provides a unified place to schedule, run, and manage backups across Redis instances. It supports external S3 storage as a backup destination, scheduled and on-demand backups, restore from history, and retention management. See the backup-and-restore solutions for the procedure for each architecture.
+
+### Common Issues
+
+Check the platform knowledge base for known issues and FAQs covering topics such as cluster mode connectivity, monitoring, crash recovery, taint tolerance, and deployment optimization.
+
+## References
+
+- Redis memory optimization: https://docs.redis.com/latest/ri/memory-optimizations/
+- Redis architecture deep dive: https://architecturenotes.co/redis/
+- Redis documentation: https://redis.io/docs/
+
+## Important Considerations
+
+- **Cap shard memory at 8 GB.** Above this point Redis tail latency degrades and persistence operations become expensive.
+- **Match parameter template to durability needs.** Use RDB as the default; switch to AOF only when you cannot tolerate any data loss; use diskless when Redis is purely a cache.
+- **Plan disk for actual usage, not `maxmemory`.** Twice `maxmemory` is a starting point; monitor real consumption.
+- **Choose anti-affinity according to node capacity.** Hard anti-affinity is the safer default but requires enough nodes; soft is acceptable when capacity is the binding constraint.
+- **Cluster mode requires cluster-aware clients.** Confirm the client and connection string before going live to avoid `MOVED` and `SELECT` errors.
+- **Use Sentinel addresses, not data-node addresses, for sentinel-mode clients.** Otherwise failover will not be transparent.

--- a/docs/en/solutions/ecosystem/redis/Redis_Best_Practices.md
+++ b/docs/en/solutions/ecosystem/redis/Redis_Best_Practices.md
@@ -3,6 +3,8 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 4.x
 ---
 
 # Redis Best Practices

--- a/docs/en/solutions/ecosystem/redis/Redis_Best_Practices.md
+++ b/docs/en/solutions/ecosystem/redis/Redis_Best_Practices.md
@@ -174,18 +174,18 @@ The following table summarizes recommended resource sizing across architectures,
 
 | Architecture | Persistence | Template | Instance size | Replicas | Sentinel | Shards | redis-exporter limits | Sentinel container limits | Redis container limits | Backup container | Total resources | Instance storage | Auto backup storage (7 retained) | Manual backup storage (7 retained) |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Sentinel | AOF | aof-redis-6.0-sentinel | 2c4g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 2c4g | unlimited (reserve capacity) | 4.5c / 4.8g | sized to write volume | | |
-| Sentinel | AOF | aof-redis-6.0-sentinel | 4c8g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 4c8g | unlimited (reserve capacity) | 8.5c / 8.8g | sized to write volume | | |
-| Sentinel | RDB | rdb-redis-6.0-sentinel | 2c4g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 2c4g | unlimited (reserve capacity) | 4.5c / 4.8g | 8 GB | 28 GB | 28 GB |
-| Sentinel | RDB | rdb-redis-6.0-sentinel | 4c8g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 4c8g | unlimited (reserve capacity) | 8.5c / 8.64g | 16 GB | 56 GB | 56 GB |
-| Sentinel | Diskless | diskless-redis-6.0-sentinel | 2c4g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 2c4g | / | 4.5c / 4.8g | / | 28 GB | 28 GB |
-| Sentinel | Diskless | diskless-redis-6.0-sentinel | 4c8g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 4c8g | / | 8.5c / 8.8g | / | 56 GB | 56 GB |
-| Cluster | AOF | aof-redis-6.0-cluster | 2c4g | / | 3 | / | 100m / 300Mi | / | 2c4g | unlimited (reserve capacity) | 12.6c / 25.8g | sized to write volume | | |
-| Cluster | AOF | aof-redis-6.0-cluster | 4c8g | / | 3 | / | 100m / 300Mi | / | 4c8g | unlimited (reserve capacity) | 24.6c / 49.8g | sized to write volume | | |
-| Cluster | RDB | rdb-redis-6.0-cluster | 2c4g | / | 3 | / | 100m / 300Mi | / | 2c4g | unlimited (reserve capacity) | 12.6c / 25.8g | 24 GB | 84 GB | 84 GB |
-| Cluster | RDB | rdb-redis-6.0-cluster | 4c8g | / | 3 | / | 100m / 300Mi | / | 4c8g | unlimited (reserve capacity) | 24.6c / 49.8g | 48 GB | 168 GB | 168 GB |
-| Cluster | Diskless | diskless-redis-6.0-cluster | 2c4g | / | 3 | / | 100m / 300Mi | / | 2c4g | / | 12.6c / 25.8g | / | 84 GB | 84 GB |
-| Cluster | Diskless | diskless-redis-6.0-cluster | 4c8g | / | 3 | / | 100m / 300Mi | / | 4c8g | / | 24.6c / 49.8g | / | 168 GB | 168 GB |
+| Sentinel | AOF | aof-redis-6.0-sentinel | 2c4g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 2c4g | unlimited (reserve capacity) | 4.5c / 4.8G | sized to write volume | | |
+| Sentinel | AOF | aof-redis-6.0-sentinel | 4c8g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 4c8g | unlimited (reserve capacity) | 8.5c / 8.8G | sized to write volume | | |
+| Sentinel | RDB | rdb-redis-6.0-sentinel | 2c4g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 2c4g | unlimited (reserve capacity) | 4.5c / 4.8G | 8 GB | 28 GB | 28 GB |
+| Sentinel | RDB | rdb-redis-6.0-sentinel | 4c8g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 4c8g | unlimited (reserve capacity) | 8.5c / 8.64G | 16 GB | 56 GB | 56 GB |
+| Sentinel | Diskless | diskless-redis-6.0-sentinel | 2c4g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 2c4g | / | 4.5c / 4.8G | / | 28 GB | 28 GB |
+| Sentinel | Diskless | diskless-redis-6.0-sentinel | 4c8g | 1 | 3 | / | 100m / 128Mi | 100m / 200Mi | 4c8g | / | 8.5c / 8.8G | / | 56 GB | 56 GB |
+| Cluster | AOF | aof-redis-6.0-cluster | 2c4g | / | 3 | / | 100m / 300Mi | / | 2c4g | unlimited (reserve capacity) | 12.6c / 25.8G | sized to write volume | | |
+| Cluster | AOF | aof-redis-6.0-cluster | 4c8g | / | 3 | / | 100m / 300Mi | / | 4c8g | unlimited (reserve capacity) | 24.6c / 49.8G | sized to write volume | | |
+| Cluster | RDB | rdb-redis-6.0-cluster | 2c4g | / | 3 | / | 100m / 300Mi | / | 2c4g | unlimited (reserve capacity) | 12.6c / 25.8G | 24 GB | 84 GB | 84 GB |
+| Cluster | RDB | rdb-redis-6.0-cluster | 4c8g | / | 3 | / | 100m / 300Mi | / | 4c8g | unlimited (reserve capacity) | 24.6c / 49.8G | 48 GB | 168 GB | 168 GB |
+| Cluster | Diskless | diskless-redis-6.0-cluster | 2c4g | / | 3 | / | 100m / 300Mi | / | 2c4g | / | 12.6c / 25.8G | / | 84 GB | 84 GB |
+| Cluster | Diskless | diskless-redis-6.0-cluster | 4c8g | / | 3 | / | 100m / 300Mi | / | 4c8g | / | 24.6c / 49.8G | / | 168 GB | 168 GB |
 
 #### Scheduling and Anti-Affinity
 

--- a/docs/en/solutions/ecosystem/redis/Redis_Emergency_Response_Playbook.md
+++ b/docs/en/solutions/ecosystem/redis/Redis_Emergency_Response_Playbook.md
@@ -3,6 +3,9 @@ products:
   - Alauda Application Services
 kind:
   - Solution
+ProductsVersion:
+  - 3.x
+  - 4.x
 ---
 
 # Redis Emergency Response Playbook

--- a/docs/en/solutions/ecosystem/redis/Redis_Emergency_Response_Playbook.md
+++ b/docs/en/solutions/ecosystem/redis/Redis_Emergency_Response_Playbook.md
@@ -1,0 +1,194 @@
+---
+products:
+  - Alauda Application Services
+kind:
+  - Solution
+---
+
+# Redis Emergency Response Playbook
+
+## Introduction
+
+This playbook collects the most common emergency-response procedures for Alauda Cache Service for Redis OSS deployments running on Kubernetes. It is intended for on-call engineers and platform operators who need fast, deterministic steps when a Redis instance, the redis-operator, or a Cluster-mode topology is in a degraded state.
+
+:::info Applicable Version
+All currently supported versions of Alauda Cache Service for Redis OSS.
+:::
+
+:::note
+This document uses "Primary" and "Replica" to refer to the main Redis node and its replicas, respectively, replacing the previously used "Master"/"Slave" terminology.
+:::
+
+The playbook covers four scenarios:
+
+1. redis-operator fails to deploy
+2. A Redis instance fails to deploy
+3. Cluster-mode slots are missing
+4. Manually removing a stale node from a Cluster-mode topology
+
+For deeper recovery procedures, refer to:
+
+- *How to Recover From a Redis Cluster Crash* (resetting an unreachable Replica)
+- *How to Recover From Cross-Shard Primary Corruption in Cluster Mode*
+- *How to Recover Sentinel Instances That Have Merged Due to IP Recycling*
+
+## Architecture Overview
+
+Understanding the deployment topology is essential before triggering recovery actions. Both Sentinel mode and Cluster mode are deployed on Kubernetes using the patterns below.
+
+### Sentinel Architecture
+
+- **Data nodes** (`rfr-<instance>-*`) run as a `StatefulSet` to provide stable identity and storage.
+- **Sentinel pods** (`rfs-<instance>-*`) run as a `Deployment` because they are stateless and benefit from rolling updates.
+- **Anti-affinity** rules schedule data and Sentinel pods on different nodes.
+- **Persistent storage** is provided by `PersistentVolume` / `PersistentVolumeClaim` for data nodes.
+- **Configuration and credentials** are stored in `Secret` and `ConfigMap`.
+
+### Cluster Architecture
+
+- **Data nodes** are deployed as multiple `StatefulSets`, one per shard. Slots are distributed across Primaries by the operator.
+- Each shard's Primary is paired with one or more Replicas via anti-affinity, so a single node failure cannot take down a shard.
+- A `Service` is exposed for each instance to provide a stable client endpoint.
+
+## Procedure
+
+### Scenario 1: redis-operator Fails to Deploy
+
+**Symptom**: redis-operator stays in `Unknown` or `Pending` state and never becomes `Running`. Subsequent Redis CRs cannot be reconciled.
+
+**Recovery**:
+
+1. Delete the redis-operator deployment / CSV:
+   ```bash
+   kubectl -n <operator-namespace> delete csv <redis-operator-csv>
+   ```
+2. Confirm there are no leftover resources from a previous install:
+   ```bash
+   kubectl -n <operator-namespace> get csv,subscription,installplan | grep -i redis
+   ```
+   Remove any stale entries before proceeding.
+3. Restart the OLM catalog operator so it re-evaluates the operator catalog:
+   ```bash
+   kubectl delete pods -n cpaas-system -l app=catalog-operator
+   ```
+4. Reinstall the redis-operator from the catalog.
+
+If the operator still fails to come up, check the catalog-operator logs and the cluster's namespace quotas, image-pull credentials, and CRD installation status (`kubectl get crd | grep -i redis`).
+
+### Scenario 2: A Redis Instance Fails to Deploy
+
+**Symptom**: A Redis CR has been created but stays in `Processing` indefinitely, or its pods stay in `Pending`/`CrashLoopBackOff`.
+
+**Recovery**:
+
+1. Inspect the data-node pod logs:
+   ```bash
+   kubectl -n <namespace> logs <pod-name> -c redis
+   ```
+
+2. Inspect pod events:
+   ```bash
+   kubectl -n <namespace> describe pod <pod-name>
+   ```
+
+3. Common causes and remedies:
+
+   | Symptom | Likely Cause | Remedy |
+   |---------|--------------|--------|
+   | `0/N nodes available: ... insufficient cpu/memory` | Insufficient cluster capacity | Scale the cluster or reduce instance resource requests. |
+   | `pod has unbound immediate PersistentVolumeClaims` | StorageClass missing or PV not provisioned | Verify the `StorageClass` and provisioner. For HostPath setups see *Create Redis Instances With HostPath*. |
+   | `failed to pull image` | Registry credentials missing or image not mirrored | Configure imagePullSecret; for air-gapped environments mirror the image into the in-cluster registry. |
+   | Repeating `LOADING Redis is loading the dataset` | Large RDB on cold start | Wait for load to complete; do not delete the pod mid-load. |
+
+4. If the operator log shows reconcile errors that mention Sentinel or Cluster topology, refer to the corresponding solution document for the affected mode.
+
+### Scenario 3: Redis Cluster Slots Are Missing
+
+**Symptom**: `redis-cli --cluster check` reports `Not all 16384 slots are covered by nodes`. Clients receive `CLUSTERDOWN` errors.
+
+**Recovery**:
+
+1. Identify the missing slots and the failing shard from any data pod:
+
+   ```bash
+   redis-cli -a $REDIS_PASSWORD --cluster check 127.0.0.1:6379
+   ```
+
+   The output highlights the slot ranges that are not covered.
+
+2. Open a shell on the failing pod (the Primary that lost the slot range):
+
+   ```bash
+   kubectl -n <namespace> exec -it <pod-name> -- bash
+   ```
+
+3. Find the failing node's IP and the cluster node IDs of healthy Replicas. From a healthy pod:
+
+   ```bash
+   redis-cli -a $REDIS_PASSWORD --cluster check 127.0.0.1:6379
+   ```
+
+4. Remove the abandoned slot mapping from the failing Primary:
+
+   ```bash
+   redis-cli -a $REDIS_PASSWORD -h <failing-primary-ip> CLUSTER DELSLOTS <slot-id>
+   ```
+
+   If multiple slots are missing, repeat or pass a range — for example using a small loop in your shell.
+
+5. Assign the slot to the Replica that should own it (run on a node that can reach the affected Replica):
+
+   ```bash
+   redis-cli -a $REDIS_PASSWORD --cluster call 127.0.0.1:6379 \
+     CLUSTER SETSLOT <slot-id> NODE <replica-node-id>
+   ```
+
+6. Promote that Replica to take over the shard:
+
+   ```bash
+   # Run on the Replica targeted in step 5:
+   redis-cli -a $REDIS_PASSWORD CLUSTER FAILOVER TAKEOVER
+   ```
+
+7. Re-run the `--cluster check`. All 16384 slots should now be covered.
+
+:::warning
+`CLUSTER FAILOVER TAKEOVER` is a forceful operation that bypasses the usual majority requirement. Use it only after confirming the original Primary is unrecoverable; otherwise prefer the regular `CLUSTER FAILOVER` to avoid divergent histories.
+:::
+
+### Scenario 4: Manually Remove a Failed Node From a Cluster
+
+**Symptom**: A pod has been permanently destroyed or rebuilt, but its node ID still appears in `CLUSTER NODES` as `fail` or `disconnected`. The operator has not yet pruned it.
+
+**Recovery**:
+
+1. List the cluster nodes and identify the stale entry:
+
+   ```bash
+   redis-cli -a $REDIS_PASSWORD CLUSTER NODES
+   ```
+
+2. Capture the failed node's `<node-id>` from the first column.
+
+3. Remove the node from every node's view of the cluster. Run from any data pod:
+
+   ```bash
+   redis-cli -a $REDIS_PASSWORD --cluster call 127.0.0.1:6379 CLUSTER FORGET <node-id>
+   ```
+
+   `--cluster call` propagates the command to every node in the cluster; this is required because `CLUSTER FORGET` is local to each node.
+
+4. Re-run `CLUSTER NODES` from any pod. The forgotten node should be gone within 60 seconds (the gossip timeout).
+
+:::warning
+- `CLUSTER FORGET` only forgets the entry; it does **not** delete the underlying pod. Verify that the pod is genuinely gone before running this command, or the gossip protocol will simply re-discover the node.
+- Do not `FORGET` a node that still owns slots. Reassign its slots first using the procedure in Scenario 3.
+:::
+
+## Important Considerations
+
+- **Always capture diagnostics before destructive recovery**: `kubectl get pods -o wide`, `kubectl describe pod`, `redis-cli CLUSTER NODES`, `redis-cli INFO replication`, and operator logs. Many of these procedures lose information about the prior incorrect state once they succeed.
+- **Run destructive commands only on the affected pod**. `CLUSTER RESET`, `FLUSHALL`, `SLAVEOF NO ONE`, and `CLUSTER FAILOVER TAKEOVER` are powerful and irrevocable.
+- **Restore order before retrying**: After a successful recovery, wait for the operator to mark the Redis CR as `Healthy` before issuing further operations such as password rotations or backups.
+- **Air-gap environments**: All commands above are local to the cluster and do not require external connectivity. The redis-operator container image and Redis images must already be available in the in-cluster registry.
+- **Escalate when stuck**: If the cluster remains unhealthy after these procedures, gather the diagnostics listed above and engage the supporting product team. Do not loop destructive commands hoping for a different result.


### PR DESCRIPTION
Port 23 troubleshooting and how-to articles for Alauda Cache Service for Redis OSS (redis-operator), filling gaps not covered by docs.alauda.io/redis/5.0/. Topics include sentinel password setup, dangerous-command ACL, slow log, custom commands, RedisInsight, RedisProxyOperator, Navicat client, cluster slot/node recovery, backup template compatibility, RedisShake migration, and an emergency playbook. Each doc carries an applicable-version callout and was reviewed against operator v5.0.x; legacy procedures are clearly scoped or routed to current alternatives.