### PR TITLE
docs: parameterize NS, CLUSTER, STORAGE_CLASS in MongoDB deploy guide

### DIFF
--- a/docs/en/solutions/How_to_Deploy_Community_Percona_MongoDB_Operator.md
+++ b/docs/en/solutions/How_to_Deploy_Community_Percona_MongoDB_Operator.md
@@ -36,12 +36,13 @@ For background on the operator's features, see:
 - A target namespace, a cluster name, and a `StorageClass`. Export them once and reuse them throughout the guide:
 
   ```bash
-  export NS=<your-namespace>          # e.g. mongodb
-  export CLUSTER=<your-cluster-name>  # e.g. my-mongo — used as the CR name; derives ${CLUSTER}-secrets, ${CLUSTER}-mongos, ${CLUSTER}-mongos-0
-  export STORAGE_CLASS=<your-sc>      # e.g. topolvm-ext4 — leave empty to use the cluster default
+  export NS=<your-namespace>             # e.g. mongodb
+  export CLUSTER=<your-cluster-name>     # e.g. my-mongo — used as the CR name; resources derive from it (e.g. <cluster>-secrets, <cluster>-mongos, <cluster>-mongos-0)
+  export STORAGE_CLASS=<your-sc>         # e.g. topolvm-ext4 — leave empty to use the cluster default
+  export PRIVATE_REGISTRY=<your-registry-with-project>   # e.g. registry.example.com:443/middleware — also used by Step 1 mirror commands
   ```
 
