### PR TITLE
docs(vmware-migration): document StorageMap for VMs spanning multiple datastores

### DIFF
--- a/docs/en/solutions/How_to_Migrate_VirtualMachine_From_VMware.md
+++ b/docs/en/solutions/How_to_Migrate_VirtualMachine_From_VMware.md
@@ -215,6 +215,12 @@ To find the Datastore UUID:
 1. Go to **Storage** in VMware and select the datastore used by the VM.
 2. Locate the **UUID** field in the details page (e.g., `68b175ce-3432506e-e94c-74867adff816`).
 
+`spec.map` is an array; each entry describes one *source datastore → destination StorageClass* mapping. **Every** VMware datastore that holds a disk of a VM you intend to migrate must have a corresponding entry, otherwise the Plan validation phase will fail.
+
+#### Single Datastore
+
+When all VM disks live on the same datastore, a single entry is enough:
+
 ```bash
 export SC_NAME=topolvm
 export VMWARE_DATA_ID=<datastore-uuid>
@@ -240,6 +246,65 @@ spec:
       namespace: konveyor-forklift
 EOF
 ```
+
+#### Multiple Datastores
+
+If the source VMware environment exposes multiple datastores and the VM you want to migrate has disks spread across several of them (for example, the OS disk on `datastore-A` and a data disk on `datastore-B`), add one entry per source datastore to `spec.map`:
+
+- Each source datastore (identified by its UUID/moRef) must appear **only once** in `spec.map`.
+- Multiple source datastores can map to **different** StorageClasses, or all of them can map to the **same** StorageClass.
+- It is recommended to cover **every** datastore used by the VM in `spec.map`; listing only a subset will fail Plan validation.
+
+The following example maps two VMware datastores to two different StorageClasses:
+
+```bash
+export VMWARE_DATA_ID_A=<datastore-a-uuid>
+export VMWARE_DATA_ID_B=<datastore-b-uuid>
+export SC_NAME_A=topolvm
+export SC_NAME_B=ceph-rbd
+
+kubectl apply -f - <<EOF
+apiVersion: forklift.konveyor.io/v1beta1
+kind: StorageMap
+metadata:
+  name: vmware-storagemap
+  namespace: konveyor-forklift
+spec:
+  map:
+    - source:
+        id: $VMWARE_DATA_ID_A
+      destination:
+        storageClass: $SC_NAME_A
+    - source:
+        id: $VMWARE_DATA_ID_B
+      destination:
+        storageClass: $SC_NAME_B
+  provider:
+    source:
+      name: vmware
+      namespace: konveyor-forklift
+    destination:
+      name: host
+      namespace: konveyor-forklift
+EOF
+```
+
+To consolidate disks from multiple source datastores into a single target StorageClass, set the same `destination.storageClass` value on each entry:
+
+```yaml
+spec:
+  map:
+    - source:
+        id: <datastore-a-uuid>
+      destination:
+        storageClass: topolvm
+    - source:
+        id: <datastore-b-uuid>
+      destination:
+        storageClass: topolvm
+```
+
+To find out which datastores a VM's disks are placed on, open the VM in vCenter → **Edit Settings** and check the datastore of each virtual disk, or query the VM's `disks[*].datastore.id` field through the Forklift inventory API.
 
 ### 8. Create Migration Plan
 

--- a/docs/zh/solutions/How_to_Migrate_VirtualMachine_From_VMware.md
+++ b/docs/zh/solutions/How_to_Migrate_VirtualMachine_From_VMware.md
@@ -216,6 +216,12 @@ EOF
 1. 在 VMware 中转到 **存储** 并选择虚拟机使用的数据存储。
 2. 在详细信息页面中找到 **UUID** 字段（例如，`68b175ce-3432506e-e94c-74867adff816`）。
 
