### PR TITLE
[codex] Update Forklift operator naming

### DIFF
--- a/docs/en/solutions/How_to_Migrate_VirtualMachine_From_VMware.md
+++ b/docs/en/solutions/How_to_Migrate_VirtualMachine_From_VMware.md
@@ -4,7 +4,7 @@ kind:
 products:
   - Alauda Container Platform
 ProductsVersion:
-  - 4.2.x
+  - 4.2.x,4.3.x
 id: KB260100011
 ---
 
@@ -20,7 +20,7 @@ Forklift supports multiple source platforms including VMware, OpenShift Virtuali
 
 Alauda Container Platform: >= 4.2.0
 
-Forklift Version: >= v4.2.1 (get latest from cloud.alauda.io)
+Alauda Build of Forklift Operator Version: >= v4.2.1 (get latest from cloud.alauda.io)
 
 ESXi Version: >= 6.7.0
 
@@ -58,11 +58,11 @@ The migration process is divided into the following steps:
 6.  Execute the Migration Plan
 7.  Post-Migration Configuration
 
-### 1. Upload Forklift Operator Using Violet
+### 1. Upload Alauda Build of Forklift Operator Using Violet
 
 Download the `violet` tool from [cloud.alauda.io](https://cloud.alauda.io).
 
-Use the `violet` tool to upload the Forklift operator artifact to the platform.
+Use the `violet` tool to upload the Alauda Build of Forklift Operator artifact to the platform.
 
 ```bash
 export PLATFORM_URL=https://<platform-address>/
@@ -78,14 +78,14 @@ violet push <forklift-operator-package-name> \
 ### 2. Deploy the Operator
 
 1. Navigate to **Administrator → Marketplace → OperatorHub**.
-2. Locate **forklift-operator**.
+2. Locate **Alauda Build of Forklift Operator**.
 3. Click **Deploy**.
 
 ### 3. Create ForkliftController Instance
 
 Create a `ForkliftController` resource to initialize the system.
 
-1. Navigate to **Deployed Operators → Resource Instances** under the Forklift Operator.
+1. Navigate to **Deployed Operators → Resource Instances** under the Alauda Build of Forklift Operator.
 2. Create the `ForkliftController`.
 
 Verify that all pods are running:

--- a/docs/zh/solutions/How_to_Migrate_VirtualMachine_From_VMware.md
+++ b/docs/zh/solutions/How_to_Migrate_VirtualMachine_From_VMware.md
@@ -4,7 +4,7 @@ kind:
 products:
   - Alauda Container Platform
 ProductsVersion:
-  - 4.2.x
+  - 4.2.x,4.3.x
 id: KB260100011
 sourceSHA: 5475b2fa63cd603660007fb15debd934d52bcb854a295cbf51702e4dd190ddaf
 ---
@@ -21,7 +21,7 @@ Forklift 支持多个源平台，包括 VMware、OpenShift 虚拟化 (OCP)、Red
 
 Alauda 容器平台：>= 4.2.0
 
-Forklift 版本：>= v4.2.1（从 cloud.alauda.io 获取最新版本）
+Alauda Build of Forklift Operator 版本：>= v4.2.1（从 cloud.alauda.io 获取最新版本）
 
 ESXi 版本：>= 6.7.0
 
@@ -59,11 +59,11 @@ ESXi 版本：>= 6.7.0
 6. 执行迁移计划
 7. 迁移后配置
 
-### 1. 使用 Violet 上传 Forklift Operator
+### 1. 使用 Violet 上传 Alauda Build of Forklift Operator
 
 从 [cloud.alauda.io](https://cloud.alauda.io) 下载 `violet` 工具。
 
-使用 `violet` 工具将 Forklift operator 工件上传到平台。
+使用 `violet` 工具将 Alauda Build of Forklift Operator 工件上传到平台。
 
 ```bash
 export PLATFORM_URL=https://<platform-address>/
@@ -79,14 +79,14 @@ violet push <forklift-operator-package-name> \
 ### 2. 部署 Operator
 
 1. 导航到 **管理员 → Marketplace → OperatorHub**。
-2. 找到 **forklift-operator**。
+2. 找到 **Alauda Build of Forklift Operator**。
 3. 点击 **部署**。
 
 ### 3. 创建 ForkliftController 实例
 
 创建一个 `ForkliftController` 资源以初始化系统。
 
-1. 在 Forklift Operator 下导航到 **已部署的 Operator → 资源实例**。
+1. 在 Alauda Build of Forklift Operator 下导航到 **已部署的 Operator → 资源实例**。
 2. 创建 `ForkliftController`。
 
 验证所有 Pod 是否正在运行：


### PR DESCRIPTION
## Summary

- Update VMware migration docs to use the formal product name `Alauda Build of Forklift Operator` where the operator is referenced by full name.
- Keep `forklift`/`forklift-operator` identifiers unchanged where they refer to package names, pod names, or placeholders.
- Add ACP `4.3.x` to `ProductsVersion` using the repository's comma-separated multi-version format.

## Validation

- Reviewed the resulting diff for the English and Chinese VMware migration documents.
- No automated tests run; documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated VMware-to-ACP migration guide with expanded version support (4.2.x and 4.3.x)
  * Clarified and reorganized deployment procedures and terminology for Alauda Build of Forklift Operator
  * Enhanced prerequisite guidance and navigation steps for improved clarity (English and Chinese versions)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/knowledge/pull/757)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->