-  All `kubectl` examples below use `"$NS"`, `"$CLUSTER"`, and `"$STORAGE_CLASS"`. If you open a fresh shell, re-export them before resuming. The cluster-wide install in Step 4 introduces an additional `OPERATOR_NS` variable for users who want the operator and the cluster CR to live in different namespaces; by default it inherits `$NS`.
+  All `kubectl` examples below use `"$NS"`, `"$CLUSTER"`, `"$STORAGE_CLASS"`, and `"$PRIVATE_REGISTRY"`. If you open a fresh shell, re-export them before resuming. The cluster-wide install in Step 4 introduces an additional `OPERATOR_NS` variable for users who want the operator and the cluster CR to live in different namespaces; by default it inherits `$NS`.
 - A `StorageClass` with dynamic PVC provisioning. Mark it as the default storage class if you want to omit `storageClassName` from the cluster CR.
 - A private container registry that your cluster nodes can pull from, with credentials to push to it.
 - A workstation with internet access where you can pull from `docker.io` and push to your private registry. Either [`skopeo`](https://github.com/containers/skopeo) or `docker` will work.
@@ -280,7 +281,7 @@ EOF
 
 ### 5b. Create the cluster CR
 
-Pick the MongoDB image tag for the version you want. The heredoc below uses `$CLUSTER`, `$PRIVATE_REGISTRY`, and `$STORAGE_CLASS` from your shell — `$PRIVATE_REGISTRY` was set in Step 1; `$CLUSTER` and `$STORAGE_CLASS` were set in Prerequisites. If you did not create an image pull Secret in Step 2, remove the `imagePullSecrets` block.
+Pick the MongoDB image tag for the version you want. The heredoc below uses `$CLUSTER`, `$PRIVATE_REGISTRY`, and `$STORAGE_CLASS` exported in Prerequisites. If you did not create an image pull Secret in Step 2, remove the `imagePullSecrets` block. The `${STORAGE_CLASS:+...}` form drops both `storageClassName` lines automatically when `STORAGE_CLASS=""`, falling back to the cluster's default StorageClass.
 
 ```bash
 MONGO_IMAGE_TAG="8.0.19-7"           # or 7.0.30-16 / 6.0.27-21
@@ -308,7 +309,7 @@ spec:
     size: 1               # production: 3 or more
     volumeSpec:
       persistentVolumeClaim:
-        storageClassName: ${STORAGE_CLASS}
+        ${STORAGE_CLASS:+storageClassName: ${STORAGE_CLASS}}
         resources:
           requests:
             storage: 10Gi
@@ -318,7 +319,7 @@ spec:
       size: 1             # production: 3 or more
       volumeSpec:
         persistentVolumeClaim:
-          storageClassName: ${STORAGE_CLASS}
+          ${STORAGE_CLASS:+storageClassName: ${STORAGE_CLASS}}
           resources:
             requests:
               storage: 10Gi
@@ -329,8 +330,6 @@ spec:
     image: ${PRIVATE_REGISTRY}/percona/percona-backup-mongodb:2.12.0
 EOF
 ```
-
-If you left `STORAGE_CLASS` empty to fall back to the cluster default, omit both `storageClassName: ${STORAGE_CLASS}` lines from the heredoc.
 
 For the full Custom Resource field reference and all available options (TLS, monitoring, backup, etc.), see the [Percona Operator Custom Resource reference](https://docs.percona.com/percona-operator-for-mongodb/operator.html).
 
@@ -344,8 +343,10 @@ Wait for `STATUS=ready`. On healthy storage, the cluster reaches ready within ~6
 
 ```text
 NAME       ENDPOINT                                            STATUS   AGE
-my-mongo   my-mongo-mongos.<NS>.svc.cluster.local:27017        ready    55s
+my-mongo   my-mongo-mongos.mongodb.svc.cluster.local:27017     ready    55s
 ```
+
+The example above assumes `CLUSTER=my-mongo` and `NS=mongodb`; your output will substitute whatever you exported.
 
 ## Step 6: Access the Cluster
 

--- a/docs/en/solutions/How_to_Deploy_Community_Percona_MongoDB_Operator.md
+++ b/docs/en/solutions/How_to_Deploy_Community_Percona_MongoDB_Operator.md
@@ -33,7 +33,13 @@ For background on the operator's features, see:
 
 - An ACP 4.x cluster with `cluster-admin` access.
 - `kubectl` configured against the target cluster.
-- A target namespace (referred to as `<NS>` below).
+- A target namespace. Export it once as `NS` and reuse it throughout the guide:
+
+  ```bash
+  export NS=<your-namespace>          # e.g. mongodb
+  ```
+
+  All `kubectl` examples below use `"$NS"`. If you open a fresh shell, re-export `NS` before resuming. The cluster-wide install in Step 4 introduces an additional `OPERATOR_NS` variable for users who want the operator and the cluster CR to live in different namespaces; by default it inherits `$NS`.
 - A `StorageClass` with dynamic PVC provisioning. Mark it as the default storage class if you want to omit `storageClassName` from the cluster CR.
 - A private container registry that your cluster nodes can pull from, with credentials to push to it.
 - A workstation with internet access where you can pull from `docker.io` and push to your private registry. Either [`skopeo`](https://github.com/containers/skopeo) or `docker` will work.
@@ -137,7 +143,7 @@ REG_PASS="<registry-password>"
 #   REG_USER=$(kubectl -n cpaas-system get secret registry-admin -o jsonpath='{.data.username}' | base64 -d)
 #   REG_PASS=$(kubectl -n cpaas-system get secret registry-admin -o jsonpath='{.data.password}' | base64 -d)
 
-kubectl -n <NS> create secret docker-registry acp-registry-pull \
+kubectl -n "$NS" create secret docker-registry acp-registry-pull \
   --docker-server="$REGISTRY_SERVER" \
   --docker-username="$REG_USER" \
   --docker-password="$REG_PASS"
@@ -150,7 +156,9 @@ If your registry allows anonymous pulls, skip this step and omit the `imagePullS
 The default `mongod`, `cfg`, and `mongos` pods created by the operator do not satisfy the Kubernetes Pod Security Admission `restricted` profile. Relabel the namespace where the **cluster CR** will live (the namespace where the database pods run) to `baseline` (or looser) before creating the CR:
 
 ```bash
-CLUSTER_NS="<NS>"   # the namespace where your PerconaServerMongoDB CR will be created
+# Defaults to $NS from Prerequisites. Override only if your cluster CR will live
+# in a different namespace from the operator (cluster-wide install — see Step 4).
+CLUSTER_NS="${CLUSTER_NS:-$NS}"
 kubectl label ns "$CLUSTER_NS" \
   pod-security.kubernetes.io/enforce=baseline \
   pod-security.kubernetes.io/audit=baseline \
@@ -186,7 +194,9 @@ Download the bundle you chose, rewrite the operator image to your private regist
 
 ```bash
 PRIVATE_REGISTRY="<your-private-registry>"
-OPERATOR_NS="<NS>"               # the namespace you will install the operator into
+# Defaults to $NS from Prerequisites. Override if you want the operator in a
+# different namespace from the cluster CR (only meaningful with cw-bundle.yaml).
+OPERATOR_NS="${OPERATOR_NS:-$NS}"
 BUNDLE="bundle.yaml"              # or cw-bundle.yaml if you chose cluster-wide above
 
 curl -sL -o "$BUNDLE" \
@@ -226,7 +236,7 @@ kubectl -n "$OPERATOR_NS" rollout status deploy/percona-server-mongodb-operator 
 Verify:
 
 ```bash
-kubectl -n <NS> get pods                # the operator pod should be Running
+kubectl -n "$OPERATOR_NS" get pods      # the operator pod should be Running
 kubectl get crd | grep psmdb            # three CRDs should be present
 ```
 
@@ -243,7 +253,7 @@ Expected CRDs:
 The operator manages five built-in users. Create a Secret containing their credentials; the cluster CR references it by name.
 
 ```bash
-kubectl -n <NS> apply -f - <<EOF
+kubectl -n "$NS" apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
@@ -314,14 +324,14 @@ spec:
     image: <PRIVATE_REGISTRY>/percona/percona-backup-mongodb:2.12.0
 ```
 
-Apply with `kubectl -n <NS> apply -f cluster.yaml`.
+Apply with `kubectl -n "$NS" apply -f cluster.yaml`.
 
 For the full Custom Resource field reference and all available options (TLS, monitoring, backup, etc.), see the [Percona Operator Custom Resource reference](https://docs.percona.com/percona-operator-for-mongodb/operator.html).
 
 ### 5c. Wait for the cluster to be ready
 
 ```bash
-kubectl -n <NS> get psmdb -w
+kubectl -n "$NS" get psmdb -w
 ```
 
 Wait for `STATUS=ready`. On healthy storage, the cluster reaches ready within ~60 seconds.
@@ -336,10 +346,10 @@ my-mongo   my-mongo-mongos.<NS>.svc.cluster.local:27017        ready    55s
 Retrieve the `userAdmin` password and run a non-interactive smoke test against the mongos router:
 
 ```bash
-PASS=$(kubectl -n <NS> get secret my-mongo-secrets \
+PASS=$(kubectl -n "$NS" get secret my-mongo-secrets \
   -o jsonpath='{.data.MONGODB_USER_ADMIN_PASSWORD}' | base64 -d)
 
-kubectl -n <NS> exec my-mongo-mongos-0 -c mongos -- mongosh --quiet \
+kubectl -n "$NS" exec my-mongo-mongos-0 -c mongos -- mongosh --quiet \
   -u userAdmin -p "$PASS" --authenticationDatabase admin \
   --eval 'print(JSON.stringify({version: db.version(), hello: db.hello().msg}))'
 ```
@@ -349,14 +359,14 @@ Expected output: `{"version":"8.0.19-7","hello":"isdbgrid"}` (the `msg` is `isdb
 For an interactive shell:
 
 ```bash
-kubectl -n <NS> exec -it my-mongo-mongos-0 -c mongos -- \
+kubectl -n "$NS" exec -it my-mongo-mongos-0 -c mongos -- \
   mongosh -u userAdmin -p "$PASS" --authenticationDatabase admin
 ```
 
 For external client access, port-forward the mongos service:
 
 ```bash
-kubectl -n <NS> port-forward svc/my-mongo-mongos 27017:27017
+kubectl -n "$NS" port-forward svc/my-mongo-mongos 27017:27017
 ```
 
 Then connect with any MongoDB client at `mongodb://userAdmin:<password>@localhost:27017/?authSource=admin`.
@@ -426,7 +436,7 @@ This guide deploys the **upstream community release** of the Percona Server for 
 - **Enabling PVC resize.** Growing `volumeSpec.persistentVolumeClaim.resources.requests.storage` is a **no-op by default**. To let the operator propagate a storage increase to the underlying PVCs, set `spec.enableVolumeExpansion: true` on the `PerconaServerMongoDB` CR. Your StorageClass must also have `allowVolumeExpansion: true`.
 - **PVC retention.** Deleting the `PerconaServerMongoDB` resource does **not** remove its PVCs. To release the storage:
   ```bash
-  kubectl -n <NS> delete pvc -l app.kubernetes.io/instance=my-mongo
+  kubectl -n "$NS" delete pvc -l app.kubernetes.io/instance=my-mongo
   ```
 - **Backup, TLS, and monitoring.** Not covered here; see the [upstream Percona Operator documentation](https://docs.percona.com/percona-operator-for-mongodb/index.html).
 - **Operator upgrades.** Follow the [upstream upgrade guide](https://docs.percona.com/percona-operator-for-mongodb/update.html). Image tags must also be updated in your CR.

--- a/docs/en/solutions/How_to_Deploy_Community_Percona_MongoDB_Operator.md
+++ b/docs/en/solutions/How_to_Deploy_Community_Percona_MongoDB_Operator.md
@@ -33,13 +33,15 @@ For background on the operator's features, see:
 
 - An ACP 4.x cluster with `cluster-admin` access.
 - `kubectl` configured against the target cluster.
-- A target namespace. Export it once as `NS` and reuse it throughout the guide:
+- A target namespace, a cluster name, and a `StorageClass`. Export them once and reuse them throughout the guide:
 
   ```bash
   export NS=<your-namespace>          # e.g. mongodb
+  export CLUSTER=<your-cluster-name>  # e.g. my-mongo — used as the CR name; derives ${CLUSTER}-secrets, ${CLUSTER}-mongos, ${CLUSTER}-mongos-0
+  export STORAGE_CLASS=<your-sc>      # e.g. topolvm-ext4 — leave empty to use the cluster default
   ```
 
-  All `kubectl` examples below use `"$NS"`. If you open a fresh shell, re-export `NS` before resuming. The cluster-wide install in Step 4 introduces an additional `OPERATOR_NS` variable for users who want the operator and the cluster CR to live in different namespaces; by default it inherits `$NS`.
+  All `kubectl` examples below use `"$NS"`, `"$CLUSTER"`, and `"$STORAGE_CLASS"`. If you open a fresh shell, re-export them before resuming. The cluster-wide install in Step 4 introduces an additional `OPERATOR_NS` variable for users who want the operator and the cluster CR to live in different namespaces; by default it inherits `$NS`.
 - A `StorageClass` with dynamic PVC provisioning. Mark it as the default storage class if you want to omit `storageClassName` from the cluster CR.
 - A private container registry that your cluster nodes can pull from, with credentials to push to it.
 - A workstation with internet access where you can pull from `docker.io` and push to your private registry. Either [`skopeo`](https://github.com/containers/skopeo) or `docker` will work.
@@ -257,7 +259,7 @@ kubectl -n "$NS" apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
-  name: my-mongo-secrets
+  name: ${CLUSTER}-secrets
 type: Opaque
 stringData:
   MONGODB_BACKUP_USER: backup
@@ -278,16 +280,19 @@ EOF
 
 ### 5b. Create the cluster CR
 
-Pick the MongoDB image tag for the version you want; substitute `<PRIVATE_REGISTRY>` and `<storage-class>`. If you created an image pull Secret in Step 2, keep the `imagePullSecrets` field; otherwise remove it.
+Pick the MongoDB image tag for the version you want. The heredoc below uses `$CLUSTER`, `$PRIVATE_REGISTRY`, and `$STORAGE_CLASS` from your shell — `$PRIVATE_REGISTRY` was set in Step 1; `$CLUSTER` and `$STORAGE_CLASS` were set in Prerequisites. If you did not create an image pull Secret in Step 2, remove the `imagePullSecrets` block.
 
-```yaml
+```bash
+MONGO_IMAGE_TAG="8.0.19-7"           # or 7.0.30-16 / 6.0.27-21
+
+kubectl -n "$NS" apply -f - <<EOF
 apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB
 metadata:
-  name: my-mongo
+  name: ${CLUSTER}
 spec:
   crVersion: 1.22.0
-  image: <PRIVATE_REGISTRY>/percona/percona-server-mongodb:8.0.19-7   # or 7.0.30-16 / 6.0.27-21
+  image: ${PRIVATE_REGISTRY}/percona/percona-server-mongodb:${MONGO_IMAGE_TAG}
   imagePullPolicy: IfNotPresent
   imagePullSecrets:
   - name: acp-registry-pull
@@ -297,13 +302,13 @@ spec:
   upgradeOptions:
     apply: disabled
   secrets:
-    users: my-mongo-secrets
+    users: ${CLUSTER}-secrets
   replsets:
   - name: rs0
     size: 1               # production: 3 or more
     volumeSpec:
       persistentVolumeClaim:
-        storageClassName: <storage-class>
+        storageClassName: ${STORAGE_CLASS}
         resources:
           requests:
             storage: 10Gi
@@ -313,7 +318,7 @@ spec:
       size: 1             # production: 3 or more
       volumeSpec:
         persistentVolumeClaim:
-          storageClassName: <storage-class>
+          storageClassName: ${STORAGE_CLASS}
           resources:
             requests:
               storage: 10Gi
@@ -321,10 +326,11 @@ spec:
       size: 1             # production: 2 or more
   backup:
     enabled: false
-    image: <PRIVATE_REGISTRY>/percona/percona-backup-mongodb:2.12.0
+    image: ${PRIVATE_REGISTRY}/percona/percona-backup-mongodb:2.12.0
+EOF
 ```
 
-Apply with `kubectl -n "$NS" apply -f cluster.yaml`.
+If you left `STORAGE_CLASS` empty to fall back to the cluster default, omit both `storageClassName: ${STORAGE_CLASS}` lines from the heredoc.
 
 For the full Custom Resource field reference and all available options (TLS, monitoring, backup, etc.), see the [Percona Operator Custom Resource reference](https://docs.percona.com/percona-operator-for-mongodb/operator.html).
 
@@ -346,10 +352,10 @@ my-mongo   my-mongo-mongos.<NS>.svc.cluster.local:27017        ready    55s
 Retrieve the `userAdmin` password and run a non-interactive smoke test against the mongos router:
 
 ```bash
-PASS=$(kubectl -n "$NS" get secret my-mongo-secrets \
+PASS=$(kubectl -n "$NS" get secret "${CLUSTER}-secrets" \
   -o jsonpath='{.data.MONGODB_USER_ADMIN_PASSWORD}' | base64 -d)
 
-kubectl -n "$NS" exec my-mongo-mongos-0 -c mongos -- mongosh --quiet \
+kubectl -n "$NS" exec "${CLUSTER}-mongos-0" -c mongos -- mongosh --quiet \
   -u userAdmin -p "$PASS" --authenticationDatabase admin \
   --eval 'print(JSON.stringify({version: db.version(), hello: db.hello().msg}))'
 ```
@@ -359,14 +365,14 @@ Expected output: `{"version":"8.0.19-7","hello":"isdbgrid"}` (the `msg` is `isdb
 For an interactive shell:
 
 ```bash
-kubectl -n "$NS" exec -it my-mongo-mongos-0 -c mongos -- \
+kubectl -n "$NS" exec -it "${CLUSTER}-mongos-0" -c mongos -- \
   mongosh -u userAdmin -p "$PASS" --authenticationDatabase admin
 ```
 
 For external client access, port-forward the mongos service:
 
 ```bash
-kubectl -n "$NS" port-forward svc/my-mongo-mongos 27017:27017
+kubectl -n "$NS" port-forward "svc/${CLUSTER}-mongos" 27017:27017
 ```
 
 Then connect with any MongoDB client at `mongodb://userAdmin:<password>@localhost:27017/?authSource=admin`.
@@ -436,7 +442,7 @@ This guide deploys the **upstream community release** of the Percona Server for 
 - **Enabling PVC resize.** Growing `volumeSpec.persistentVolumeClaim.resources.requests.storage` is a **no-op by default**. To let the operator propagate a storage increase to the underlying PVCs, set `spec.enableVolumeExpansion: true` on the `PerconaServerMongoDB` CR. Your StorageClass must also have `allowVolumeExpansion: true`.
 - **PVC retention.** Deleting the `PerconaServerMongoDB` resource does **not** remove its PVCs. To release the storage:
   ```bash
-  kubectl -n "$NS" delete pvc -l app.kubernetes.io/instance=my-mongo
+  kubectl -n "$NS" delete pvc -l "app.kubernetes.io/instance=${CLUSTER}"
   ```
 - **Backup, TLS, and monitoring.** Not covered here; see the [upstream Percona Operator documentation](https://docs.percona.com/percona-operator-for-mongodb/index.html).
 - **Operator upgrades.** Follow the [upstream upgrade guide](https://docs.percona.com/percona-operator-for-mongodb/update.html). Image tags must also be updated in your CR.


### PR DESCRIPTION
## Summary

Follow-up to #187 / #188. Reader feedback on the merged guide: replacing `<NS>` (and other placeholders like `my-mongo`, `my-mongo-secrets`, `<storage-class>`) by hand throughout the document is friction. Promote them to shell env vars defined once in Prerequisites so every command block can be copy-pasted as-is.

## Changes

- **Prerequisites** now exports three vars once: `NS`, `CLUSTER`, `STORAGE_CLASS`. The block explains the derivation rule (`${CLUSTER}-secrets`, `${CLUSTER}-mongos-0`, etc.) and notes that fresh shells need a re-export. The cluster-wide install path keeps the existing `OPERATOR_NS="${OPERATOR_NS:-$NS}"` default.
- **Steps 2 / 3 / 4 / 5 / 6 + Important Considerations**: every `kubectl -n <NS> ...` becomes `kubectl -n "$NS" ...`. Step 4 verify uses `"$OPERATOR_NS"` (operator pod, not the CR).
- **Step 5a heredoc**: secret name becomes `${CLUSTER}-secrets` so a single shell var seeds the cluster's full naming scheme.
- **Step 5b** is converted from a "save as `cluster.yaml` then edit placeholders" workflow into a `kubectl apply -f - <<EOF` heredoc. The CR body now references `$CLUSTER`, `$PRIVATE_REGISTRY`, `$STORAGE_CLASS` plus a local `MONGO_IMAGE_TAG` so the version choice is visible at the call site. A one-liner explains how to drop the `storageClassName` lines if `STORAGE_CLASS=""`.
- The illustrative `kubectl get psmdb` output line in Step 5c keeps literal `my-mongo` / `<NS>` because it shows display text, not a command.

## Test plan

- [ ] Render check: Prerequisites bullet shows the three `export` lines in one fenced block
- [ ] Step 5a heredoc renders with `${CLUSTER}-secrets` and the `<change-me>` reminder still applies
- [ ] Step 5b renders as a single `bash` fenced block ending in `EOF`, not as two separate `yaml` + bash blocks
- [ ] `grep -c 'my-mongo' docs/en/solutions/How_to_Deploy_Community_Percona_MongoDB_Operator.md` returns 2 (the Prerequisites comment and the Step 5c output example) — every other occurrence has been replaced with `$CLUSTER`
- [ ] `grep -c '<NS>' ...` returns 1 (Step 5c output example only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Percona MongoDB Operator deployment guide to use environment variables (`NS`, `CLUSTER`, `STORAGE_CLASS`) for flexible, customizable deployments without manual value substitution.
  * Enhanced deployment instructions with consistent variable references across namespace setup, operator installation, and cluster configuration steps.
  * Refined cleanup guidance for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->