+`spec.map` 是一个数组，每个元素描述一对「源数据存储 → 目标 StorageClass」的映射关系。要迁移的虚拟机所使用的**每一个** VMware 数据存储都必须在该数组中存在对应条目，否则计划校验阶段会报错。
+
+#### 单数据存储
+
+虚拟机的所有磁盘都位于同一个数据存储时，只需一条映射：
+
 ```bash
 export SC_NAME=topolvm
 export VMWARE_DATA_ID=<datastore-uuid>
@@ -241,6 +247,65 @@ spec:
       namespace: konveyor-forklift
 EOF
 ```
+
+#### 多数据存储
+
+如果 VMware 中存在多个数据存储，并且要迁移的虚拟机的磁盘分布在多个数据存储上（例如系统盘在 `datastore-A`、数据盘在 `datastore-B`），则需要在 `spec.map` 中为每个源数据存储分别添加一条映射条目：
+
+- 每个源数据存储（按 UUID/moRef 标识）在 `spec.map` 中**只能出现一次**。
+- 多个源数据存储既可以映射到**不同**的 StorageClass，也可以映射到**同一个** StorageClass。
+- 推荐在 `spec.map` 中覆盖虚拟机用到的全部数据存储；只列出部分会导致计划校验失败。
+
+下面的示例将两个 VMware 数据存储分别映射到不同的 StorageClass：
+
+```bash
+export VMWARE_DATA_ID_A=<datastore-a-uuid>
+export VMWARE_DATA_ID_B=<datastore-b-uuid>
+export SC_NAME_A=topolvm
+export SC_NAME_B=ceph-rbd
+
+kubectl apply -f - <<EOF
+apiVersion: forklift.konveyor.io/v1beta1
+kind: StorageMap
+metadata:
+  name: vmware-storagemap
+  namespace: konveyor-forklift
+spec:
+  map:
+    - source:
+        id: $VMWARE_DATA_ID_A
+      destination:
+        storageClass: $SC_NAME_A
+    - source:
+        id: $VMWARE_DATA_ID_B
+      destination:
+        storageClass: $SC_NAME_B
+  provider:
+    source:
+      name: vmware
+      namespace: konveyor-forklift
+    destination:
+      name: host
+      namespace: konveyor-forklift
+EOF
+```
+
+如果希望将多个数据存储统一迁移到同一个目标 StorageClass，把每条映射条目的 `destination.storageClass` 设置成相同的值即可：
+
+```yaml
+spec:
+  map:
+    - source:
+        id: <datastore-a-uuid>
+      destination:
+        storageClass: topolvm
+    - source:
+        id: <datastore-b-uuid>
+      destination:
+        storageClass: topolvm
+```
+
+要确认虚拟机的磁盘分布在哪些数据存储上，可以在 vCenter 中打开虚拟机 → **编辑设置**，查看每块虚拟磁盘所在的数据存储；或通过 Forklift 的 inventory API 查询该虚拟机的 `disks[*].datastore.id` 字段。
 
 ### 8. 创建迁移计划
 


### PR DESCRIPTION
## Summary
- Expand the StorageMap section of the VMware → ACP migration guide (both ZH and EN) so it covers VMs whose disks live on more than one VMware datastore.
- Split the section into **Single Datastore** / **Multiple Datastores** subsections, add a multi-datastore YAML example, document that each source datastore must appear in `spec.map` exactly once and may share or differ in `destination.storageClass`, and add a tip on how to discover a VM's datastore distribution (vCenter Edit Settings or Forklift inventory `disks[*].datastore.id`).

## Test plan
- [ ] Render `docs/zh/solutions/How_to_Migrate_VirtualMachine_From_VMware.md` and verify the new Single/Multiple Datastores subsections display correctly
- [ ] Render `docs/en/solutions/How_to_Migrate_VirtualMachine_From_VMware.md` and verify the same
- [ ] Sanity-check the multi-datastore StorageMap YAML against the `forklift.konveyor.io/v1beta1` CRD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced VMware migration guide with expanded StorageMap configuration requirements and practical examples
  * Added comprehensive guidance for single-datastore and multi-datastore migration scenarios
  * Included instructions for determining VM disk placement locations
  * Documentation updates available in English and Chinese

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/knowledge/pull/756)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->