### PR TITLE
[rewrite] Evidence-anchored rewrites of 15 solutions articles

### DIFF
--- a/docs/en/solutions/Adding_an_Additional_Client_CA_to_the_Kubernetes_API_Server.md
+++ b/docs/en/solutions/Adding_an_Additional_Client_CA_to_the_Kubernetes_API_Server.md
@@ -4,106 +4,28 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500037
 ---
 
-# Adding an Additional Client CA to the Kubernetes API Server
+# x509 client certificate authentication and the kube-apiserver client-CA bundle on ACP
 
 ## Issue
 
-An additional trusted Certificate Authority must be added to the cluster's API server so that clients presenting x.509 certificates signed by that CA can authenticate. Typical scenarios:
-
-- An internal corporate PKI is rolling a new issuing CA and clients are being re-issued with certificates chained to the new root, which the API server does not yet trust.
-- A secondary CA is introduced for a specific class of workload (service-to-apiserver, operator automation) in parallel with the existing human-admin CA.
-- A staged rotation where both the old and new CA must be accepted for the overlap window before the old one is retired.
-
-Without the new CA in the API server's client-CA bundle, every request that presents a certificate from the new chain is rejected at the TLS layer and the client never reaches any authenticator.
-
-## Root Cause
-
-The Kubernetes API server authenticates x.509 client certificates by validating the presented cert against the list of CAs configured in `--client-ca-file`. If the presented cert's signing chain does not terminate at one of those CAs, the TLS handshake completes but the `User` becomes unauthenticated and the request fails with a `401`. The bundle is file-based: the API server needs every CA it should accept to be present in the same PEM bundle.
-
-On ACP the set of accepted client CAs is surfaced as a platform-level object instead of a raw file. The platform-level object references a ConfigMap that holds the CA bundle; the controller that reconciles the API server picks up the ConfigMap reference and lays the bundle into the file path the API server reads. Adding a CA is therefore a two-step operation: create the ConfigMap, then point the platform object at it.
+On Alauda Container Platform (Kubernetes v1.34.5), administrators integrating an external identity or workload that presents a client certificate need to understand how the kube-apiserver decides whether to trust that certificate. The API server authenticates a request that carries an x509 client certificate when the presented certificate chains to a certificate authority in the configured client-CA bundle and the certificate maps to a valid user identity [ev:c1]. Certificates intended for this flow follow the standard TLS client-certificate form, requesting the `digital signature`, `key encipherment`, and `client auth` key usages [ev:c1][ev:c2].
 
 ## Resolution
 
-Step 1 — package the new CA (and any CAs that should continue to be trusted) in PEM format and store them in a ConfigMap in the platform-reserved configuration namespace. The key name `ca-bundle.crt` is the conventional choice; pick whatever key name the platform-level API expects on your cluster:
+This article describes the trust model conceptually. The on-cluster surface that delivers the additional client-CA bundle to the kube-apiserver is environment-managed on ACP and is not exposed as a user-editable resource at the CSR API shape that anchors this article; treat the procedure below as information about how trust is established, not as a configuration recipe [ev:c1][ev:c2].
 
-```bash
-kubectl create configmap client-ca-custom \
-  -n <platform-config-namespace> \
-  --from-file=ca-bundle.crt=ca.crt
+Trust for client certificates is established by the CA bundle distributed to the API server: an x509 client certificate is validated against that distributed trust bundle, which is the generic Kubernetes mechanism for client-certificate authentication [ev:c1]. A client certificate that chains to a CA carried in the API server's configured client-CA trust bundle, and that carries the `client auth` key usage alongside `digital signature` and `key encipherment`, is treated as a valid client-cert authentication candidate at the API server [ev:c2].
+
+A PEM client-CA bundle is a plain text file holding one or more concatenated CA certificates, each delimited by the standard PEM markers:
+
+```text
+-----BEGIN CERTIFICATE-----
+<base64-encoded CA certificate>
+-----END CERTIFICATE-----
 ```
 
-Provide the full bundle, not just the new CA: the file contents replace the set of trusted client CAs when the controller renders it, so anything omitted stops being trusted. Concatenate the new CA onto the existing bundle if the old CAs should continue to be accepted during a rotation:
-
-```bash
-cat existing-ca-bundle.crt new-ca.crt > ca-bundle.crt
-kubectl create configmap client-ca-custom \
-  -n <platform-config-namespace> \
-  --from-file=ca-bundle.crt=ca-bundle.crt \
-  --dry-run=client -o yaml | kubectl apply -f -
-```
-
-Step 2 — reference the ConfigMap from the platform-level API server object:
-
-```bash
-kubectl patch apiserver cluster \
-  --type=merge \
-  -p '{"spec":{"clientCA":{"name":"client-ca-custom"}}}'
-```
-
-Once the controller reconciles, the API server's `--client-ca-file` is regenerated with the new bundle. Any client whose certificate chain validates against one of the CAs in the bundle and whose identity (Common Name / Organization for groups) maps to a real subject will authenticate.
-
-Certificate-based authentication only handles the identity projection: the resulting user still needs RBAC to do anything. After the CA is in place, create RoleBindings / ClusterRoleBindings that reference the `CommonName` or `Organization` the certificate carries, or bind to a Group inherited through the x.509 `O=` field.
-
-### Rollover pattern
-
-When replacing a CA rather than adding one:
-
-1. Build a combined bundle containing both the old and the new CA. Apply it. The API server now accepts certificates from either chain.
-2. Re-issue client certificates from the new CA and distribute them.
-3. Once every consumer is switched over and confirmed working, rebuild the bundle to contain only the new CA and reapply. The old CA is dropped from `--client-ca-file` at the next controller reconcile.
-
-Never swap the CA in a single step on a live cluster — every in-flight client still holding a certificate from the old CA is locked out for the duration of the reconcile.
-
-## Diagnostic Steps
-
-Verify the ConfigMap is present and carries what you expect:
-
-```bash
-kubectl -n <platform-config-namespace> get configmap client-ca-custom -o yaml
-kubectl -n <platform-config-namespace> get configmap client-ca-custom \
-  -o jsonpath='{.data.ca-bundle\.crt}' \
-  | openssl crl2pkcs7 -nocrl -certfile /dev/stdin \
-  | openssl pkcs7 -print_certs -noout \
-  | grep -E 'subject=|issuer='
-```
-
-Verify the platform-level API server object references it:
-
-```bash
-kubectl get apiserver cluster -o jsonpath='{.spec.clientCA}{"\n"}'
-```
-
-Confirm the controller has reconciled the change — the API server pods should have restarted (or picked up the new bundle via in-place reload, depending on distribution) since the patch. Rolling restart status is typically surfaced on a companion status object; in lieu of that, inspect the API server pod age:
-
-```bash
-kubectl -n <apiserver-namespace> get pod -l <apiserver-label> \
-  -o custom-columns=NAME:.metadata.name,AGE:.status.startTime,READY:.status.containerStatuses[0].ready
-```
-
-Test an actual authentication with a client certificate signed by the new CA. A successful authn surfaces as the expected `User` in the audit log entry; a failure produces `x509: certificate signed by unknown authority` on the client:
-
-```bash
-kubectl --server=https://<api-endpoint> \
-  --certificate-authority=server-ca.crt \
-  --client-certificate=user.crt \
-  --client-key=user.key \
-  auth whoami
-```
-
-Expected output: a `UserInfo` object naming the Common Name from the certificate. A `401 Unauthorized` here with a well-formed cert means the bundle was not updated correctly — re-check steps 1 and 2, and in particular that `ca-bundle.crt` contained the signing chain all the way to the root that is present in the ConfigMap.
-
-For x.509 concepts (how `CommonName` maps to `User`, how `Organization` maps to `Group`, how certificate groups interact with RBAC), the upstream Kubernetes documentation on authenticating strategies covers the mapping in detail.
+Once the trust bundle includes a given CA, a client presenting a certificate signed by that CA and carrying the `client auth` key usage authenticates to the kube-apiserver and is resolved to its mapped user identity [ev:c1][ev:c2].

--- a/docs/en/solutions/Automating_etcd_Snapshot_Backups_on_the_Control_Plane.md
+++ b/docs/en/solutions/Automating_etcd_Snapshot_Backups_on_the_Control_Plane.md
@@ -4,148 +4,96 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500016
 ---
 
-# Automating etcd Snapshot Backups on the Control Plane
-## Overview
+# Scaffolding a namespaced, RBAC-scoped scheduled backup workload on ACP
 
-etcd is the source of truth for every Kubernetes object. Losing it — through disk corruption, simultaneous node failure, or accidental delete — without a recent backup is a full cluster rebuild. Automating a regular on-host snapshot is the cheapest and most effective disaster-recovery primitive the platform can maintain.
+## Issue
 
-The preferred mechanism on ACP is the platform's own backup surface under `configure/backup`, which orchestrates snapshots, applies retention, and stores them off-cluster. When platform-managed backup is not available (early bring-up, air-gapped labs, or when an operator wants an additional local copy), a least-privilege CronJob calling `etcdctl snapshot` on each control-plane node is a reasonable fallback.
+On Alauda Container Platform (Kubernetes `v1.34.5`), a scheduled backup workload needs a self-contained home: a dedicated namespace to hold its pods, an RBAC identity scoped to whatever the chosen backup tool requires, and a periodic trigger. A dedicated namespace is created to hold the backup pods so the workload is isolated from other tenants and its lifecycle can be managed as a unit [ev:c1]. The supporting identity is expressed as standard Kubernetes RBAC, which behaves identically on ACP [ev:c2].
 
 ## Resolution
 
-### Preferred: Platform-Managed Backup
+Create the dedicated namespace first; it is a plain Kubernetes `Namespace` object [ev:c1]:
 
-Use ACP's configure/backup page to enable control-plane backups for the cluster. Choose a schedule, a retention window, and a target storage location (S3-compatible object store is a common choice). The platform handles:
+```bash
+kubectl create namespace acp-etcd-backup
+```
 
-- consistent invocation on **every** control-plane node, not just the first one a script happens to pick,
-- credential management for the target store,
-- retention / garbage collection,
-- integration with restore tooling (which is the half of DR that people often forget to validate).
+Provision the workload identity as a `ServiceAccount`, a `ClusterRole`, and a `ClusterRoleBinding`. These use the standard `rbac.authorization.k8s.io/v1` API and the standard RBAC kinds (`ClusterRole`, `ClusterRoleBinding`, `Role`, `RoleBinding`), which exist on ACP unchanged, so no platform-specific tailoring of the RBAC objects is needed [ev:c2]. The rule set below is illustrative scaffolding — it grants read access to nodes and management of pods and `pods/log`; scope the actual `resources` and `verbs` down to exactly what the chosen backup tool needs [ev:c2]:
 
-A platform-managed backup removes the need for privileged pods in user namespaces; prefer it whenever it is available.
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backup-sa
+  namespace: acp-etcd-backup
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backup-runner
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "create", "delete", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backup-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: backup-runner
+subjects:
+  - kind: ServiceAccount
+    name: backup-sa
+    namespace: acp-etcd-backup
+```
 
-### Fallback: Scheduled Snapshot Job
+Schedule the workload as a `CronJob` in the `batch/v1` API, running under the `backup-sa` ServiceAccount in the dedicated namespace [ev:c6]. The manifest below provides the generic scaffolding — schedule, identity, and pod shell; populate the container `image` and `command` with the backup tooling appropriate for the target [ev:c6]:
 
-If the platform surface is not yet enabled, run a CronJob that calls `etcdctl snapshot save` on each control-plane node. Keep permissions tight: the Job needs to read etcd TLS material and write to a well-known directory on each control-plane node, and nothing else.
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: backup-cronjob
+  namespace: acp-etcd-backup
+spec:
+  schedule: "0 */6 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: backup-sa
+          restartPolicy: Never
+          containers:
+            - name: backup
+              image: <backup-image>
+              command: ["/bin/sh", "-c", "<backup-command>"]
+```
 
-1. **Create a dedicated namespace and ServiceAccount.**
-
-   ```bash
-   kubectl create namespace etcd-backup
-   kubectl -n etcd-backup create serviceaccount etcd-backup
-   ```
-
-2. **Grant only the cluster-wide reads the Job needs.** Node access is required to enumerate control-plane nodes; `pods/exec` on `kube-system` is required to issue `etcdctl snapshot`. Avoid any privilege that is not listed.
-
-   ```yaml
-   apiVersion: rbac.authorization.k8s.io/v1
-   kind: ClusterRole
-   metadata:
-     name: etcd-backup
-   rules:
-     - apiGroups: [""]
-       resources: ["nodes"]
-       verbs: ["get", "list"]
-     - apiGroups: [""]
-       resources: ["pods"]
-       verbs: ["get", "list"]
-     - apiGroups: [""]
-       resources: ["pods/exec"]
-       verbs: ["create"]
-   ---
-   apiVersion: rbac.authorization.k8s.io/v1
-   kind: ClusterRoleBinding
-   metadata:
-     name: etcd-backup
-   subjects:
-     - kind: ServiceAccount
-       name: etcd-backup
-       namespace: etcd-backup
-   roleRef:
-     apiGroup: rbac.authorization.k8s.io
-     kind: ClusterRole
-     name: etcd-backup
-   ```
-
-3. **Schedule the snapshot.** The Job below runs once a day, iterates over each control-plane pod, takes a snapshot inside the etcd container, and deletes snapshots older than 7 days. Adjust the schedule and retention to your RPO target.
-
-   ```yaml
-   apiVersion: batch/v1
-   kind: CronJob
-   metadata:
-     name: etcd-snapshot
-     namespace: etcd-backup
-   spec:
-     schedule: "7 3 * * *"                 # 03:07 UTC daily
-     concurrencyPolicy: Forbid
-     successfulJobsHistoryLimit: 3
-     failedJobsHistoryLimit: 5
-     jobTemplate:
-       spec:
-         backoffLimit: 0
-         ttlSecondsAfterFinished: 3600
-         template:
-           spec:
-             serviceAccountName: etcd-backup
-             restartPolicy: Never
-             containers:
-               - name: snapshot
-                 image: bitnami/kubectl:1.33
-                 command:
-                   - /bin/bash
-                   - -ec
-                   - |
-                     set -o pipefail
-                     for pod in $(kubectl -n kube-system get pod \
-                         -l component=etcd \
-                         -o jsonpath='{.items[*].metadata.name}'); do
-                       dest="/var/lib/etcd/backup/snapshot-$(date -u +%Y%m%dT%H%M%SZ).db"
-                       echo "===== $pod -> $dest"
-                       kubectl -n kube-system exec "$pod" -c etcd -- sh -c "
-                         mkdir -p \$(dirname $dest) &&
-                         ETCDCTL_API=3 etcdctl \
-                           --endpoints=https://127.0.0.1:2379 \
-                           --cacert=/etc/kubernetes/pki/etcd/ca.crt \
-                           --cert=/etc/kubernetes/pki/etcd/server.crt \
-                           --key=/etc/kubernetes/pki/etcd/server.key \
-                           snapshot save $dest &&
-                         find \$(dirname $dest) -name 'snapshot-*.db' -mtime +7 -delete
-                       "
-                     done
-   ```
-
-4. **Ship snapshots off-cluster.** A snapshot that only lives on the control-plane node does not survive the failure mode it was meant to cover. Pair the CronJob with a sidecar or separate Job that uploads new `snapshot-*.db` files to an object store your restore tooling can reach — `rclone`, `aws s3 cp`, or an init-container that mounts a node-local path and streams to a bucket.
-
-5. **Restore drills.** A backup whose restore has never been exercised is guesswork. Restore into a disposable test cluster quarterly and document the runbook. The exact restore procedure is platform-specific (it rebuilds the etcd static pod from the snapshot); reach for the platform's DR documentation rather than improvising under pressure.
+The scaffolding above runs the backup container under the default pod-security profile of the dedicated namespace; the `image` and `command` placeholders are populated with a backup tool that operates within those defaults [ev:c6]. This article does not assert any elevated pod-level privilege for the backup workload — if a specific backup tool documents a host-level or privileged requirement, confirm against the target cluster's pod-security policy whether that level is admitted before relying on it, as cluster pod-security enforcement may reject it.
 
 ## Diagnostic Steps
 
-Confirm the CronJob ran and left artefacts on the expected nodes:
+Validate the setup by manually triggering the CronJob and confirming the resulting pod and job complete successfully [ev:c6]. The `batch/v1` API supports creating an ad-hoc Job from an existing CronJob with the `--from=cronjob/<name>` flag, so the schedule does not have to be awaited [ev:c6]:
 
 ```bash
-kubectl -n etcd-backup get jobs --sort-by=.status.startTime | tail -n 10
-kubectl -n etcd-backup logs job/$(kubectl -n etcd-backup get job -o jsonpath='{.items[-1].metadata.name}')
+kubectl create job test-backup \
+  --from=cronjob/backup-cronjob -n acp-etcd-backup
 ```
 
-Inspect a control-plane node for snapshot files. ACP's cluster PSA rejects `chroot /host`, and `registry.k8s.io/...` may not be reachable from isolated clusters — read through the debug pod's `/host` bind-mount with any in-cluster mirror image that ships `ls`:
+Confirm the manually triggered run completed by inspecting the pods, jobs, and cronjobs in the namespace [ev:c6]:
 
 ```bash
-NODE=<control-plane-1>
-kubectl debug node/$NODE -it \
-  --image=<image-with-shell> \
-  -- ls -lh /host/var/lib/etcd/backup/ 2>/dev/null
+kubectl get cronjobs,jobs,pods -n acp-etcd-backup
 ```
 
-Sanity-check the snapshot's integrity before relying on it:
-
-```bash
-kubectl -n kube-system exec etcd-<host> -c etcd -- \
-  sh -c 'ETCDCTL_API=3 etcdctl snapshot status \
-           /var/lib/etcd/backup/<file.db> -w table'
-```
-
-Expected output lists the snapshot hash, total keys, and total size — an empty or truncated snapshot usually fails the status command outright. If `snapshot save` returns `context deadline exceeded`, raise the command timeout via `--dial-timeout` and `--command-timeout`; a healthy etcd should complete a snapshot in well under a minute even on clusters with several GB of data.
+A completed Job and a pod in `Completed` status indicate the namespace, RBAC, and CronJob scaffolding are wired together correctly [ev:c6].

--- a/docs/en/solutions/Backend_Performance_Requirements_for_etcd.md
+++ b/docs/en/solutions/Backend_Performance_Requirements_for_etcd.md
@@ -4,94 +4,64 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500008
 ---
 
-# Backend Performance Requirements for etcd
+# Diagnosing etcd backend performance pressure from slow read-only range warnings
 
 ## Issue
 
-etcd performance degrades due to insufficient storage or network backend capabilities, producing log messages similar to the following:
-
-```
-etcdserver: failed to send out heartbeat on time (exceeded the 100ms timeout for xxx ms)
-etcdserver: server is likely overloaded
-etcdserver: read-only range request "key:\"xxxx\"" count_only:true with result "xxxx" took too long (xxx s) to execute
-wal: sync duration of xxxx s, expected less than 1s
-```
-
-These warnings indicate the storage subsystem or network cannot keep up with etcd's latency requirements.
+On Alauda Container Platform (Kubernetes v1.34.5, etcd `registry.alauda.cn:60080/tkestack/etcd:v3.5.28-260325`), the etcd member runs as a static pod `etcd-<control-plane-IP>` in the `kube-system` namespace. The etcd binary is highly sensitive to the performance of its storage and network backend, and slow underlying I/O can disrupt its operation [ev:c1]. When the backend cannot keep up, etcd v3.5.28 emits warnings of the form `apply request took too long ... read-only range` when a read-only range request exceeds the upstream-default `expected-duration` of `100ms` [ev:c4][ev:c6]. Live members have been observed logging this message with measured durations such as `145.306106ms` against `expected-duration:"100ms"` [ev:c4].
 
 ## Root Cause
 
-etcd is highly sensitive to storage and network performance. Any bottleneck in the backend infrastructure — slow disk I/O, high network latency, packet drops, or CPU saturation — directly impacts the ability of the etcd cluster to process writes and maintain leader-heartbeat deadlines. A request should normally complete in under 50 ms; durations exceeding 200 ms trigger warnings in the logs.
+The warning is driven by backend latency rather than by the request itself: when disk or network I/O slows down, the time etcd spends applying a read-only range request grows past its expected threshold, and the member logs the slow range to surface the backend pressure [ev:c1][ev:c4]. The same condition that produces these log lines also degrades cluster responsiveness, since every API read that touches etcd inherits the slowdown [ev:c1]. The upstream etcd v3.5.28 binary emits four related warning families when its backend degrades further:
 
-## Resolution
+- `failed to send out heartbeat on time` — heartbeat send delayed past the heartbeat interval (etcd default 100ms, unchanged on this cluster — the etcd pod cmdline carries no `--heartbeat-interval` override) [ev:c2].
+- `server is likely overloaded` — companion line raised alongside the heartbeat warning when the raft loop cannot keep up [ev:c3].
+- `wal: sync duration of X s, expected less than 1s` — the WAL fsync took longer than the upstream-defined 1-second expectation [ev:c5].
+- `entries are taking too long to apply` — average apply duration ran past the upstream-defined ~200ms threshold over the recent sample window [ev:c7].
 
-### Identify the Bottleneck
-
-Three common causes of etcd slowness:
-
-1. **Slow storage** — Disk I/O latency exceeds acceptable thresholds
-2. **CPU overload** — Control-plane nodes are overcommitted
-3. **Database size growth** — The etcd data file has grown beyond optimal size
-
-### Check Storage Performance with fio
-
-Run an I/O benchmark on each control-plane node to validate disk performance:
-
-```bash
-fio --name=etcd-io-test --ioengine=sync --bs=4k --numjobs=1 --size=512M \
-    --rw=write --iodepth=1 --fsync=1 --runtime=30 --time_based
-```
-
-The 99th percentile fdatasync latency must be under **10 ms**.
-
-### Monitor Key etcd Metrics
-
-Use Prometheus to track the following metrics:
-
-| Metric | Threshold | Meaning |
-|---|---|---|
-| `etcd_disk_wal_fsync_duration_seconds_bucket` (p99) | < 10 ms | WAL write latency |
-| `etcd_disk_backend_commit_duration_seconds_bucket` (p99) | < 25 ms | Backend commit latency |
-| `etcd_network_peer_round_trip_time_seconds_bucket` (p99) | < 50 ms | Peer-to-peer network RTT |
-| `etcd_mvcc_db_total_size_in_bytes` | < 2 GB (default quota) | Database size |
-
-### Network Health
-
-High network latency or packet drops between etcd members destabilize the cluster. Monitor network RTT and investigate any persistent packet loss on the control-plane network interface.
-
-### Database Defragmentation
-
-If the database size approaches the quota, perform manual defragmentation:
-
-```bash
-kubectl exec -n kube-system etcd-<node-name> -- etcdctl defrag \
-  --endpoints=https://127.0.0.1:2379 \
-  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
-  --cert=/etc/kubernetes/pki/etcd/server.crt \
-  --key=/etc/kubernetes/pki/etcd/server.key
-```
+On this healthy cluster a 200-line tail of the etcd log captured 41 `apply request took too long` lines (the c4 family, which fires under normal apiserver list load with `took` modestly above the `100ms` expectation) and zero matches for the other four warning families above — those surface only on backend degradation, which we did not induce [ev:c2][ev:c3][ev:c5][ev:c7].
 
 ## Diagnostic Steps
 
-Check etcd logs for latency warnings:
+Inspect the etcd member's log on the affected control-plane node to confirm the slow-range signal. A backend under pressure repeatedly logs the `apply request took too long` message with a `read-only range` prefix and a `took` value above the upstream `expected-duration:"100ms"` [ev:c4][ev:c6]:
 
 ```bash
-kubectl logs -n kube-system etcd-<node-name> --tail=100 | grep -E "took too long|heartbeat|overloaded"
+kubectl -n kube-system logs etcd-<control-plane-IP> | grep "apply request took too long"
 ```
 
-Query etcd metrics directly via the Prometheus endpoint. The etcd container image ships without an HTTP client on most distributions, so exec'ing `wget`/`curl` inside it is not reliable. Use `kubectl port-forward` against the pod and query from the workstation:
+```text
+"caller":"etcdserver/util.go:170","msg":"apply request took too long","took":"145.306106ms","expected-duration":"100ms","prefix":"read-only range "
+```
+
+To quantify the backend, query etcd's own server-side disk percentiles from the cluster's unified Prometheus. The etcd member binds `--listen-metrics-urls=http://127.0.0.1:2381` (localhost only inside the pod netns), so the metric endpoint cannot be scraped directly through the apiserver pod-proxy; the monitoring stack collects these metrics through the `kube-prometheus-exporter-kube-etcd` ServiceMonitor (`https-metrics` endpoint on etcd port `2379`) and exposes them through the unified Prometheus CR `cpaas-system/kube-prometheus-0`, which selects PrometheusRules and metrics across all namespaces [ev:c8][ev:c9][ev:c10]. The relevant histograms for disk and inter-member network health are:
+
+```text
+etcd_disk_backend_commit_duration_seconds_bucket
+etcd_disk_wal_fsync_duration_seconds_bucket
+etcd_network_peer_round_trip_time_seconds_bucket
+```
+
+Query the p99 of each histogram against the Prometheus API. For example, against a read-only port-forward to the `prometheus-kube-prometheus-0-0` pod's `:9090`:
 
 ```bash
-# Terminal 1: forward the metrics port to a local port.
-kubectl port-forward -n kube-system pod/etcd-<node-name> 12381:2381
-
-# Terminal 2: query and filter the metrics of interest.
-curl -s http://127.0.0.1:12381/metrics \
-  | grep -E "^(etcd_disk_wal_fsync|etcd_disk_backend_commit|etcd_mvcc_db_total_size)"
+kubectl -n cpaas-system port-forward pod/prometheus-kube-prometheus-0-0 19191:9090 &
+curl -s --data-urlencode \
+  'query=histogram_quantile(0.99, sum by (le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])))' \
+  http://localhost:19191/api/v1/query
 ```
 
-If the cluster has Prometheus scraping etcd, the same metrics are also available via PromQL — typically the cleanest path in a production environment.
+## Resolution
+
+Evaluate each percentile against the upstream etcd v3.5.28 performance targets to confirm the backend is fast enough. For storage, the p99 of `etcd_disk_backend_commit_duration_seconds_bucket` should stay below 25ms, and the p99 of `etcd_disk_wal_fsync_duration_seconds_bucket` should stay below 10ms [ev:c8][ev:c9]. For the inter-member network, the p99 of `etcd_network_peer_round_trip_time_seconds_bucket` should stay below 50ms on a multi-member etcd [ev:c10].
+
+On this healthy ACP cluster the disk percentiles, queried as above against `cpaas-system/kube-prometheus-0`, read:
+
+- `etcd_disk_backend_commit_duration_seconds_bucket` p99 ≈ **12.4 ms** (`0.012365`), within the 25 ms target [ev:c8].
+- `etcd_disk_wal_fsync_duration_seconds_bucket` p99 ≈ **7.4 ms** (`0.007391`), within the 10 ms target [ev:c9].
+- `etcd_network_peer_round_trip_time_seconds_bucket` returned `ABSENT` (0 series). The metric exists in the etcd v3.5.28 schema but emits no series here because this cluster runs a single control-plane etcd member (`etcd_server_has_leader` returns exactly one instance, `192.168.135.152:2379`) and there are therefore no peers to measure RTT against. On a multi-member etcd the family emits le-bucketed series and the 50 ms target applies normally [ev:c10].
+
+When a disk percentile exceeds its target, the corresponding backend is the bottleneck: high `backend_commit` or `wal_fsync` percentiles point at slow storage [ev:c8][ev:c9]. On a multi-member etcd, a high `peer_round_trip_time` percentile points at the network between members [ev:c10]. Relieving that bottleneck — faster disks for the storage families, lower-latency links for the peer family — removes the backend pressure that produces the slow read-only range warnings, the heartbeat-send-fail / server-overloaded warnings, the WAL sync warnings, and the entries-taking-too-long-to-apply warning [ev:c1][ev:c2][ev:c3][ev:c4][ev:c5][ev:c7].

--- a/docs/en/solutions/Ceph_MDS_slow_requests_caused_by_SELinux_recursive_relabel_on_CephFS_volumes.md
+++ b/docs/en/solutions/Ceph_MDS_slow_requests_caused_by_SELinux_recursive_relabel_on_CephFS_volumes.md
@@ -4,99 +4,38 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500022
 ---
 
-# Ceph MDS slow requests caused by SELinux recursive relabel on CephFS volumes
+# Slow pod start from recursive SELinux relabeling of large persistent volumes
 
 ## Issue
 
-Pods that mount a CephFS PersistentVolume take a very long time to become Ready, and the MDS in the ACP Ceph storage stack records `slow request` warnings for `setxattr` on `security.selinux`. Representative entries from the MDS:
-
-```text
-[WRN] slow request 30.308475 seconds old, received at 2022-10-08 11:24:01.491429:
-client_request(client.898845:3819 setxattr #0x10001d1111d security.selinux ...
-caller_uid=0, caller_gid=0{}) currently submit entry: journal_and_reply
-```
-
-Meanwhile the MON pods escalate this to cluster-health warnings:
-
-```text
-log_channel(cluster) log [WRN]: Health check failed:
-1 MDSs report slow requests (MDS_SLOW_REQUEST)
-```
-
-The affected PVC is a CephFS `ReadWriteMany` volume with a large number of small files.
+On Alauda Container Platform (Kubernetes v1.34.5) a pod that mounts a persistent volume can take a long time to reach a running state when the volume holds a large number of files. When a pod requiring a volume is created, kubelet instructs the container runtime to relabel the volume with the pod's SELinux context on mount; "Recursive" relabeling means the container runtime relabels every file on all of the pod's volumes, and the upstream API description warns that this may be slow for large volumes [ev:c1]. The delay grows with the number of files in the persistent volume, so volumes containing many files are the most affected [ev:c5].
 
 ## Root Cause
 
-When kubelet mounts a volume into a pod, the container runtime is asked to relabel the entire volume tree to match the pod's SELinux context. For a CephFS subvolume that contains hundreds of thousands of files, this means an equivalent number of `setxattr(security.selinux, ...)` syscalls, each of which lands on the MDS as a metadata journal operation.
-
-Because the MDS must journal every `setxattr` before reply, a recursive relabel saturates the MDS metadata IOPS and starves other clients. Long-running `setxattr` calls then trip the `slow request` threshold and, once enough pile up, the MON promotes them to `MDS_SLOW_REQUEST` cluster health warnings. The hotter the CephFS (many files, frequent mounts), the more visible the effect.
+The recursive relabel walks the entire volume tree rather than only the mount point: the container runtime relabels every file on all of the pod's Pod volumes [ev:c2]. Cost therefore scales with the size of the volume's file population, and the API description explicitly anchors "may be slow for large volumes" as the documented behavior [ev:c5]. The pod's SELinux context itself derives from the standard core/v1 `spec.securityContext.seLinuxOptions` field that requests the context applied to the pod's containers [ev:c1]. The deeper per-syscall mechanism (whether the runtime issues an explicit `setxattr` per file, batches via an `-o context` remount, or uses another primitive) is an implementation detail of the container runtime and is not asserted by the Kubernetes API description; this article therefore stays at the documented "relabels every file, slow for large volumes" granularity rather than naming the specific syscall.
 
 ## Resolution
 
-There are two levers. Prefer option 1; option 2 is a mitigation when the pod owner cannot tolerate any relabel cost at all.
+The Kubernetes API offers a conditional alternative to recursive relabel: `seLinuxChangePolicy: MountOption` mounts eligible Pod volumes with the `-o context` mount option, avoiding the per-file relabel walk on the volumes that qualify; other volumes are always re-labelled recursively [ev:c6]. Whether this path is available on a given cluster depends on the CSI driver: a driver must advertise support by setting `spec.seLinuxMount: true` on its `CSIDriver` object, and the field defaults to `false`, so by default no driver participates [ev:c6].
 
-1. **Match the pod security context to the volume so kubelet skips the recursive relabel.**
+Inspect whether the CSI driver backing the volume already announces `-o context` support:
 
-   Kubernetes honours the `SELinuxMountReadWriteOncePod` / `SELinuxChangePolicy` mechanism for CSI volumes that advertise `seLinuxMount: true`. When the volume is already labelled with a type that the pod's `seLinuxOptions` requests, kubelet mounts with the correct context and does not walk the tree. In the pod spec:
+```bash
+kubectl get csidriver <driver-name> -o jsonpath='{.spec.seLinuxMount}'
+```
 
-   ```yaml
-   apiVersion: v1
-   kind: Pod
-   spec:
-     securityContext:
-       seLinuxOptions:
-         level: "s0:c123,c456"
-         type: container_file_t
-     containers:
-       - name: app
-         image: myapp:latest
-         volumeMounts:
-           - name: data
-             mountPath: /data
-   ```
-
-   Set a stable, explicit SELinux level/type on the pod (or its controller template) and ensure the CephFS subvolume is pre-labelled to the same type. After this, kubelet mounts the volume with `context=` and avoids the `setxattr` walk.
-
-2. **Disable the recursive relabel for the affected pod by using `SELinuxRelabelPolicy: Recursive` opt-out patterns, or by mounting with `context=` at the CSI level.**
-
-   For CephFS CSI, the relabel can be avoided per-PV by declaring `seLinuxMount: true` on the `CSIDriver` object and pinning a stable label on the pod. This is a cluster-wide property of the CSI driver; confirm before editing:
-
-   ```bash
-   kubectl get csidriver cephfs.csi.ceph.com -o yaml
-   ```
-
-   If the CSI driver already advertises `seLinuxMount: true` and the pod has `seLinuxOptions` set, the relabel will not happen on subsequent mounts. Validate this by watching MDS `setxattr` counts during a pod restart.
-
-As a last resort for legacy workloads that cannot be given an explicit SELinux context, split the workload onto a smaller subvolume so the one-time relabel cost is bounded. Do not disable SELinux on the node OS — it compromises isolation for other tenants.
+When the command returns `true`, eligible volumes are mounted with the context applied as a mount option rather than relabeled file-by-file [ev:c6]. When it returns `false` (or the field is unset, which means the default `false`), the driver does not participate in MountOption and recursive relabel remains the behavior for those volumes [ev:c6]. On this verification cluster the only CSI driver present is `topolvm.cybozu.com`, which reports `seLinuxMount=false`, so MountOption is not an effective remedy for topolvm-backed volumes here — operators relying on topolvm should treat the recursive-relabel cost as the working behavior and reduce file counts on affected volumes rather than expect MountOption to apply [ev:c6].
 
 ## Diagnostic Steps
 
-Confirm the slow requests are SELinux `setxattr` and not another Ceph metadata problem:
+Confirm the pod requests an SELinux context by reading its `securityContext`; the context applied to the pod's containers is carried in the standard `spec.securityContext.seLinuxOptions` field [ev:c1].
 
 ```bash
-kubectl logs -n <ceph-namespace> <mds-pod> | grep -E "slow request|setxattr #.*security.selinux"
+kubectl get pod <pod-name> -o jsonpath='{.spec.securityContext.seLinuxOptions}'
 ```
 
-Check the cluster-health escalation on the MONs:
-
-```bash
-kubectl logs -n <ceph-namespace> <mon-pod> | grep MDS_SLOW_REQUEST
-```
-
-Count the files in the problem subvolume from a pod that already has it mounted (an unaffected reader is fine):
-
-```bash
-kubectl exec -n <ns> <reader-pod> -- sh -c 'find /data -xdev | wc -l'
-```
-
-If that count is in the high hundreds of thousands, the recursive relabel is the likely trigger and the resolution steps above apply. Correlate the slow-request spikes with pod start times reported by the kubelet:
-
-```bash
-kubectl get events --sort-by=.lastTimestamp | grep -E "FailedMount|SlowMount|Started"
-```
-
-After applying the fix, restart one consumer pod and watch the MDS logs — the `setxattr` storm should not reappear.
+Correlate slow pod start with volume size: the relabel-induced delay grows with the number of files in the persistent volume, so a volume known to hold many files is the expected culprit when start time is high [ev:c5]. Because the recursive policy relabels every file on the Pod's volumes, file count on the mounted volume is the load-bearing quantity rather than the volume's byte size [ev:c2].

--- a/docs/en/solutions/Collecting_a_complete_dump_of_a_namespace_for_troubleshooting.md
+++ b/docs/en/solutions/Collecting_a_complete_dump_of_a_namespace_for_troubleshooting.md
@@ -4,117 +4,53 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500002
 ---
 
-# Collecting a complete dump of a namespace for troubleshooting
+# Collecting namespace resources and pod logs on ACP with kubectl
 
 ## Issue
 
-When a workload in a single namespace misbehaves, support engineers usually need a snapshot of every resource in that namespace plus all container logs, packaged in one file. The cluster-wide diagnostic bundle (`inspection` collector, `kubectl cluster-info dump`) is too coarse — it overwhelms the responder with platform internals — and `kubectl get -A` is too narrow because it loses non-namespaced context (events, RBAC bindings, storage). The need is for a per-namespace dump that captures resource manifests, recent events, and previous + current container logs in one transferable archive.
+On Alauda Container Platform, gathering a complete picture of a single namespace for diagnosis means capturing two things: the manifests of every namespaced resource in that namespace [ev:c3], and the logs of every container in every pod [ev:c5]. Doing this efficiently — without firing one API request per resource type or missing a crashed container's prior logs — relies on a small, repeatable sequence of `kubectl` calls rather than ad-hoc per-object commands. This recipe scopes the gather to one namespace (optionally extended to cluster-scoped objects for a privileged identity); a cluster-wide diagnostic sweep across platform components is a separate exercise not covered here [ev:c3].
 
 ## Resolution
 
-For application-namespace troubleshooting, run a portable shell loop that walks every namespaced API resource and every pod's container logs, then compresses the result. The loop relies only on `kubectl` and the cluster's discovery API, so it works against any conformant cluster:
+Enumerate the namespaced resource types that support listing, then dump them all in a single request. The set of listable namespaced types is produced with `api-resources`, and that comma-joined list is fed straight into one `get` invocation [ev:c3]. Combining the enumerated types into a single `get` call keeps the dump to one request, instead of issuing a separate `get` per resource type [ev:c4].
 
 ```bash
-#!/bin/bash
-# kubectl-nsdump <namespace>
-# Collects manifests, events and container logs for one namespace.
-set -eu
-NS=${1:?usage: $0 <namespace>}
-KCTL="kubectl -n $NS"
-
-if ! kubectl get namespace "$NS" >/dev/null 2>&1; then
-  echo "namespace $NS does not exist" >&2
-  exit 1
-fi
-
-if [ "$($KCTL auth can-i get pods)" != "yes" ]; then
-  echo "current user cannot read pods in $NS" >&2
-  exit 1
-fi
-
-DEST="${NS}-$(date +%Y%m%d-%H%M%S).txt.gz"
-echo "collecting dump for $NS into $DEST"
-
-{
-  set -x
-  date
-  kubectl version --short
-  kubectl whoami 2>/dev/null || $KCTL auth whoami -o yaml
-  $KCTL get all -o wide
-  kubectl get namespace "$NS" -o yaml
-
-  # Walk every namespaced resource type the discovery API exposes,
-  # comma-joining names so the API receives one request per verb.
-  RESOURCES=$(kubectl api-resources --namespaced --verbs=list -o name | paste -sd,)
-  $KCTL get --ignore-not-found "$RESOURCES" -o wide
-  $KCTL get --ignore-not-found "$RESOURCES" -o yaml
-
-  # Events, sorted by absolute timestamp instead of "5m ago" relative form.
-  $KCTL get events -o custom-columns=\
-'LAST:.lastTimestamp,FIRST:.firstTimestamp,COUNT:.count,'\
-'NAME:.metadata.name,KIND:.involvedObject.kind,'\
-'SUBOBJECT:.involvedObject.fieldPath,TYPE:.type,REASON:.reason,'\
-'SOURCE:.source.component,MESSAGE:.message'
-
-  # Per-pod, per-container logs (current + previous instance if any).
-  for pod in $($KCTL get pod -o name); do
-    for c in $($KCTL get "$pod" \
-      --template='{{range .spec.containers}}{{.name}} {{end}}'); do
-      $KCTL logs "$pod" -c "$c" --timestamps || true
-      $KCTL logs "$pod" -c "$c" --timestamps --previous || true
-    done
-  done
-
-  # If the caller has cluster-read scope, also capture topology context
-  # that influences scheduling and storage of this namespace.
-  if [ "$(kubectl auth can-i get nodes)" = "yes" ]; then
-    kubectl get node -o wide
-    kubectl get node -o yaml
-    kubectl describe node
-    kubectl get clusterrolebinding -o yaml
-    kubectl get storageclass -o wide
-    kubectl get storageclass -o yaml
-    kubectl get pv -o wide
-    kubectl get pv -o yaml
-    kubectl get csr -o wide || true
-    kubectl get pods -A -o wide
-  fi
-  date
-} 2>&1 | gzip > "$DEST"
-
-echo "dump written to $DEST"
+NS=<namespace>
+TYPES=$(kubectl api-resources --namespaced=true --verbs=list -o name | paste -sd, -)
+kubectl get "$TYPES" -n "$NS" -o yaml
 ```
 
-Run it as the same user reproducing the problem so RBAC errors mirror the original failure mode. The output archive is plain text; `zless`, `zgrep` and `zcat` work on it directly without expanding to disk.
-
-The script intentionally batches the resource list into one comma-joined `kubectl get` per verb — issuing one request per resource type would cost dozens of API calls and can trigger rate-limit responses from the apiserver. Search the gzipped output with `zgrep '^secret|^kind: Secret'` rather than re-running the script with a different filter.
-
-For cluster-wide problems (apiserver, scheduler, ingress controllers, CNI), the per-namespace dump is the wrong tool. Use the platform's built-in `inspection` collector or its equivalent diagnostic-bundle CR — those bundle node, etcd, control-plane and operator state in one pass.
-
-## Diagnostic Steps
-
-If the script aborts on a specific resource type, identify which type triggered the failure:
+Collect container logs for the whole namespace by listing its pods, reading each pod's container names from its spec, and pulling logs per container with timestamps. The container names come from `.spec.containers[*].name`, and `logs --container=<c> --timestamps` emits RFC3339-prefixed lines for each one [ev:c5].
 
 ```bash
-kubectl api-resources --namespaced --verbs=list -o name | while read r; do
-  echo "--- $r ---"
-  kubectl -n "$NS" get --ignore-not-found "$r" -o name | head -3
+for pod in $(kubectl get pods -n "$NS" -o name); do
+  for c in $(kubectl get "$pod" -n "$NS" -o jsonpath='{.spec.containers[*].name}'); do
+    kubectl logs "$pod" -n "$NS" --container="$c" --timestamps
+  done
 done
 ```
 
-A 405 or 403 on a particular type points at a CRD with restricted access; either grant `get`/`list` to the executing service account or remove that resource from the loop.
-
-If the resulting archive is unexpectedly small for a long-lived namespace, container logs were probably truncated on a recent pod restart. Re-run the dump immediately after reproducing the problem and pin the relevant pods with `kubectl debug` if a longer collection window is needed.
-
-If the customer cannot send the archive over their normal channel, attach it to a `ConfigMap` and let support pull it through the platform's existing log-export pipeline:
+For a container that has restarted, the logs of the prior terminated instance are retrieved separately with the `-p/--previous` flag, which returns the previous run's log rather than the current one [ev:c6].
 
 ```bash
-kubectl -n "$NS" create configmap nsdump-$(date +%s) \
-  --from-file="$DEST"
+kubectl logs <pod> -n "$NS" --container=<c> --previous --timestamps
 ```
 
-This avoids out-of-band file transfer and preserves audit trail through the cluster's audit log.
+## Diagnostic Steps
+
+Before attempting the log dump, confirm the current identity is permitted to read pod logs in the namespace. A self RBAC check answers this without trial and error [ev:c7].
+
+```bash
+kubectl auth can-i get pods/log -n "$NS"
+```
+
+When the identity additionally holds cluster-reader or cluster-admin — detectable with a self check against a cluster-scoped verb — extend the gather to cluster-scoped objects as well. On this environment (Kubernetes `v1.34.5`), a `get nodes` self check resolves to yes for such an identity, and nodes, clusterrolebindings, storageclasses, persistentvolumes, and csrs all exist as listable objects on the cluster [ev:c8]. These cluster-scoped kinds are typically reachable to a cluster-reader/admin; if you are unsure of a specific kind, run the same `auth can-i` check against it before adding it to the dump.
+
+```bash
+kubectl auth can-i get nodes
+kubectl get nodes,clusterrolebindings,storageclasses,persistentvolumes,csr -o yaml
+```

--- a/docs/en/solutions/Configuring_Container_and_Image_Garbage_Collection_on_the_kubelet.md
+++ b/docs/en/solutions/Configuring_Container_and_Image_Garbage_Collection_on_the_kubelet.md
@@ -4,124 +4,53 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500005
 ---
 
-# Configuring Container and Image Garbage Collection on the kubelet
-## Overview
+# Default kubelet garbage collection on ACP nodes
 
-The kubelet on every worker node continuously reclaims resources from the local container runtime. Two related mechanisms drive this:
+## Issue
 
-- **Container garbage collection** — periodic deletion of dead containers belonging to terminated or replaced pods.
-- **Image garbage collection** — periodic deletion of unused container images once disk pressure crosses a threshold.
+Cluster operators planning capacity, disk headroom, or eviction policy on Alauda Container Platform nodes need to know what kubelet does by default for image and container garbage collection — whether it runs at all, which signals it watches, and what the inherited thresholds are before any node-side override. Because every ACP node runs the upstream kubelet, garbage collection is enabled out of the box and continues to run unless the node administrator changes it [ev:c1].
 
-Both behaviors are enabled by default with conservative thresholds. Operators rarely need to disable them; the common task is to *tune* them so that nodes do not run out of disk during heavy churn (frequent rollouts, batch-job nodes, dev clusters with many tags pulled per day).
+## Root Cause
 
-This article describes the parameters, where to set them on Alauda Container Platform, and how to verify the change took effect on a node.
+There is no single "GC on/off" switch. The kubelet exposes a fixed set of tunables grouped into image GC (driven by `imageGCHighThresholdPercent` / `imageGCLowThresholdPercent` and the image-age fields) and pod eviction (driven by the `evictionHard` and `evictionSoft` signal maps), and every node inherits the upstream defaults for those fields unless an administrator changes them on the node [ev:c2]. The eviction half of the policy is built around the standard kubelet signal definitions: `memory.available` is derived from the node's memory capacity minus the working set, `nodefs.available` and `nodefs.inodesFree` come from the node filesystem stats, and `imagefs.available` and `imagefs.inodesFree` come from the container-runtime image filesystem stats — exactly the shape the upstream `kubelet.config.k8s.io/v1beta1` KubeletConfiguration declares [ev:c4].
 
 ## Resolution
 
-### Where the Parameters Live
+Treat the inherited defaults as the baseline policy. The set of knobs the kubelet exposes for garbage collection breaks down into three independent groups, any combination of which may be tuned: a soft-eviction policy for containers, a hard-eviction policy for containers, and an image garbage-collection policy keyed off image-filesystem usage [ev:c3]. The standard upstream form for those tunables is the `KubeletConfiguration` struct under `kubelet.config.k8s.io/v1beta1`; on ACP nodes the same struct shape is honored, and any override is applied at the node level (for example, by editing `/var/lib/kubelet/config.yaml` and restarting the kubelet) rather than via a cluster-scoped custom resource [ev:c3].
 
-The kubelet reads its configuration from a YAML file on each node (`/var/lib/kubelet/config.yaml` on most distributions). Garbage-collection parameters live alongside the eviction thresholds:
+A typical edit on a single node, with the fields kept inside the upstream struct shape:
 
 ```yaml
-# /var/lib/kubelet/config.yaml — relevant fields only
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-
-# --- Container GC ---
-# Once a node has more than this many terminated containers, kubelet
-# starts removing the oldest first.
-maxContainersPerPod: 1                 # legacy; use maxPerPodContainerCount
-maxPerPodContainerCount: 1             # max dead containers retained per pod
-maxContainerCount: 100                 # max dead containers retained on the node
-
-# --- Image GC ---
-# Once imagefs usage rises above HighThresholdPercent, kubelet deletes
-# unused images until usage falls below LowThresholdPercent.
-imageGCHighThresholdPercent: 85        # default 85
-imageGCLowThresholdPercent: 80         # default 80
-imageMinimumGCAge: 2m                  # do not GC images younger than this
-
-# --- Eviction (node pressure) ---
-# Soft and hard thresholds that trigger pod eviction; tune in concert
-# with image GC so the node does not flap.
+imageGCHighThresholdPercent: 85
+imageGCLowThresholdPercent: 80
 evictionHard:
-  memory.available:   "100Mi"
-  nodefs.available:   "10%"
-  nodefs.inodesFree:  "5%"
-  imagefs.available:  "15%"
+  memory.available: "100Mi"
+  nodefs.available: "10%"
+  nodefs.inodesFree: "5%"
+  imagefs.available: "15%"
   imagefs.inodesFree: "5%"
-evictionSoft:
-  memory.available:   "200Mi"
-  nodefs.available:   "15%"
-evictionSoftGracePeriod:
-  memory.available:   "1m30s"
-  nodefs.available:   "1m30s"
 ```
-
-The variables that drive the eviction subsystem map to runtime measurements as follows:
-
-```text
-memory.available    := node.status.capacity[memory] - node.stats.memory.workingSet
-nodefs.available    := node.stats.fs.available
-nodefs.inodesFree   := node.stats.fs.inodesFree
-imagefs.available   := node.stats.runtime.imagefs.available
-imagefs.inodesFree  := node.stats.runtime.imagefs.inodesFree
-```
-
-### How to Apply Changes Across a Node Pool
-
-On Alauda Container Platform the kubelet config is managed at the node-pool level through `configure/clusters/nodes`. Edit the relevant pool's kubelet profile, set the desired GC and eviction values, and let the platform roll the change to each member node. The platform serializes the rollout, drains nodes one at a time, restarts the kubelet, and waits for the node to become Ready before proceeding to the next.
-
-For air-gapped or single-node environments where the platform surface is not available, the equivalent edit is direct:
-
-```bash
-# On the node — bookkeeping only; the platform-managed flow above is
-# preferred wherever it is available.
-sudo cp -a /var/lib/kubelet/config.yaml /var/lib/kubelet/config.yaml.bak
-sudo $EDITOR /var/lib/kubelet/config.yaml
-sudo systemctl restart kubelet
-```
-
-Restarting kubelet briefly drops the node from the API server's heartbeat — schedule the change during a maintenance window or use the platform-managed flow which handles drain/cordon for you.
-
-### Recommended Tuning per Workload Profile
-
-| Workload | Notable kubelet settings |
-|---|---|
-| Long-lived services with infrequent rollouts | Defaults are fine. |
-| Batch / CI workloads (many short pods) | Drop `maxContainerCount` to 50 to reduce dead-container clutter; lower `imageMinimumGCAge` to 30s so transient images are reclaimed quickly. |
-| Dev clusters that pull many image tags | Lower `imageGCHighThresholdPercent` to 75 and `imageGCLowThresholdPercent` to 70 so disk does not fill during long working hours. |
-| Nodes with separate `/var/lib/containers` partition | Tune `imagefs.available` eviction independently of `nodefs.available`; check `crictl info` for the runtime's reported imagefs path. |
 
 ## Diagnostic Steps
 
-Inspect the kubelet's *live* configuration (the parsed config it is actually using, not the file on disk — useful when troubleshooting drift):
+Before changing anything, read the live, effective kubelet configuration off the running node — this returns the merged view (upstream defaults plus any node-local override) and includes all the GC and eviction fields described above [ev:c7]:
 
 ```bash
-NODE=<worker-node-name>
-kubectl get --raw "/api/v1/nodes/${NODE}/proxy/configz" | jq .
+kubectl get --raw "/api/v1/nodes/<node>/proxy/configz" \
+  | jq '.kubeletconfig'
 ```
 
-The `kubeletconfig` block in the response contains every default the kubelet has applied, including those the YAML did not set explicitly.
-
-Check the running kubelet process for the GC values. ACP's cluster PSA rejects `chroot /host`, and `registry.k8s.io/...` images may not be pullable from isolated clusters — read the host's `/var/lib/kubelet/config.yaml` through the debug pod's `/host` bind-mount with any in-cluster mirror image that ships `grep`:
+Narrow the projection to the garbage-collection and eviction subset when only those fields are of interest [ev:c7]:
 
 ```bash
-kubectl debug node/${NODE} -it \
-  --image=<image-with-shell> \
-  -- grep -E "GC|eviction" /host/var/lib/kubelet/config.yaml
+kubectl get --raw "/api/v1/nodes/<node>/proxy/configz" \
+  | jq '.kubeletconfig | {imageGCHighThresholdPercent, imageGCLowThresholdPercent, imageMinimumGCAge, imageMaximumGCAge, evictionSoft, evictionHard, evictionPressureTransitionPeriod, evictionMinimumReclaim, kubeReserved, systemReserved}'
 ```
 
-Confirm garbage collection is doing work by tailing the kubelet journal. `journalctl --root=/host` reads the host's journal directory:
-
-```bash
-kubectl debug node/${NODE} -it \
-  --image=<image-with-systemd> --profile=sysadmin \
-  -- journalctl --root=/host -u kubelet --since "10 minutes ago" | grep -iE 'image_gc|container_gc|evict'
-```
-
-A healthy node logs occasional `image_gc_manager` lines reporting how many bytes were reclaimed and which images were removed; recurrent eviction lines suggest the thresholds are too tight for the workload.
+The endpoint is served by the kubelet itself and is independent of any cluster-side configuration delivery; it answers the operator's question "what is this kubelet actually using right now" directly, which is the right diagnostic for verifying both the inherited defaults and the effect of any node-level change [ev:c7]. Cross-checking the same projection on more than one node confirms whether the values are uniform across the cluster or have drifted on a single node [ev:c2].

--- a/docs/en/solutions/CoreDNS_pods_crashloop_with_Wrong_argument_count_parsing_error.md
+++ b/docs/en/solutions/CoreDNS_pods_crashloop_with_Wrong_argument_count_parsing_error.md
@@ -4,152 +4,58 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500017
 ---
 
-# CoreDNS pods crashloop with "Wrong argument count" parsing error
+# CoreDNS pods crash-loop with a "Wrong argument count" Corefile parse error
+
 ## Issue
 
-DNS pods enter `CrashLoopBackOff`. The pod log includes a Corefile
-parsing error:
+The cluster DNS is served by CoreDNS, which runs as the `coredns` Deployment in the `kube-system` namespace and reads its configuration from a Corefile [ev:c1]. On Alauda Container Platform v4.3.4 the Corefile is supplied by the ConfigMap `kube-system/cpaas-coredns` (data key `Corefile`), mounted into the container at `/etc/coredns` and loaded through the container argument `-conf /etc/coredns/Corefile` [ev:c1]. The DNS pods run CoreDNS 1.14.2 (image `registry.alauda.cn:60080/tkestack/coredns:1.14.2-v4.3.4`) [ev:c1].
 
-```text
-plugin/forward: /etc/coredns/Corefile:19 - Error during parsing:
-  Wrong argument count or unexpected line ending after '.'
-```
-
-Pod restarts emit the same line every time. Cluster DNS is unavailable
-to all workloads while the pods are looping because the cluster's
-DNS Service has no healthy backends.
+When the Corefile contains a `forward` plugin block whose zone is not followed by at least one upstream, CoreDNS fails to parse the Corefile at startup [ev:c3]. The CoreDNS process then exits and the DNS pods enter `CrashLoopBackOff`, with the container terminating with reason `Error` (exit code 1), never reaching `Ready`, and the restart count climbing [ev:c5].
 
 ## Root Cause
 
-The CoreDNS configuration injected into the pods includes a `forward`
-plugin block whose stanza is incomplete. The DNS Operator (or the
-operator-equivalent that builds the Corefile from declarative
-configuration) emits a `forward` block for every zone the operator's
-custom resource declares — but if a zone entry is present in the
-operator's CR with no `forwardPlugin` (no list of upstream resolvers,
-or a malformed upstream entry), the resulting Corefile contains a
-`forward .` (or `forward <zone>`) line with no following arguments.
+A `forward` block declares a FROM zone followed by one or more TO upstreams. A block such as `forward .` that names the zone but lists no upstream is incomplete, and the CoreDNS parser rejects it [ev:c3]. Because the configuration cannot be loaded, the process aborts at startup rather than serving DNS [ev:c5].
 
-CoreDNS parses Corefiles strictly. A `forward` directive must be
-followed by at least one upstream resolver. A trailing `.` with no
-upstream is rejected with the `Wrong argument count` error and the
-pod fails to start the plugin chain. The pod exits, the kubelet
-restarts it, and the cycle continues indefinitely.
+The failure is surfaced in the CoreDNS container log as a parse error that names the `forward` plugin together with the Corefile path and the offending line number [ev:c4]:
 
-The same shape applies to any operator that builds a CoreDNS Corefile
-from a CR — a stale or mistakenly added zone entry without a forwarder
-will reproduce the failure.
+```text
+plugin/forward: /etc/coredns/Corefile:3 - Error during parsing: Wrong argument count or unexpected line ending after '.'
+```
 
 ## Resolution
 
-Inspect the operator-managed DNS configuration and either populate the
-zone with a valid `forwardPlugin` or delete the zone entry entirely:
+Correct the Corefile so that every `forward` block lists at least one upstream after its zone [ev:c8]. For the default zone forwarding to the node resolver, the well-formed block is:
 
-```bash
-kubectl edit dns.operator default
+```text
+.:1053 {
+    errors
+    forward . /etc/resolv.conf
+}
 ```
 
-The CR's `spec.servers` list contains entries of the form:
-
-```yaml
-servers:
-  - name: ABC
-    forwardPlugin:
-      policy: Random
-      upstreams:
-        - 10.0.0.100
-    zones:
-      - ABC
-  - name: XYZ          # <-- this entry has no forwardPlugin
-    zones:
-      - XYZ
-```
-
-Either:
-
-### Option A — remove the orphaned zone entry
-
-```yaml
-servers:
-  - name: ABC
-    forwardPlugin:
-      policy: Random
-      upstreams:
-        - 10.0.0.100
-    zones:
-      - ABC
-```
-
-Save and exit. The operator regenerates the Corefile, the DNS pods
-restart with valid configuration, and the crashloop clears within a
-single rollout cycle.
-
-### Option B — finish the zone configuration
-
-```yaml
-- name: XYZ
-  forwardPlugin:
-    policy: Random
-    upstreams:
-      - 10.0.0.200
-  zones:
-    - XYZ
-```
-
-If the zone was added on purpose, supply at least one upstream
-resolver. Use the same `policy` value as the existing entries unless
-there is a reason to differ.
-
-After the configuration is corrected the operator regenerates the
-ConfigMap, the DNS Deployment rolls out the new Corefile, and the
-pods leave `CrashLoopBackOff`. Cluster DNS resumes within seconds of
-the new pods becoming Ready.
+Once the upstream is present, CoreDNS parses the configuration successfully — the restarted pod logs the `CoreDNS-1.14.2` startup banner with no `Error during parsing` line and returns to a running state (`Running`, ready, restart count 0) [ev:c8].
 
 ## Diagnostic Steps
 
-1. Confirm the failure mode is the Corefile parser, not an unrelated
-   crash:
+Inspect the CoreDNS workload and pods in `kube-system` to confirm they are crash-looping [ev:c1][ev:c5]:
 
-   ```bash
-   kubectl logs -n <dns-ns> <dns-pod> --previous \
-     | grep -i "Error during parsing"
-   ```
+```bash
+kubectl -n kube-system get pods -l k8s-app=kube-dns
+kubectl -n kube-system get deploy coredns -o jsonpath='{.spec.template.spec.containers[0].image}'
+```
 
-2. Inspect the rendered Corefile from the operator-managed ConfigMap:
+Read the CoreDNS container log to find the parse error; it names the `forward` plugin and the Corefile line that is malformed [ev:c4]:
 
-   ```bash
-   kubectl get configmap -n <dns-ns> -o yaml | yq '.items[].data.Corefile'
-   ```
+```bash
+kubectl -n kube-system logs -l k8s-app=kube-dns --tail=30
+```
 
-   Look for `forward .` or `forward <zone>` lines with no upstreams
-   following them. The line number reported in the error message
-   points at the offending entry.
+Examine the Corefile to locate the `forward` block that has no upstream after its zone [ev:c3]:
 
-3. Inspect the operator CR for the zone entry that produced the
-   broken line:
-
-   ```bash
-   kubectl get dns.operator default -o yaml | yq '.spec.servers'
-   ```
-
-4. After applying the correction, watch the pods recover:
-
-   ```bash
-   kubectl get pods -n <dns-ns> -w
-   ```
-
-   The new pods reach `Running` and the crashloop counter stops
-   incrementing.
-
-5. Validate cluster DNS is functional from a workload pod. The image must ship `nslookup` (or `dig`); a vanilla `busybox` image works on clusters that mirror Docker Hub but is often unreachable on isolated ACP clusters — substitute with any in-cluster mirror image that ships `nslookup`:
-
-   ```bash
-   kubectl run dnscheck --rm -it --image=<image-with-nslookup> -- nslookup kubernetes.default
-   ```
-
-   A successful answer confirms the DNS Service is back to having
-   healthy backends.
+```bash
+kubectl -n kube-system get configmap cpaas-coredns -o jsonpath='{.data.Corefile}'
+```

--- a/docs/en/solutions/Deploy_a_Throwaway_SMTP_Sink_to_Test_Alertmanager_Email_Receiver_Configuration.md
+++ b/docs/en/solutions/Deploy_a_Throwaway_SMTP_Sink_to_Test_Alertmanager_Email_Receiver_Configuration.md
@@ -4,73 +4,157 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500028
 ---
 
 # Deploy a Throwaway SMTP Sink to Test Alertmanager Email Receiver Configuration
+
 ## Issue
 
-When wiring up an Alertmanager email receiver (`smtp_smarthost`, `smtp_auth_username`, `smtp_from`, `smtp_require_tls`, etc.) the actual delivery path runs through corporate relays, anti-spam filters, and TLS chains that may quarantine, silently drop, or rate-limit the test alert. A failed delivery in any of those layers makes it hard to tell whether the misconfiguration is in Alertmanager, in the relay, or in the recipient mailbox. A disposable in-cluster SMTP sink lets the operator verify the Alertmanager pipeline end-to-end before swapping the smarthost back to the production relay.
+When wiring up an Alertmanager email receiver (`smtp_smarthost`, `smtp_auth_username`, `smtp_from`, `smtp_require_tls`, an `email_configs[]` entry on the receiver), the production delivery path runs through corporate relays, anti-spam filters, and TLS chains that may quarantine, silently drop, or rate-limit the test alert. A failed delivery in any of those layers makes it hard to tell whether the misconfiguration is in Alertmanager itself, in the relay, or in the recipient mailbox. A disposable in-cluster SMTP sink lets the operator verify the Alertmanager pipeline end-to-end before swapping the smarthost back to the production relay. The standard `alertmanager.yaml` schema — `global.smtp_*` settings plus per-receiver `email_configs[]` — is accepted verbatim by the platform Alertmanager binary [ev:c2_a].
+
+On Alauda Container Platform the platform Alertmanager configuration lives in the Opaque Secret `cpaas-system/alertmanager-kube-prometheus`, single data key `alertmanager.yaml`; the Secret carries an operator-editable marker so raw patches survive chart reconciliation [ev:c3]. The default rendered configuration ships zero `smtp_*` globals and zero `email_configs[]` entries, so any email receiver capability is something the operator adds [ev:c2_a].
 
 ## Resolution
 
-### Step 1 — Deploy a throwaway SMTP sink in-cluster
+The flow has four steps: deploy a throwaway in-cluster SMTP sink that exposes the captured messages over HTTP, point the Alertmanager configuration's `smtp_smarthost` at the sink Service, push a test alert (either through a `PrometheusRule` that always fires or directly via the Alertmanager v2 API), and verify the rendered message landed on the sink. Each of the four steps is anchored end-to-end on the platform Alertmanager binary `alertmanager:v0.32.1-v4.3.4` shipped by `chart-kube-prometheus` v4.3.3 [ev:c2_a][ev:c3].
 
-[`mailhog`](https://github.com/mailhog/MailHog) is a single-binary SMTP server that accepts every message into an in-memory store and exposes them through an HTTP UI. Run it as a single Pod fronted by a ClusterIP Service:
+### Step 1 — Deploy a disposable SMTP sink in-cluster [ev:c2_b]
+
+Run the sink as a single Pod fronted by a ClusterIP Service. The image must come from the in-cluster registry. The sink does two jobs: (1) accept SMTP on port 1025 and append each delivered message to a JSONL file; (2) serve the captured messages over HTTP on port 8025. A pure-busybox shape avoids any package install on the disposable workload [ev:c2_b].
 
 ```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sink-scripts
+  namespace: alertmanager-smoke
+data:
+  smtp_handler.sh: |
+    #!/bin/sh
+    # SMTP responder invoked per-connection by busybox tcpsvd.
+    # Talks 220 / 250 / 354 SMTP, appends one JSON line per delivered
+    # message to /var/sink/messages.jsonl.
+    LOG=/var/sink/messages.jsonl
+    mkdir -p /var/sink
+    printf '220 sink ESMTP ready\r\n'
+    mode=cmd; mailfrom=""; rcpt=""; body=""
+    while IFS= read -r raw; do
+      line=$(printf '%s' "$raw" | tr -d '\r')
+      if [ "$mode" = data ]; then
+        if [ "$line" = "." ]; then
+          subj=$(printf '%s' "$body" | awk '/^Subject:/{sub(/^Subject: */,""); print; exit}')
+          from=$(printf '%s' "$body" | awk '/^From:/{sub(/^From: */,""); print; exit}')
+          to=$(printf '%s' "$body" | awk '/^To:/{sub(/^To: */,""); print; exit}')
+          NOW=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          # JSON escape via sed (busybox awk's escape semantics differ from gawk).
+          esc() { printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr -d '\r' | sed ':a;N;$!ba;s/\n/\\n/g'; }
+          printf '{"received_at":"%s","mailfrom":"%s","rcpttos":["%s"],"headers":{"From":"%s","To":"%s","Subject":"%s"},"body":"%s"}\n' \
+            "$NOW" "$(esc "$mailfrom")" "$(esc "$rcpt")" "$(esc "$from")" "$(esc "$to")" "$(esc "$subj")" "$(esc "$body")" \
+            >> "$LOG"
+          printf '250 2.0.0 Ok: queued\r\n'
+          mode=cmd; mailfrom=""; rcpt=""; body=""
+          continue
+        fi
+        if [ -z "$body" ]; then body="$line"; else body="$body
+    $line"; fi
+        continue
+      fi
+      upper=$(printf '%s' "$line" | tr '[:lower:]' '[:upper:]')
+      case "$upper" in
+        EHLO*|HELO*) printf '250-sink Hello\r\n'; printf '250 HELP\r\n' ;;
+        "MAIL FROM:"*) mailfrom=$(printf '%s' "$line" | sed -e 's/^[Mm][Aa][Ii][Ll] [Ff][Rr][Oo][Mm]: *//' -e 's/^<//' -e 's/>.*$//'); printf '250 2.1.0 OK\r\n' ;;
+        "RCPT TO:"*)   rcpt=$(printf '%s' "$line"     | sed -e 's/^[Rr][Cc][Pp][Tt] [Tt][Oo]: *//'   -e 's/^<//' -e 's/>.*$//'); printf '250 2.1.5 OK\r\n' ;;
+        DATA) printf '354 End data with <CR><LF>.<CR><LF>\r\n'; mode=data ;;
+        QUIT) printf '221 2.0.0 Bye\r\n'; break ;;
+        STARTTLS) printf '454 4.7.0 TLS not available\r\n' ;;
+      esac
+    done
+  messages.cgi: |
+    #!/bin/sh
+    echo "Content-Type: application/json"; echo ""
+    if [ -s /var/sink/messages.jsonl ]; then
+      awk 'BEGIN{print "["} NR>1{print ","} {print} END{print "]"}' /var/sink/messages.jsonl
+    else
+      echo "[]"
+    fi
+  httpd.conf: |
+    A:*
+  entrypoint.sh: |
+    #!/bin/sh
+    set -e
+    mkdir -p /var/sink /www/cgi-bin
+    cp /scripts/messages.cgi /www/cgi-bin/messages
+    chmod +x /www/cgi-bin/messages
+    busybox tcpsvd -E -v 0.0.0.0 1025 /bin/sh /scripts/smtp_handler.sh 2>&1 | sed 's/^/[smtp] /' &
+    exec busybox httpd -f -p 8025 -h /www -c /scripts/httpd.conf
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mailhog
-  namespace: monitoring
+  name: sink
+  namespace: alertmanager-smoke
+  labels: {app: sink}
 spec:
   replicas: 1
-  selector:
-    matchLabels: { app: mailhog }
+  selector: {matchLabels: {app: sink}}
   template:
-    metadata:
-      labels: { app: mailhog }
+    metadata: {labels: {app: sink}}
     spec:
       containers:
-        - name: mailhog
-          image: mailhog/mailhog:v1.0.1
+        - name: sink
+          image: registry.alauda.cn:60080/ops/alpine:3.23.3-alauda-202604121100
+          command: ["/bin/sh", "/scripts/entrypoint.sh"]
           ports:
-            - containerPort: 1025
-              name: smtp
-            - containerPort: 8025
-              name: http
+            - {name: smtp, containerPort: 1025}
+            - {name: http, containerPort: 8025}
+          volumeMounts:
+            - {name: scripts, mountPath: /scripts}
+      volumes:
+        - name: scripts
+          configMap: {name: sink-scripts, defaultMode: 0755}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: mailhog
-  namespace: monitoring
+  name: sink
+  namespace: alertmanager-smoke
 spec:
-  selector: { app: mailhog }
+  selector: {app: sink}
   ports:
-    - name: smtp
-      port: 1025
-      targetPort: 1025
-    - name: http
-      port: 8025
-      targetPort: 8025
+    - {name: smtp, port: 1025, targetPort: 1025}
+    - {name: http, port: 8025, targetPort: 8025}
 ```
 
-### Step 2 — Point Alertmanager at the sink
+Apply and confirm the sink Pod reaches Running, then port-forward the HTTP port and confirm the messages list is empty (this is the baseline before any alert is dispatched) [ev:c2_b]:
 
-Edit the Alertmanager configuration so the `smtp_smarthost` is `mailhog.monitoring.svc.cluster.local:1025` and authentication is disabled (the sink accepts everything):
+```bash
+kubectl create ns alertmanager-smoke
+kubectl apply -n alertmanager-smoke -f sink.yaml
+kubectl rollout status deploy/sink -n alertmanager-smoke --timeout=120s
+
+kubectl -n alertmanager-smoke port-forward svc/sink 18025:8025 &
+curl -s http://localhost:18025/cgi-bin/messages
+# expected: []
+```
+
+### Step 2 — Point Alertmanager at the sink [ev:c3]
+
+The platform Alertmanager configuration lives in the Opaque Secret `cpaas-system/alertmanager-kube-prometheus`, data key `alertmanager.yaml`. Decode the current Secret, add the SMTP globals and an `email_configs[]` entry to the receiver, then re-apply [ev:c3]. The `alertmanager.yaml` schema is the standard form — `global.smtp_smarthost / smtp_from / smtp_require_tls / smtp_hello` plus per-receiver `email_configs[]` with `to` / `require_tls` / `send_resolved` — accepted verbatim by the Alertmanager binary [ev:c2_a]:
 
 ```yaml
 global:
-  smtp_smarthost: 'mailhog.monitoring.svc.cluster.local:1025'
+  smtp_smarthost: 'sink.alertmanager-smoke.svc.cluster.local:1025'
   smtp_from: 'alerts@example.com'
   smtp_require_tls: false
   smtp_hello: 'alertmanager'
 
 route:
   receiver: smoke
+  group_wait: 5s
+  group_interval: 10s
+  repeat_interval: 1h
 
 receivers:
   - name: smoke
@@ -80,18 +164,46 @@ receivers:
         send_resolved: true
 ```
 
-If Alertmanager is managed by the Prometheus Operator, the corresponding `AlertmanagerConfig` CR uses the same `email_configs` shape; if it is configured by a `Secret` named `kube-prometheus-alertmanager` (or similar), edit the Secret's `alertmanager.yaml` payload and restart the Alertmanager Pods.
+Patch the platform Secret with the new payload, then restart the Alertmanager Pod so the new process loads the updated configuration; Alertmanager logs `Loading configuration file` and `Completed loading of configuration file` on the new process [ev:c3][ev:c5_b]:
 
-### Step 3 — Drive a test alert
+```bash
+kubectl -n cpaas-system patch secret alertmanager-kube-prometheus \
+  --type=merge \
+  -p "{\"data\":{\"alertmanager.yaml\":\"$(base64 -w0 < alertmanager.yaml)\"}}"
 
-Create a `PrometheusRule` that always fires, attached to whatever `Prometheus` instance Alertmanager listens to:
+kubectl -n cpaas-system delete pod alertmanager-kube-prometheus-0
+kubectl -n cpaas-system rollout status statefulset/alertmanager-kube-prometheus --timeout=180s
+```
+
+### Step 3 — Drive a test alert [ev:c4][ev:c6]
+
+Two paths work. The deterministic path is to push a single alert straight to Alertmanager's v2 API and observe the dispatcher select the configured receiver [ev:c6]. The chart-managed path is to create a `PrometheusRule` that always fires and let the live Prometheus instance scrape and forward it; the live Prometheus instance is reconciled and available, with the standard `monitoring.coreos.com/v1` `PrometheusRule` CRD on the cluster [ev:c4].
+
+Direct v2 API path — port-forward the platform Alertmanager and POST a single alert. The `/api/v2/alerts` endpoint accepts the upstream v2 schema; the dispatcher selects the configured receiver and emits the email via the configured smarthost [ev:c6][ev:c2_b]:
+
+```bash
+kubectl -n cpaas-system port-forward pod/alertmanager-kube-prometheus-0 19093:9093 &
+curl -s -XPOST -H 'Content-Type: application/json' \
+  http://localhost:19093/api/v2/alerts \
+  -d '[{"labels":{"alertname":"SmoketestAlert","severity":"info","job":"smoke"},
+       "annotations":{"summary":"Alertmanager email path smoke test",
+                      "description":"throwaway smoke test against in-cluster sink"},
+       "generatorURL":"http://example/smoke"}]'
+
+# wait ~10s for the group_wait + group_interval window, then read back:
+curl -s http://localhost:19093/api/v2/alerts \
+  | python3 -c "import sys,json; a=json.load(sys.stdin); print([(x['labels']['alertname'], x.get('receivers'), x['status']['state']) for x in a])"
+# expected: [('SmoketestAlert', [{'name': 'smoke'}], 'active')]
+```
+
+Chart-managed path — create a `PrometheusRule` with `expr: vector(1)` and `for: 0m`; the rule fires immediately, the live Prometheus instance in `cpaas-system` (`prometheus-kube-prometheus-0-0`) scrapes the rule, and within one or two scrape intervals the alert reaches Alertmanager which then dispatches via the configured email receiver [ev:c4]:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: smoketest-always-firing
-  namespace: monitoring
+  namespace: cpaas-system
   labels:
     role: alert-rules
 spec:
@@ -105,51 +217,50 @@ spec:
             severity: info
           annotations:
             summary: Alertmanager email path smoke test
-            description: This alert always fires; safe to ignore once seen in mailhog.
+            description: This alert always fires; safe to ignore once seen on the sink.
 ```
 
-Within one or two scrape intervals the alert reaches Alertmanager and the email receiver fires.
+### Step 4 — Verify the message landed [ev:c5_a]
 
-### Step 4 — Verify the message landed
-
-Port-forward the mailhog HTTP UI:
+Port-forward the sink's HTTP port and read the captured messages through the sink's CGI endpoint. After a successful dispatch the captured record carries `mailfrom` equal to the configured `smtp_from`, `rcpttos` equal to the configured `email_configs[].to`, and a rendered Alertmanager body with a `[FIRING:N]  (<alertname> <labels>)` Subject and the standard `multipart/alternative` HTML body [ev:c5_a]:
 
 ```bash
-kubectl -n monitoring port-forward svc/mailhog 8025:8025
+kubectl -n alertmanager-smoke port-forward svc/sink 18025:8025 &
+curl -s http://localhost:18025/cgi-bin/messages \
+  | python3 -c "import sys,json; m=json.load(sys.stdin); print('count:',len(m)); print('headers:',m[0]['headers']); print('body_len:',len(m[0]['body']))"
+# count: 1
+# headers: {'From': 'alerts@example.com', 'To': 'oncall@example.com',
+#           'Subject': '[FIRING:1]  (SmoketestAlert smoke info)', ...}
+# body_len: ~9800 (rendered Alertmanager multipart/alternative)
 ```
 
-Open `http://127.0.0.1:8025` and confirm the test alert appears with the configured `From:` and `To:` headers and the rendered Alertmanager body. The same data is available through the JSON API:
+### Step 5 — Cleanup [ev:c3]
+
+Once the smoke test passes, switch `smtp_smarthost` back to the production relay (and `smtp_require_tls: true` if the production path enforces it) by patching the same operator-editable Secret `cpaas-system/alertmanager-kube-prometheus`, drop the `PrometheusRule`, and delete the disposable namespace [ev:c3]:
 
 ```bash
-curl -s http://127.0.0.1:8025/api/v2/messages | jq '.items[0] | {From, To, Subject: .Content.Headers.Subject}'
+kubectl delete prometheusrule smoketest-always-firing -n cpaas-system
+kubectl delete ns alertmanager-smoke
 ```
-
-### Step 5 — Cleanup
-
-Delete the smoke-test PrometheusRule, switch Alertmanager `smtp_smarthost` back to the production relay, and remove the mailhog Deployment/Service.
 
 ## Diagnostic Steps
 
-If the message never reaches mailhog:
+If the captured-messages list stays empty after the test alert is dispatched, the failure is in the Alertmanager-to-sink path; the Alertmanager container log is the diagnostic surface — the `alertmanager` binary writes config-load lines on startup (`Starting Alertmanager version=0.32.1`, `Loading configuration file`, `Completed loading of configuration file`, `Listening on [::]:9093`) and SMTP-delivery error lines (dial / TLS / authentication failures) on the failure path. The success path is quiet on this version, so the absence of error lines combined with a non-empty sink is the green-light signal [ev:c5_b].
 
-- Check that Alertmanager actually received the alert from Prometheus:
+```bash
+# Read the Alertmanager binary log directly (the alertmanager / config-reloader
+# / proxy containers in this Pod are scratch images — no shell, no wget/curl
+# inside the Pod; read the log from outside).
+kubectl -n cpaas-system logs alertmanager-kube-prometheus-0 -c alertmanager --tail=200 \
+  | grep -iE 'notify|smtp|email|integration|error|fail|connection refused' \
+  | tail -20
+```
 
-  ```bash
-  kubectl -n monitoring exec deploy/kube-prometheus-alertmanager -c alertmanager -- \
-    wget -qO- http://localhost:9093/api/v2/alerts | jq '.[].labels.alertname'
-  ```
+Confirm the dispatcher selected the email receiver by reading `/api/v2/alerts` after the trigger; `receivers` should list the receiver name configured in `alertmanager.yaml` and the alert `state` should be `active` [ev:c6]:
 
-- Tail the Alertmanager log for the SMTP attempt:
+```bash
+kubectl -n cpaas-system port-forward pod/alertmanager-kube-prometheus-0 19093:9093 &
+curl -s http://localhost:19093/api/v2/alerts | python3 -m json.tool
+```
 
-  ```bash
-  kubectl -n monitoring logs deploy/kube-prometheus-alertmanager -c alertmanager --tail=50 | grep -i smtp
-  ```
-
-- Confirm Pod-to-Pod DNS resolves the sink Service:
-
-  ```bash
-  kubectl -n monitoring exec deploy/kube-prometheus-alertmanager -- \
-    nslookup mailhog.monitoring.svc.cluster.local
-  ```
-
-- If TLS is forced upstream, set `smtp_require_tls: false` for the smoke test only — re-enable it before pointing back at the production relay.
+If the sink's HTTP endpoint returns `[]` but `/api/v2/alerts` shows the alert with the correct receiver, the SMTP TCP path itself is the culprit — DNS resolution of the sink Service name, NetworkPolicy on the namespace, or the sink Pod not Running. On Alauda Container Platform with `chart-kube-prometheus` v4.3.3 and `alertmanager:v0.32.1-v4.3.4`, the live Prometheus + Alertmanager surface accepts both the direct `/api/v2/alerts` POST and the `PrometheusRule` scrape-and-forward path verbatim, so the test is reproducible end-to-end against the platform pod [ev:c4][ev:c6].

--- a/docs/en/solutions/Generating_an_emergency_admin_kubeconfig_via_CertificateSigningRequest.md
+++ b/docs/en/solutions/Generating_an_emergency_admin_kubeconfig_via_CertificateSigningRequest.md
@@ -4,169 +4,59 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500014
 ---
 
-# Generating an emergency admin kubeconfig via CertificateSigningRequest
+# Minting a client certificate on ACP with the Kubernetes CSR API
 
 ## Issue
 
-The original administrator kubeconfig produced at install time can be lost, leaked, or fail with `x509: certificate signed by unknown authority` after a control-plane CA rotation. When that happens — and the operator no longer has any working cluster-admin path through the OIDC / OAuth identity provider — the cluster still has to be reachable.
+On Alauda Container Platform (Kubernetes `v1.34.5`), an administrator needs to mint a fresh client certificate suitable for authenticating to the kube-apiserver, using only the standard Kubernetes API. The `CertificateSigningRequest` resource (`certificates.k8s.io/v1`, kind `CertificateSigningRequest`, short name `csr`) is cluster-scoped, and a request submitted with `signerName: kubernetes.io/kube-apiserver-client` and the `client auth` usage asks that signer to issue a client certificate; once approved, the issued certificate is one that, per the signer's documented purpose, can be used to authenticate to the kube-apiserver [ev:c1]. How that certificate's subject is then mapped to a Kubernetes user/group identity is determined by the cluster's authentication and RBAC configuration and is out of scope for this article.
 
-This procedure mints a fresh, short-lived client certificate that authenticates as the conventional admin identity (`CN=system:admin`, group `system:masters`) using the standard Kubernetes CSR API. It is a recovery path of last resort: the resulting credential bypasses the IdP and inherits the full `cluster-admin` ClusterRoleBinding that ships with every conformant cluster. Treat the generated key as a sensitive secret and rotate it immediately after the incident is closed.
+## Root Cause
 
-If a non-CSR signing path (custom CA appended to the apiserver `client-ca-file`) is available, prefer that — its expiry is bounded by the operator's own CA, not by the cluster signer's 14-month rotation horizon.
+Requests against the `kubernetes.io/kube-apiserver-client` signer are never auto-approved by the kube-controller-manager, so a freshly submitted CSR for this signer stays pending until an authorized approver acts on it [ev:c1]. A client-certificate request of this kind conventionally carries the `digital signature`, `key encipherment`, and `client auth` usages [ev:c1].
 
 ## Resolution
 
-### Generate a key + CSR
-
-Create a 4096-bit RSA key and a PKCS#10 CSR whose subject embeds the recovery identity:
-
-```bash
-openssl req -new -newkey rsa:4096 -nodes \
-  -keyout admin-recovery.key \
-  -out admin-recovery.csr \
-  -subj "/CN=system:admin/O=system:masters"
-```
-
-The Common Name is the username the apiserver will see; the Organization is the group, and `system:masters` is the group bound to the built-in `cluster-admin` ClusterRole.
-
-### Submit the CSR to the cluster
-
-The CSR resource references the upstream `kube-apiserver-client` signer, which is what every standard cluster uses to sign client-auth certificates:
+Submit a `CertificateSigningRequest` with the `kubernetes.io/kube-apiserver-client` signer name and the client-auth usages, embedding a base64-encoded PEM certificate signing request in `spec.request` [ev:c1]. The optional `spec.expirationSeconds` field carries the requested validity duration of the issued certificate; in-tree signers honor that request only up to the cluster-wide maximum configured by `--cluster-signing-duration`, may issue a different (typically capped) duration, and reject any value below the minimum of 600 seconds [ev:c2]. In the manifests and commands below, `admin-client` is a placeholder CSR name — substitute the metadata.name of the CSR you actually create [ev:c1]:
 
 ```yaml
 apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
-  name: admin-recovery
+  name: admin-client
 spec:
   signerName: kubernetes.io/kube-apiserver-client
-  expirationSeconds: 86400          # 1 day; cap to the shortest acceptable
-  groups:
-    - system:authenticated
-  request: <BASE64_OF_admin-recovery.csr>
+  request: <base64-encoded PEM CSR>
+  expirationSeconds: 86400
   usages:
+    - digital signature
+    - key encipherment
     - client auth
 ```
 
-Inline the encoded CSR and create it:
+Because this signer is never auto-approved, an authorized approver must approve the pending request before it is signed [ev:c1]. Approval is recorded through the `certificatesigningrequests/approval` subresource, which is distinct from the `certificatesigningrequests/status` subresource [ev:c3]:
 
 ```bash
-REQUEST=$(base64 -w0 admin-recovery.csr)
-sed "s|<BASE64_OF_admin-recovery.csr>|${REQUEST}|" csr.yaml | kubectl apply -f -
+kubectl certificate approve admin-client
 ```
 
-`expirationSeconds` is honoured by the apiserver as long as the chosen signer accepts it; the cluster's signing CA may further cap the lifetime. The default — when omitted — is one year, and most platform-managed signers cap individual certificates to far less than the signer's own validity.
-
-### Approve and harvest the certificate
-
-A user that already holds `certificates.k8s.io/certificatesigningrequests/approval` permission must approve the CSR. From a session that does have that permission:
+After an `Approved` condition is present, the signer populates the issued certificate into `.status.certificate` via the `/status` subresource; the certificate is encoded in PEM format and is additionally base64-encoded when serialized as JSON or YAML [ev:c3]. Read and decode it once the field is populated [ev:c3]:
 
 ```bash
-kubectl get csr
-kubectl certificate approve admin-recovery
-kubectl get csr admin-recovery \
-  -o jsonpath='{.status.certificate}' | base64 -d > admin-recovery.crt
+kubectl get csr admin-client \
+  -o jsonpath='{.status.certificate}' | base64 -d > admin-client.crt
 ```
-
-If no such session exists — meaning the operator has no working admin path at all — the recovery becomes a node-local operation: SSH to a control-plane node, present a kubeconfig that points at `https://localhost:6443` with the localhost serving CA, and approve from there. That out-of-band path is platform-specific and should be treated as the last fallback.
-
-### Assemble the recovery kubeconfig
-
-Build a fresh kubeconfig containing the new certificate, the cluster's serving CA bundle, and a context that selects the recovery user. Pull the apiserver CA from a service-account token secret in any system namespace:
-
-```bash
-KUBECTL=kubectl
-$KUBECTL get secret \
-  -n kube-system \
-  -l kubernetes.io/service-account.name=default \
-  -o jsonpath='{.items[0].data.ca\.crt}' | base64 -d > apiserver-ca.crt
-```
-
-If the cluster fronts the apiserver with custom-CA-signed certificates that are not part of the in-cluster CA bundle, append them:
-
-```bash
-cat custom-apiserver-ca.crt >> apiserver-ca.crt
-```
-
-Then assemble the kubeconfig with three `kubectl config` calls so the file lays itself out idiomatically:
-
-```bash
-KCFG=/tmp/recovery.kubeconfig
-SERVER=$($KUBECTL config view --minify -o jsonpath='{.clusters[0].cluster.server}')
-CLUSTER=$($KUBECTL config view --minify -o jsonpath='{.clusters[0].name}')
-
-kubectl config set-cluster "$CLUSTER" \
-  --server="$SERVER" \
-  --certificate-authority=apiserver-ca.crt \
-  --embed-certs \
-  --kubeconfig="$KCFG"
-
-kubectl config set-credentials system:admin \
-  --client-certificate=admin-recovery.crt \
-  --client-key=admin-recovery.key \
-  --embed-certs \
-  --kubeconfig="$KCFG"
-
-kubectl config set-context system:admin \
-  --cluster="$CLUSTER" \
-  --namespace=default \
-  --user=system:admin \
-  --kubeconfig="$KCFG"
-
-kubectl config use-context system:admin --kubeconfig="$KCFG"
-```
-
-### Verify the credential
-
-Authenticate against the cluster and confirm the principal:
-
-```bash
-kubectl --kubeconfig="$KCFG" auth whoami -o yaml
-kubectl --kubeconfig="$KCFG" get nodes
-```
-
-`auth whoami` should report `username: system:admin` plus `system:masters` and `system:authenticated` group membership. Once the recovery kubeconfig is verified working, immediately:
-
-1. Re-establish the long-term admin identity through the regular IdP / OAuth path.
-2. Rotate the cluster-signer if there is any reason to believe the apiserver CA was compromised.
-3. Delete the recovery key (`shred -u admin-recovery.key`) and revoke the CSR record.
 
 ## Diagnostic Steps
 
-If `kubectl certificate approve` returns `Forbidden`, the executing identity does not hold the `approve` verb on `signers/kubernetes.io/kube-apiserver-client`. Check it explicitly:
+Confirm the request reached the intended signer and inspect its approval state — the request remains pending until an approver acts, since this signer does not auto-approve [ev:c1]:
 
 ```bash
-kubectl auth can-i approve certificatesigningrequests \
-  --subresource=approval
+kubectl get csr admin-client \
+  -o jsonpath='{.spec.signerName}{"\n"}{.status.conditions}{"\n"}'
 ```
 
-If false, no recovery is possible from that session — escalate to a node-local approval path or use a backup of the long-term admin kubeconfig if one is on file.
-
-If the resulting kubeconfig still fails with `x509: certificate signed by unknown authority`, the embedded CA bundle does not include the chain that signs the apiserver's serving cert. Confirm what the apiserver actually presents:
-
-```bash
-echo Q | openssl s_client -connect "${SERVER#https://}" -showcerts 2>/dev/null \
-  | awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/'
-```
-
-Compare the issuer of the leaf certificate against the bundle in `apiserver-ca.crt`. If they don't match, append the missing intermediate or root.
-
-If `kubectl auth whoami` reports `system:anonymous` or fails, the certificate is being rejected before being mapped to a user. Re-decode the CSR's status and confirm the `Subject` matches what was requested:
-
-```bash
-openssl x509 -in admin-recovery.crt -noout -subject -issuer -dates
-```
-
-Subject must be `CN=system:admin, O=system:masters`; if `O=` was dropped during signing, the cluster will authenticate the user but not grant cluster-admin (that ClusterRoleBinding is keyed by group, not by user).
-
-To inspect the binding that confers admin rights:
-
-```bash
-kubectl get clusterrolebinding cluster-admin -o yaml
-```
-
-The default upstream binding maps `Group: system:masters` to `ClusterRole: cluster-admin`; if that binding has been edited or replaced (some hardened distributions do), adjust the recovery CSR's subject to whatever group the local cluster trusts for admin.
+If `.status.certificate` is empty, verify an `Approved` condition is present: the signer only populates the certificate through the `/status` subresource after approval has been recorded through the separate `/approval` subresource [ev:c3]. If the issued certificate's validity is shorter than the value placed in `spec.expirationSeconds`, that is expected — the signer honors the request only up to the cluster-wide `--cluster-signing-duration` and will not issue below the 600-second minimum [ev:c2].

--- a/docs/en/solutions/Identifying_Which_Client_Deleted_a_Node_Object_Using_Kubernetes_Audit_Logs.md
+++ b/docs/en/solutions/Identifying_Which_Client_Deleted_a_Node_Object_Using_Kubernetes_Audit_Logs.md
@@ -4,120 +4,62 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500003
 ---
 
 # Identifying Which Client Deleted a Node Object Using Kubernetes Audit Logs
+
 ## Issue
 
-A worker node disappears from the cluster shortly after it joined, or vanishes during steady-state operation. `kubectl get nodes` no longer lists it, the kubelet on the host is healthy and continues to make heartbeat calls (which now create the node again under the same name and the cycle repeats), and there is no obvious controller status condition that explains the deletion.
-
-The recurring question is *who* deleted the Node object. The Kubernetes audit log records every API write, including the identity of the client that issued it. With the right query, the audit log identifies the responsible service account, controller, or human user.
+A Node object disappears from the cluster unexpectedly — for example a worker is removed shortly after it joins. Because Kubernetes Events do not record the identity of the requester that performed an operation, the cluster's own event stream cannot say which client deleted the Node. The authoritative record for attributing the deletion to a specific client is the kube-apiserver audit log, which captures the request verb, the target object, the requesting identity and the source IP for every API request [ev:c1].
 
 ## Root Cause
 
-Node deletion is a routine API call: `DELETE /api/v1/nodes/<name>`. Anything with `delete` permission on `nodes` can issue it. The usual deleters in a cluster are:
-
-- A cluster operator running maintenance (a real human via `kubectl`).
-- The cluster autoscaler removing an underused node.
-- A node-lifecycle policy controller from a multi-cluster management or governance platform.
-- A bespoke controller a team installed themselves.
-
-Determining which one issued the deletion requires correlating the deletion event with the calling identity. That correlation lives in the `kube-apiserver` audit log, which records `verb`, `objectRef`, `user.username`, and `sourceIPs` for every request that crosses the API server.
+A Node object can be deleted by any authenticated subject — a human user or a ServiceAccount — that is bound to a role granting the `delete` verb on the `nodes` resource. On Alauda Container Platform a broad set of ClusterRoles carry node-delete permission, including ServiceAccount-bindable platform roles, so a controller running under a ServiceAccount is fully capable of removing a Node object [ev:c5]. When a Node vanishes, the question is therefore not whether a client could delete it but which client did — and that is answered from the audit log [ev:c1].
 
 ## Resolution
 
-Run a structured search of the apiserver audit log on each control-plane node, filtered to `delete` operations against the affected node's resource. The query below returns one line per matching audit event with the timestamp, verb, request URI, target object, calling identity, and source IP:
+Confirm that audit logging is active on the kube-apiserver, then read the requesting identity out of the audit records [ev:c2].
 
-```bash
-NODE=worker-01
-
-kubectl get nodes -l node-role.kubernetes.io/control-plane \
-  -o name \
-  | while read -r master; do
-      master_name=${master#node/}
-      echo "===== $master_name ====="
-      # Stream the apiserver audit log off this control-plane node.
-      # Path is the kubeadm default; adjust to your cluster's audit
-      # policy if you use a different sink.
-      # ACP cluster PSA rejects `chroot /host`; read host files via the
-      # debug pod's /host bind-mount. The image must contain `cat`.
-      kubectl debug node/${master_name} \
-        -it --image=registry.alauda.cn:60070/acp/alb-nginx:v4.3.1 \
-        -- cat /host/var/log/kube-apiserver/audit.log 2>/dev/null \
-        | jq -cr --arg node "$NODE" '
-            select(
-              (.verb != "get") and (.verb != "watch") and
-              (.objectRef.resource == "nodes") and
-              (.objectRef.name == $node)
-            )
-            | "\(.stageTimestamp)|\(.verb)|\(.requestURI)|\(.user.username)|\(.sourceIPs[0])"
-          ' \
-        | column -t -s'|' \
-        | sort -k1
-  done
-```
-
-A typical hit:
+On Alauda Container Platform the kube-apiserver runs as a static Pod `kube-apiserver-<node-ip>` in the `kube-system` namespace (image `kube-apiserver:v1.34.5`). Audit logging is enabled through the apiserver flags, and the records are written as JSON [ev:c2]:
 
 ```text
-2026-04-23T00:45:25.943914Z  delete  /api/v1/nodes/worker-01  system:serviceaccount:cluster-policy:policy-controller-sa  10.0.5.42
+--audit-policy-file=/etc/kubernetes/audit/policy.yaml
+--audit-log-path=/etc/kubernetes/audit/audit.log
+--audit-log-format=json
+--audit-log-mode=batch
 ```
 
-The `user.username` field tells you exactly who issued the deletion: in this example the service account `policy-controller-sa` from the `cluster-policy` namespace. From that identifier you can:
-
-- Inspect the namespace where the service account lives to discover which controller owns it.
-- `kubectl auth can-i delete nodes --as=system:serviceaccount:cluster-policy:policy-controller-sa` to confirm the identity actually has the permission it used.
-- Read the controller's logs over the same time window to see *why* it decided to delete the node.
-
-If the username is a real human (e.g. `alice@example.com`), the deletion was a hands-on operation; investigate the human-side runbook that triggered it.
-
-If the username belongs to a system controller you do not recognise, the controller is a candidate to disable, scope down via RBAC, or reconfigure so it stops removing nodes you want to keep.
-
-### Scoping Down the Offending Identity
-
-Once the identity is known, the safest tactical fix is to revoke its `delete` permission on `nodes` while you investigate the controller's behaviour:
+Inspect the running apiserver Pod to confirm these flags are present before relying on the log [ev:c2]:
 
 ```bash
-kubectl create clusterrole node-delete-block \
-  --verb=delete --resource=nodes --dry-run=client -o yaml \
-  > /tmp/blocker.yaml
-# Edit /tmp/blocker.yaml — add a rule that has the same shape but
-# removes the binding instead of granting it; then look at existing
-# ClusterRoleBindings on the offending SA:
-
-kubectl get clusterrolebinding -o json \
-  | jq '.items[] | select(.subjects[]? | .name == "policy-controller-sa")'
+kubectl -n kube-system get pod kube-apiserver-<node-ip> \
+  -o jsonpath='{.spec.containers[0].command}' | tr ',' '\n' | grep audit
 ```
 
-Remove the binding that grants `delete` on `nodes`. The controller will start logging permission errors instead of silently deleting nodes — which is the visibility you need to fix it properly.
+The audit records follow the standard `audit.k8s.io/v1` Event shape. Each record for a Node deletion exposes `stageTimestamp`, `verb`, `requestURI`, `objectRef.resource`, `objectRef.name`, `user.username` and `sourceIPs` [ev:c3_a]. The audit log file is written on the control-plane node at the configured `--audit-log-path` and is read there [ev:c2].
 
 ## Diagnostic Steps
 
-If the audit search above returns no rows, two failure modes are likely:
+Filter the audit log for delete requests against the `nodes` resource that target the missing node; the matching record's `user.username` and `sourceIPs` identify the deleting client [ev:c3_b]. With the JSON-format log lines collected into a file, the following selects the relevant rows [ev:c3_a]:
 
-1. **Audit logging is not enabled.** Check the apiserver process arguments on a control-plane host:
+```bash
+NODE=<node-name>
+jq -cr --arg node "$NODE" '
+  select((.verb != "get") and (.verb != "watch")
+    and (.objectRef.resource == "nodes")
+    and (.objectRef.name == $node))
+  | "\(.stageTimestamp)|\(.verb)|\(.requestURI)|\(.objectRef.resource)/\(.objectRef.name)|\(.user.username)|\(.sourceIPs)"
+' audit.log | sort
+```
 
-   ```bash
-   # `ps -ef` from a debug pod with --profile=sysadmin sees the host PID
-   # namespace; chroot is not needed (and is rejected by ACP's PSA).
-   kubectl debug node/<master> -it \
-     --image=registry.alauda.cn:60070/acp/alb-nginx:v4.3.1 --profile=sysadmin \
-     -- ps -ef | grep kube-apiserver | grep -oE '\-\-audit-(log-path|policy-file)=[^ ]+'
-   ```
+A matching line such as a `delete` on `nodes/<node-name>` whose `user.username` is a ServiceAccount name confirms that a non-human client removed the Node [ev:c3_b]. Cross-reference that identity against the ClusterRoles that grant `delete` on `nodes` to determine which workload or controller holds the permission [ev:c5]:
 
-   Both `--audit-policy-file` and `--audit-log-path` should be set. If they are not, configure an audit policy (a permissive policy that records all `verbs` against `nodes` is enough for this investigation) and roll the apiserver pods.
-
-2. **The audit policy filters out the `delete` verb on `nodes`.** Inspect the audit policy:
-
-   ```bash
-   kubectl debug node/<master> -it \
-     --image=registry.alauda.cn:60070/acp/alb-nginx:v4.3.1 \
-     -- cat /host<policy-file-path>
-   ```
-
-   Add a rule for the `nodes` resource at `level: Metadata` (or higher) so the deletion is recorded going forward.
-
-After audit logging captures a deletion, the same query above will surface the responsible identity and the investigation can proceed with concrete evidence.
-</content>
+```bash
+kubectl get clusterrole -o json | jq -r '
+  .items[] | select(any(.rules[]?;
+    (.resources[]? == "nodes" or .resources[]? == "*")
+    and (.verbs[]? == "delete" or .verbs[]? == "*")))
+  | .metadata.name'
+```

--- a/docs/en/solutions/MutatingAdmissionWebhook_Timeout_During_Pod_Creation.md
+++ b/docs/en/solutions/MutatingAdmissionWebhook_Timeout_During_Pod_Creation.md
@@ -4,104 +4,55 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500015
 ---
 
-# MutatingAdmissionWebhook Timeout During Pod Creation
+# MutatingAdmissionWebhook admission timeouts on ACP — webhook, network, and etcd as causes
 
 ## Issue
 
-The Kubernetes API server reports that a MutatingAdmissionWebhook fails to complete its mutation within the 13-second deadline:
+On Alauda Container Platform (validated on Kubernetes `v1.34.5` with the upstream etcd v3 static-pod control plane) the kube-apiserver runs the upstream Kubernetes admission chain, and any registered mutating webhook that fails to return inside its configured per-call timeout causes the apiserver to fail the entire admission decision. Callers (controllers and `kubectl` clients) observe an `Internal error occurred: admission plugin "MutatingAdmissionWebhook" failed to complete mutation in <N>s` response, where the literal `<N>s` value is the timeout that the webhook configuration declared at the time of the call [ev:c1]. Because admission denial is synchronous, every workload-creation path that traverses the slow webhook — pod creation by controllers, direct `kubectl apply`, CR reconciliation that spawns child objects — surfaces the same error and stops making progress on the affected objects.
 
-```
-Internal error occurred: admission plugin "MutatingAdmissionWebhook" failed to complete mutation in 13s
-```
-
-This error appears when creating pods, tasks, or other resources. The webhook pods themselves appear healthy and report no errors in their logs.
+The symptom is not localised to one component, so the same error string can appear in the logs of any control-plane or workload controller that drives object creation through admission [ev:c1]. The shape of the message is fixed by the upstream Kubernetes apiserver; only the timeout value and the failing-webhook identity vary between occurrences.
 
 ## Root Cause
 
-The mutating admission webhook invokes an external service for every relevant API request. When the webhook backend takes too long to respond — typically because the etcd cluster is underperforming — the API server cancels the request after the 13-second timeout.
+The timeout does not by itself identify which side of the webhook call is slow. A webhook responds to an admission request by reading and writing cluster state, and on the apiserver side that round-trip lands on etcd; if any link in the chain — the webhook pod, the network path between the apiserver and the webhook service, or the etcd backend the webhook pod depends on — is slow enough to push the request past the declared timeout, admission fails with the same wording [ev:c8]. The reverse is also true: a webhook pod that is `Running` and reports no error in its own logs can still be the cause, because admission throughput is bound by the slowest step in the request path rather than by pod readiness alone [ev:c4].
 
-Potential causes, in order of likelihood:
-
-1. **Slow etcd** — The webhook pods perform etcd lookups during mutation. A degraded etcd cluster slows these operations below the deadline.
-2. **Webhook pod resource exhaustion** — Insufficient CPU or memory causes slow response times.
-3. **Network partition** — Connectivity problems between the API server and webhook service.
+Etcd performance is therefore a candidate root cause, but it is not the only one and not the first one to investigate. Webhook-pod-side faults (the webhook process is healthy as a process but is itself slow, deadlocked on its own dependencies, or undersized for the request rate) and pod-to-pod network problems between the apiserver pods and the webhook service must be ruled out before the investigation turns to etcd [ev:c9].
 
 ## Resolution
 
-### Step 1: Verify Webhook Pod Health
+Work the causes in the order their evidence weight dictates. First, confirm webhook-pod health beyond simple readiness: the pods backing the failing webhook service may be `Running` and emit no errors of their own while admission requests through them still time out, so liveness alone is not a discharge of suspicion [ev:c4]. Inspect the webhook pods directly — list them in their namespace, read their logs across all replicas, and confirm they are actually serving the admission endpoint that the `MutatingWebhookConfiguration` points at.
 
-Confirm that the webhook pods are running and responsive:
-
-```bash
-kubectl get pods -n <webhook-namespace> -l app=<webhook-label>
-kubectl logs -n <webhook-namespace> <webhook-pod> --tail=50
-```
-
-Check whether the webhook endpoint responds within a reasonable time:
+Identify the failing webhook and its pods:
 
 ```bash
-kubectl run curl-test --image=curlimages/curl --rm -it --restart=Never -- \
-  curl -sk https://<webhook-service>.<namespace>.svc:443/healthz
+kubectl get mutatingwebhookconfiguration -o yaml \
+  | grep -E 'name:|service:|namespace:|timeoutSeconds:' | head -40
+kubectl get pods -A -l <webhook-app-label>
+kubectl logs -n <webhook-ns> <webhook-pod> --previous --tail=200
 ```
 
-### Step 2: Check etcd Performance
+Second, rule out pod-to-pod network problems between the apiserver and the webhook service. The apiserver dials the webhook over the cluster service network, so the round-trip latency, DNS resolution to the webhook Service, and any CNI-level loss on that path all factor into the budget [ev:c9].
 
-If the webhook pods are healthy, investigate etcd latency. Refer to the etcd backend performance knowledge base article for detailed metrics and thresholds.
+Third — and only after the first two are clean — turn to etcd. Validate that the cluster's etcd meets the documented backend performance requirements that apply to the platform [ev:c10]. Etcd backend performance is the upstream-published bar for fsync / commit latency that must be cleared before any control-plane component can be expected to behave predictably; the same backend bar applies on ACP because the control plane runs the upstream etcd v3 binary. Graph etcd metrics with Prometheus to gauge actual performance against that bar, using the standard upstream etcd histograms that the etcd binary exports on its metrics endpoint [ev:c11]. The Prometheus instance that scrapes those series on this platform is the kube-prometheus stack in the `cpaas-system` namespace; per-instance dashboarding follows the upstream etcd dashboard shape.
 
-Key indicators:
+If the metrics show a backend that has outgrown its disk envelope, defragmenting etcd to decrease the on-disk database size is a remediation worth attempting [ev:c12]. Defragmentation reclaims space released by tombstones and historical revisions and shrinks the `db` file; it is performed per-member, in sequence, to avoid taking quorum down. The operation uses the etcdctl client distributed with the same etcd v3 release, invoked against each member's local client URL with the member's own peer/client TLS certificates — the exact certificate paths come from the etcd container's own command-line flags, which set `--cert-file`, `--key-file`, and `--trusted-ca-file` on the server side and require matching client-side `--cacert / --cert / --key` arguments for any etcdctl invocation that targets the TLS-only listen-client URL.
 
-```bash
-kubectl exec -n kube-system etcd-<node-name> -- etcdctl endpoint health \
-  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
-  --cert=/etc/kubernetes/pki/etcd/server.crt \
-  --key=/etc/kubernetes/pki/etcd/server.key
-```
-
-If the response time exceeds 100 ms, the etcd cluster needs attention — check disk I/O, CPU load, and database size.
-
-### Step 3: Check Network Connectivity
-
-Verify that the API server can reach the webhook service:
-
-```bash
-kubectl get endpoints <webhook-service> -n <namespace>
-```
-
-Ensure the endpoints list contains valid pod IPs and that those IPs are reachable from the control-plane nodes.
-
-### Step 4: Defragment etcd (If Needed)
-
-If etcd database fragmentation is the root cause:
-
-```bash
-kubectl exec -n kube-system etcd-<node-name> -- etcdctl defrag \
-  --endpoints=https://127.0.0.1:2379 \
-  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
-  --cert=/etc/kubernetes/pki/etcd/server.crt \
-  --key=/etc/kubernetes/pki/etcd/server.key
-```
+The same first-webhook-then-network-then-etcd ordering applies regardless of which workload component first surfaced the timeout — controllers that create pods, CR reconcilers, and ad-hoc `kubectl` callers all share the single admission chain, so a fix that restores the slowest link restores all of them [ev:c9].
 
 ## Diagnostic Steps
 
-Search API server logs for webhook timeout events:
+Start from the error string itself. The apiserver-emitted message `admission plugin "MutatingAdmissionWebhook" failed to complete mutation in <N>s` is the canonical signal that a registered mutating webhook is at fault; capture both the literal timeout value and any caller-side wrapping context (which controller / which object) from the log line where it appears [ev:c1].
+
+Enumerate the registered mutating webhooks and the namespaces that host them:
 
 ```bash
-kubectl logs -n kube-system kube-apiserver-<node-name> --tail=500 | \
-  grep "admission plugin.*MutatingAdmissionWebhook.*failed to complete"
+kubectl get mutatingwebhookconfiguration -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.webhooks[*].clientConfig.service.namespace}/{.webhooks[*].clientConfig.service.name}{"\n"}{end}'
 ```
 
-Identify which webhooks are registered and their failure policies:
+For each candidate webhook, check the backing pods and confirm that "pod Running" is not the only signal being relied on; correlate request volume and any internal latency the webhook exports with the time window when admission was timing out [ev:c4]. A webhook pod whose process is alive but stalled on its own backend is the most common shape of this failure and is invisible to a readiness probe.
 
-```bash
-kubectl get mutatingwebhookconfigurations -o wide
-```
-
-Review the timeout setting for each webhook configuration:
-
-```bash
-kubectl get mutatingwebhookconfiguration <name> -o jsonpath='{.webhooks[*].timeoutSeconds}'
-```
+When neither the webhook pods nor the network path between apiserver and webhook show a problem, broaden the scope to etcd performance before declaring the cause unknown [ev:c9]. Validating etcd against the documented backend performance requirements, plus graphing the etcd histograms in Prometheus, gives a defensible answer for whether etcd-side slowness is making otherwise-healthy webhooks miss their admission budget [ev:c10][ev:c11]. If that investigation shows backend growth as a contributor, the per-member defragmentation procedure is the targeted remediation [ev:c12].

--- a/docs/en/solutions/Navigating_Kubernetes_API_deprecations_and_removals.md
+++ b/docs/en/solutions/Navigating_Kubernetes_API_deprecations_and_removals.md
@@ -4,87 +4,45 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500011
 ---
 
-# Navigating Kubernetes API deprecations and removals
+# Handling removed Kubernetes API versions before and after a cluster upgrade
 
-## Overview
+## Issue
 
-Kubernetes follows a strict API versioning policy. Every beta API (`v1beta1`, `v2beta1`, and so on) is guaranteed to be supported for nine months or three Kubernetes releases — whichever is longer — after it is marked deprecated, and is then free to be removed from the server entirely. When that removal happens, any workload, controller, tool or pipeline that still talks to the old version stops working.
+Alauda Container Platform runs the upstream Kubernetes API server and follows the upstream API lifecycle, so beta API versions are eventually removed as the cluster advances across Kubernetes minor releases. On a cluster at Kubernetes v1.34.5, the flow-control group serves only the GA version `flowcontrol.apiserver.k8s.io/v1`; no `v1beta*` versions of that group are served, reflecting the upstream rule that a beta API version is retained for a defined window after deprecation and then removed in a later minor release [ev:c1]. Once a version reaches that point and is dropped, requests from workloads, tools, or other components that still target the removed version begin to fail [ev:c2].
 
-Upstream maintains the canonical timeline in the [API deprecation policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/) and the per-release [deprecated API migration guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/). Administrators should expect to audit their clusters for deprecated versions in use at every minor-version upgrade, migrate affected manifests to the new version, and then unblock the upgrade explicitly once the audit is clean.
+```text
+Error from server (NotFound): the server could not find the requested resource
+```
 
-This article describes how to identify deprecated API usage on an ACP cluster, how to migrate to the successor versions, and what the cluster exposes as signals that usage has not yet been cleaned up.
+A direct request against a removed version such as `flowcontrol.apiserver.k8s.io/v1beta3` is answered with HTTP `404 Not Found` by the API server, because that version is no longer served [ev:c2].
+
+## Root Cause
+
+The set of served API versions is governed entirely by the upstream Kubernetes API machinery for the running minor version. When the cluster reaches a release in which a beta version has aged past its deprecation window, that version is removed from the served set; at v1.34.5 the flow-control group exposes only `flowcontrol.apiserver.k8s.io/v1`, and any client still issuing calls against a removed `v1beta*` form has no served endpoint to reach [ev:c1]. The failures are therefore not a misconfiguration of the cluster but the expected result of a client continuing to use an API version that the upgraded API server no longer recognizes [ev:c2].
 
 ## Resolution
 
-Treat every minor-version upgrade as an API audit. The workflow below generalises across any Kubernetes-based platform:
+Before upgrading a cluster across a release where API removals occur, identify which workloads, manifests, controllers, and client tools still target the soon-to-be-removed API versions, and migrate them to the appropriate replacement version ahead of the upgrade [ev:c3]. The commands below show only which versions the API server currently serves; they do not by themselves list which clients are still calling a given version, so the workload-side review must be done by inspecting manifests, Helm charts, GitOps repos, controller images, and any other sources of API traffic that are known to reference the deprecated version [ev:c3]. For the flow-control group, the surviving served version on a v1.34.5 cluster is the GA `flowcontrol.apiserver.k8s.io/v1`; manifests and clients should be updated to that version so they continue to resolve after the upgrade [ev:c1].
 
-1. **Inventory every removed API in the target release.** The upstream [deprecated API migration guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) lists exactly which `group/version/kind` triples are removed in each minor release (for example, Kubernetes 1.22 removed a large batch of `v1beta1` APIs that had been deprecated in 1.16). Build a list of the kinds that the target release will stop serving.
+Confirm which versions a group currently serves on the running cluster, then update resources to target the GA version:
 
-2. **Scan all stored objects for those kinds.** Every deprecated object has two dimensions: the `storedVersion` (what etcd keeps on disk, returned by `kubectl get --raw /apis/<group>`) and the `served` version (what clients and controllers submit). Both need to be upgraded:
+```bash
+kubectl api-versions | grep flowcontrol.apiserver.k8s.io
+```
 
-   ```bash
-   # Which versions does the cluster still serve?
-   kubectl api-resources -o wide
-   kubectl api-versions
-
-   # What versions are stored in etcd per resource?
-   kubectl get apiservices.apiregistration.k8s.io \
-     -o custom-columns=NAME:.metadata.name,AVAILABLE:.status.conditions[?(@.type=="Available")].status
-   ```
-
-   Use `kubectl get <kind> -A -o yaml` for each deprecated kind and look at the `apiVersion` in the returned YAML. Anything still bound to the deprecated version will not survive the next upgrade.
-
-3. **Rewrite manifests, charts, and automation to the successor version.** Typical migrations include:
-
-   - `extensions/v1beta1` Ingress → `networking.k8s.io/v1` Ingress
-   - `policy/v1beta1` PodDisruptionBudget → `policy/v1` PodDisruptionBudget
-   - `autoscaling/v2beta2` HorizontalPodAutoscaler → `autoscaling/v2`
-   - `batch/v1beta1` CronJob → `batch/v1`
-   - `apiregistration.k8s.io/v1beta1` APIService → `apiregistration.k8s.io/v1`
-
-   For CRD-backed workloads, bump `apiVersion` across the whole toolchain: raw manifests, Helm charts, GitOps application source, CI pipeline fixtures, and any admission-webhook client code. Leaving even one generator on the old version means the next `kubectl apply` will silently recreate a deprecated object.
-
-4. **Re-run the scan until it is clean,** then proceed with the upgrade. Do not rely on post-upgrade repair scripts; once the server stops serving the old version, existing controllers that use it simply begin to error.
-
-5. **Prefer `apiVersion`-agnostic tooling** when possible. `conversion webhooks` on CRDs, `kustomize` `apiVersion` patches, and Helm templates keyed off the running Kubernetes minor version let you roll out a single source tree across a fleet of clusters on different versions without a separate manifest per server version.
+```yaml
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+```
 
 ## Diagnostic Steps
 
-On a running cluster, two signals tell you whether deprecated API usage is still in play:
+To identify whether a failure stems from a removed API version, inspect the API server response to the affected request. A removed version returns `404 Not Found` and the API server reports that it could not find the requested resource, distinguishing a removed-version call from an authorization or admission failure [ev:c2]. Cross-check the served versions for the affected group against the GA-only set present on the v1.34.5 cluster: this confirms whether the version named in the failing request is still served on the running minor and which version remains as the migration target [ev:c1]. The query reports served versions, not in-use callers, so it confirms the diagnosis of a removed-version call but does not by itself enumerate every client still issuing the old version — that enumeration has to come from inspecting the workloads, manifests, and tools known to send the failing request [ev:c1].
 
 ```bash
-# Every deprecated request bumps this counter. A non-zero rate after
-# migration work is complete means some controller or cronjob is still
-# dragging on the old version.
-kubectl get --raw '/metrics' | grep apiserver_requested_deprecated_apis
+kubectl get --raw /apis/flowcontrol.apiserver.k8s.io
 ```
-
-Query Prometheus for the same counter to see *which* resource is still being used:
-
-```text
-sum by (group, version, resource) (
-  rate(apiserver_requested_deprecated_apis[5m])
-)
-```
-
-The group/version/resource labels identify the offender — often a controller or operator that has not been upgraded. Upgrade the component (or, if it is in-house, bump its client-go dependency) until the counter drops to zero.
-
-Audit stored resources against the removed list for the next release:
-
-```bash
-for api in \
-  ingresses.extensions \
-  podsecuritypolicies.policy \
-  cronjobs.batch \
-  horizontalpodautoscalers.autoscaling \
-  ; do
-  echo "=== $api ==="
-  kubectl get "$api" -A -o json 2>/dev/null | jq -r '.items[] | "\(.apiVersion) \(.metadata.namespace)/\(.metadata.name)"' | sort -u
-done
-```
-
-Any line showing a deprecated `apiVersion` is a migration candidate. Re-apply the object in the successor version to rewrite the stored copy in etcd. Once the output only contains successor versions, the cluster is safe for the upgrade that removes the old ones.

--- a/docs/en/solutions/Node_NotReady_with_PLEG_is_not_healthy.md
+++ b/docs/en/solutions/Node_NotReady_with_PLEG_is_not_healthy.md
@@ -4,127 +4,113 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500038
 ---
 
-# Node NotReady with "PLEG is not healthy"
+# Node NotReady on ACP with kubelet "PLEG is not healthy"
+
 ## Issue
 
-One or more cluster nodes flap into `NotReady` and the kubelet status logs report errors similar to:
-
-```text
-container runtime is down, PLEG is not healthy: pleg was last seen active ...
-```
-
-Workloads on the affected node stop receiving lifecycle updates, new pods fail to schedule there, and if the condition persists the controller-manager starts evicting pods off the node. The node usually recovers briefly after a kubelet restart and then flaps again a few minutes later.
+On an Alauda Container Platform cluster (kube v1.34.5, container runtime `containerd://2.2.1-5`), a worker node flips to `NotReady` while the kubelet reports the message "container runtime is down, PLEG is not healthy" on the node's `Ready` condition. The Ready condition exposes the standard upstream `NodeCondition` fields (`type`, `status`, `reason`, `message`, `lastHeartbeatTime`, `lastTransitionTime`); on a healthy node `type=Ready`, `status=True`, `reason=KubeletReady`, with the message carrying the kubelet's free-form text. The same fields surface the PLEG-not-healthy text when the kubelet's Pod Lifecycle Event Generator cannot complete its periodic relist against the container runtime [ev:c1].
 
 ## Root Cause
 
-The Pod Lifecycle Event Generator (PLEG) is a component inside the kubelet that periodically asks the container runtime for the list of containers and their state. Each iteration is called a "relist". If the kubelet cannot complete a full relist within the PLEG health window (three minutes), it marks the node `NotReady` with `PLEG is not healthy` and surfaces a CRI-level error.
+The kubelet's PLEG runs a continuous relist loop against the CRI socket (`/run/containerd/containerd.sock` on ACP) to keep an in-memory cache of pod and container state. The `kubelet_pleg_last_seen_seconds` metric is the relist heartbeat — it advances roughly one-for-one with wallclock on a healthy node, and the kubelet considers PLEG unhealthy when the heartbeat ages past the relist threshold; a `kubelet_pleg_discard_events` counter tracks dropped events when the loop falls behind [ev:c2].
 
-The underlying causes cluster into four buckets:
+Per-relist work scales with the number of pods on the node, independent of host spec: across four otherwise-identical nodes (same kernel, container runtime, kube version), the `kubelet_pleg_relist_duration_seconds_sum` cumulative counter is higher on the nodes carrying more pods (33 pods produced about 8967 s; 48 and 49 pods produced about 9501 s and 10785 s respectively). The relist interval itself stays close to the 1 s upstream cadence — what scales is the per-pass cost, not the loop frequency [ev:c3].
 
-- **Container runtime latency or hang.** The CRI endpoint is responding slowly, stuck on a deadlocked goroutine, or serialised behind an expensive operation (for example, removing a very large container root filesystem). Every relist queues behind it and PLEG times out.
-- **Pod density too high for the relist window.** PLEG cost scales with the number of containers on the node, not with host CPU / memory budget. A 96-core host running 1,000 containers still has to walk each one per relist and will miss the deadline before a smaller host with 50 containers ever does.
-- **CNI problems during pod status fetch.** Getting pod network status is part of the relist path; a hung CNI call (network plugin unresponsive, `cni-bin` missing a binary, network policy controller stuck) stalls PLEG exactly the same way a runtime hang does.
-- **Resource starvation of the kubelet itself.** Containers without requests/limits starving the node of CPU, memory pressure causing OOM kills of kubelet helpers, or a hot I/O loop starving the container runtime process of syscall throughput — all of these show up at the PLEG boundary because that is the first thing the kubelet misses a deadline on.
+Runtime latency, deadlocks, or timeouts on remote CRI requests push relist work past the kubelet's `runtimeRequestTimeout` (live value `2m0s`) and surface as `kubelet_runtime_operations_errors_total{operation_type=…}` increments — broken out per CRI verb (`container_status`, `exec_sync`, `pull_image`, `run_podsandbox`, `remove_container`, `start_container`). A degraded runtime drives these counters up and starves the relist loop in the same window [ev:c4].
+
+A second class of stall sits in the CNI plugin chain. The node uses Multus as the meta-plugin (`00-multus.conf`) delegating to `kube-ovn` (`01-kube-ovn.conflist`), and the kube-ovn plugin reaches a local socket at `/run/openvswitch/kube-ovn-daemon.sock` on every CNI invocation. A bug or stall in that daemon blocks the CRI's `PodSandbox` network-status callback inside the same `runtimeRequestTimeout` window and contributes to PLEG unhealthiness [ev:c5].
 
 ## Resolution
 
-The immediate recovery is to cordon and drain the node, restart the runtime and kubelet, and clean up dead containers and dangling images that add unnecessary cost to each relist. Then address whichever of the structural causes apply.
-
-Step 1 — drain the node so workloads fail over cleanly:
+Evacuate the node before touching the kubelet or the runtime. `kubectl drain` cordons the target node first, then evicts non-DaemonSet pods. With `--ignore-daemonsets`, per-node agents (CNI, storage, monitoring) stay during maintenance; standalone pods (no controller) are refused without `--force`, which acts as a safety gate against evicting workloads that have no scheduler-managed replacement [ev:c6]:
 
 ```bash
 kubectl cordon <node-name>
 kubectl drain <node-name> --ignore-daemonsets --delete-emptydir-data
 ```
 
-Step 2 — on the node host, restart the runtime and kubelet. ACP's cluster PSA rejects `chroot /host`; instead use `kubectl debug node` with `--profile=sysadmin` (which mounts the host's systemd socket and PID namespace) and an image that ships `systemctl`. A `busybox` image lacks `systemctl`:
+With the node drained, restart the kubelet and the container runtime via systemd; the runtime daemon on ACP nodes is `containerd.service` (loaded, enabled, active in the live capture) and the kubelet unit name matches upstream [ev:c6]:
 
 ```bash
-kubectl debug node/<node-name> --image=<image-with-systemd> --profile=sysadmin -it -- \
-  sh -c 'systemctl restart crio && systemctl restart kubelet'
+systemctl restart kubelet
+systemctl restart containerd
 ```
 
-Step 3 — purge exited containers and untagged images. These accumulate on a node across workload churn and inflate every relist. The image must ship `crictl`:
+Prune exited containers with `crictl`. ACP nodes ship the runtime-agnostic `crictl` CLI wired to the containerd socket via `/etc/crictl.yaml` (`runtime-endpoint: unix:///run/containerd/containerd.sock`); `crictl version` reports `RuntimeName: containerd / RuntimeVersion: v2.2.1-5`. `crictl ps -a --state exited` enumerates exited containers — the canary node observed 43 — and `crictl rm` accepts CONTAINER-IDs with the upstream `--all` / `--force` / `--keep-logs` flags [ev:c8]:
 
 ```bash
-kubectl debug node/<node-name> --image=<image-with-crictl> --profile=sysadmin -it -- \
-  sh -c '
-    crictl ps -a | awk "/Exited/ {print \$1}" | xargs -r crictl rm
-    crictl images | awk "/<none>/ {print \$3}" | xargs -r crictl rmi
-  '
+crictl ps -a --state exited
+crictl ps -a | grep -i Exited | awk '{print $1}' | xargs -r crictl rm
 ```
 
-Step 4 — uncordon the node:
+Prune untagged images the same way. `crictl images` returns the standard IMAGE / TAG / IMAGE ID / SIZE columns; untagged images appear with `TAG=<none>`. `crictl rmi` accepts IMAGE-IDs with `--all` / `--prune`, so the upstream cleanup form ports verbatim [ev:c9]:
+
+```bash
+crictl images
+crictl images | awk '$2=="<none>" {print $3}' | xargs -r crictl rmi
+```
+
+Set `requests` and `limits` on workloads to guard the node against OOM and CPU starvation that degrade node processes including the runtime. The standard `pod.spec.containers.resources` `ResourceRequirements` struct exposes `requests<map[string]Quantity>` and `limits<map[string]Quantity>`. The kubelet's `evictionHard` thresholds — live values `memory.available: 100Mi` and `pid.available: 10%` — are the signals that flip the node's `MemoryPressure` and `PIDPressure` conditions; on a healthy cluster all nodes report both as `False/KubeletHasSufficientMemory` and `False/KubeletHasSufficientPID` [ev:c10]:
+
+```yaml
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+```
+
+After the kubelet and containerd come back, uncordon the node:
 
 ```bash
 kubectl uncordon <node-name>
 ```
 
-If PLEG recurs after this cleanup, it is one of the structural causes and the fix is not on the node itself:
-
-- **Set `resources.requests` and `resources.limits` on every workload.** Unbounded pods routinely starve the kubelet at load. Start with the offender identified by `kubectl top pod --sort-by=cpu` and `--sort-by=memory` during the incident window.
-- **Cap pod density** on hosts that exceed roughly 250 pods per node. The kubelet's `maxPods` default is 110; values above that are supported but the PLEG budget tightens quickly, especially with many short-lived containers. Lower `maxPods` on the node-config for affected pools, or scale horizontally.
-- **Check CNI health.** The cluster CNI on ACP is Kube-OVN. Watch the Kube-OVN controller and daemon pods for restart loops or stuck reconciles during the same window as the PLEG error:
-
-  ```bash
-  kubectl -n kube-system get pod -l app=kube-ovn-cni -o wide
-  kubectl -n kube-system logs ds/kube-ovn-cni --since=30m | grep -iE 'timeout|deadline|reconcile'
-  ```
-
-  A hang inside the CNI during pod-status fetch surfaces as a PLEG symptom on the kubelet side even though the root cause is in the network stack.
-- **Upgrade the runtime if a known deadlock has been fixed upstream.** The node-config surface (`configure/clusters/nodes`, or the **Immutable Infrastructure** extension) is where the runtime version is pinned; bumping the runtime is a declarative rolling change from there, not a per-node yum transaction.
-
 ## Diagnostic Steps
 
-Confirm PLEG is the actual condition the node is reporting (not a generic `KubeletNotReady`):
+Confirm the node's `Ready` condition is the surface carrying the PLEG message — the standard upstream NodeCondition shape applies on ACP, with `type=Ready` and the kubelet's free-form text in `.message` [ev:c1]:
 
 ```bash
-kubectl describe node <node-name> | sed -n '/Conditions/,/Addresses/p'
+kubectl get node <node-name> -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
 ```
 
-Look at the kubelet log around the transition to `NotReady` to see which CRI call was outstanding when PLEG timed out. `journalctl --root=/host` reads the host's journal directory through the `/host` bind-mount — no chroot needed:
+Read the kubelet's PLEG metrics through the node's proxy `/metrics` endpoint to verify the heartbeat is advancing and watch the per-relist latency distribution; on a degraded node `kubelet_pleg_last_seen_seconds` will stop tracking wallclock and `kubelet_pleg_discard_events` will increment [ev:c2]:
 
 ```bash
-kubectl debug node/<node-name> --image=<image-with-systemd> --profile=sysadmin -it -- \
-  journalctl --root=/host -u kubelet --since='30 min ago' \
-    | grep -iE 'pleg|relist|container runtime'
+kubectl get --raw "/api/v1/nodes/<node-name>/proxy/metrics" \
+  | grep -E '^kubelet_pleg_(last_seen_seconds|discard_events|relist_duration_seconds_(sum|count))'
 ```
 
-Look at the container runtime log for the same window — a runtime-side deadlock or exceptionally long syscall usually shows as a matching stall there:
+Correlate the relist load with per-node pod density. Higher pod counts produce higher cumulative `kubelet_pleg_relist_duration_seconds_sum` across nodes that share the same hardware profile; this is the data point that distinguishes a sizing problem (move pods off) from a runtime problem (investigate containerd) [ev:c3]:
 
 ```bash
-kubectl debug node/<node-name> --image=<image-with-systemd> --profile=sysadmin -it -- \
-  journalctl --root=/host -u crio --since='30 min ago' | tail -200
+kubectl get pods -A --field-selector spec.nodeName=<node-name> -o name | wc -l
 ```
 
-Count containers on the node to rule out density. `crictl` talks to the runtime over its CRI socket at `/run/crio/crio.sock` (or `/run/containerd/containerd.sock`); `--profile=sysadmin` mounts those:
+Read the live kubelet config (`/configz` proxy) for the runtime knobs governing CRI calls — `containerRuntimeEndpoint`, `runtimeRequestTimeout` (live `2m0s`), `maxPods` (live `255`) — and the `kubelet_runtime_operations_errors_total{operation_type=…}` counter to see which CRI verbs are failing [ev:c4]:
 
 ```bash
-kubectl debug node/<node-name> --image=<image-with-crictl> --profile=sysadmin -it -- \
-  crictl ps -a | wc -l
+kubectl get --raw "/api/v1/nodes/<node-name>/proxy/configz" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin)['kubeletconfig']; \
+                print({k:d[k] for k in ('runtimeRequestTimeout','containerRuntimeEndpoint','maxPods')})"
+kubectl get --raw "/api/v1/nodes/<node-name>/proxy/metrics" \
+  | grep '^kubelet_runtime_operations_errors_total'
 ```
 
-Nodes routinely over 300 live containers plus exited-not-yet-reclaimed are in the danger zone for PLEG.
-
-Spot-check unused resources that balloon relist cost:
+Inspect the CNI plugin chain on the node. The configuration lives in `/etc/cni/net.d/` (`00-multus.conf` + `01-kube-ovn.conflist`); a stalled kube-ovn daemon socket at `/run/openvswitch/kube-ovn-daemon.sock` will block the CRI's PodSandbox network-status callback. Check the daemon pod's health on the affected node before assuming the kubelet itself is at fault [ev:c5]:
 
 ```bash
-kubectl debug node/<node-name> --image=<image-with-crictl> --profile=sysadmin -it -- \
-  sh -c 'crictl ps -a | grep -i Exited | wc -l; crictl images | grep -c "<none>"'
+kubectl -n kube-system get pod -l app=kube-ovn-cni -o wide --field-selector spec.nodeName=<node-name>
 ```
 
-Large numbers for either indicate garbage collection is not keeping up — the periodic kubelet container and image GC settings may need tightening for that node pool.
-
-For the capacity angle, pair node-level pod count with cluster-wide top pods during the incident:
+Check the node's pressure conditions to decide whether `requests`/`limits` tuning is part of the fix. `MemoryPressure=True` or `PIDPressure=True` means workloads have overrun the eviction thresholds and the kubelet itself is competing for resources [ev:c10]:
 
 ```bash
-kubectl top node
-kubectl top pod -A --sort-by=cpu | head -20
-kubectl top pod -A --sort-by=memory | head -20
+kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"  "}{range .status.conditions[?(@.type=="MemoryPressure")]}{.type}={.status}{end}{"  "}{range .status.conditions[?(@.type=="PIDPressure")]}{.type}={.status}{end}{"\n"}{end}'
 ```
-
-If the top consumers are consistently unbounded workloads on the same node that hits PLEG, the fix is requests/limits (and pod anti-affinity to spread replicas), not anything on the runtime side.

--- a/docs/en/solutions/Pod_Pending_didnt_find_available_persistent_volumes_to_bind_Local_PVs_Pin_to_a_Specific_Node.md
+++ b/docs/en/solutions/Pod_Pending_didnt_find_available_persistent_volumes_to_bind_Local_PVs_Pin_to_a_Specific_Node.md
@@ -4,187 +4,47 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500033
 ---
 
-# Pod Pending: `didn't find available persistent volumes to bind` — Local PVs Pin to a Specific Node
+# Pod stays Pending with scheduler message "didn't find available persistent volumes to bind" on local PVs
 
 ## Issue
 
-A pod (typically a StatefulSet member — Prometheus, database, queue broker) stays Pending. `kubectl describe pod` shows the scheduler found **no** node where both a matching local PV and the pod's own node affinity can coexist:
-
-```text
-0/6 nodes are available:
-  3 node(s) didn't find available persistent volumes to bind,
-  3 node(s) didn't match Pod's node affinity/selector.
-preemption: 0/6 nodes are available: 6 Preemption is not helpful for scheduling.
-```
-
-The message is unusually clear about the intersection failure: three nodes carry local PVs but fail the pod's nodeSelector, and the other three nodes satisfy the nodeSelector but have no matching local PV. The scheduler has no candidate that satisfies both constraints simultaneously, so the pod never lands.
+On Alauda Container Platform 4.x (kube v1.34.5; topolvm CSI driver `topolvm.cybozu.com`, StorageClass `topolvm-hdd`), a Pod that consumes a PersistentVolumeClaim backed by a node-local PersistentVolume can stay in `Pending` indefinitely when the Pod template's `spec.nodeSelector` (or `spec.affinity.nodeAffinity`) narrows scheduling to a set of nodes that does not include the node named in the PV's `spec.nodeAffinity`. The kube-scheduler then reports a two-clause `FailedScheduling` event of the form `0/N nodes are available: X node(s) didn't find available persistent volumes to bind, Y node(s) didn't match Pod's node affinity/selector`, and the Pod never schedules — the same root mechanism applies whether the candidate PV is still `Available` (this exact message) or already `Bound` (the variant `X node(s) didn't match PersistentVolume's node affinity, Y node(s) didn't match Pod's node affinity/selector`) [ev:c1].
 
 ## Root Cause
 
-Local PVs created by the Local Storage Operator (or any equivalent tool that provisions PVs from a node's attached disks) carry a `nodeAffinity` field that hard-pins the PV to the specific node whose disk it was cut from:
-
-```yaml
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: local-pv-abcd
-spec:
-  nodeAffinity:
-    required:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: kubernetes.io/hostname
-              operator: In
-              values: [node-3]
-```
-
-That affinity is a hard constraint: the PV can only be consumed by a pod that runs on the named node. The PV cannot "migrate" to another node in any meaningful sense — the disk it represents is physically attached to one machine.
-
-When a pod's template carries its own `nodeSelector` (or `affinity` stanza) that narrows the pod to a *different* set of nodes — for example, a monitoring pod that expects to run on the control plane, while the local PVs were carved out of worker disks — the intersection of the two constraints is empty. The scheduler truthfully reports "no node satisfies both" and the pod stays Pending.
-
-Neither constraint can be relaxed without consequences: dropping the PV's nodeAffinity would allow the pod to try to mount a disk that isn't there, and dropping the pod's nodeSelector might land the pod on a node that lacks the unrelated requirements the selector was meant to enforce.
+A local PV's `spec.nodeAffinity` is a hard constraint: the PV cannot be bound or mounted on any node other than the one named in its affinity, because the underlying disk lives on that single machine. On ACP the default local-block storage path is TopoLVM (CSI driver `topolvm.cybozu.com`, StorageClass `topolvm-hdd`, `volumeBindingMode: WaitForFirstConsumer`); TopoLVM PVs also carry `nodeAffinity` pinning each volume to a single node, but the affinity key is `topology.topolvm.cybozu.com/node` rather than `kubernetes.io/hostname`. When the Pod's scheduling constraints exclude that single node, the VolumeBinding and NodeAffinity predicates run on disjoint node sets and the scheduler emits the two-clause failure shown above [ev:c3].
 
 ## Resolution
 
-Align the pod's scheduling constraints with the nodes that own the local PVs.
+Align the Pod's scheduling constraints with the node that owns the local PV. The two-clause scheduler message itself names the two predicates and their disjoint node populations: the `didn't find available persistent volumes to bind` clause counts the nodes the PVC could bind on, and the `didn't match Pod's node affinity/selector` clause counts the nodes the Pod template allowed; only their intersection is schedulable, and the PV's `nodeAffinity` is a hard pin to a single node [ev:c1][ev:c3].
 
-### Step 1 — enumerate which nodes hold the local PVs the pod expects
-
-```bash
-# List the bound PVs and their hostname affinity.
-kubectl get pv -o json | \
-  jq -r '.items[]
-         | select(.spec.nodeAffinity != null) |
-         (.spec.nodeAffinity.required.nodeSelectorTerms[0]
-            .matchExpressions[] |
-          select(.key == "kubernetes.io/hostname") |
-          .values[]) as $host |
-         "\(.metadata.name)\t\(.status.phase)\t\($host)\t\(.spec.storageClassName)"'
-```
-
-Output:
-
-```text
-local-pv-abcd   Available   node-3   local-block
-local-pv-efgh   Available   node-4   local-block
-local-pv-ijkl   Available   node-5   local-block
-```
-
-The PVs that the pod's PVC could bind to are the rows whose `storageClassName` matches the PVC's storage class. Note their `hostname` values — those are the nodes the pod **must** be able to land on.
-
-### Step 2 — inspect the pod's current scheduling constraints
-
-```bash
-kubectl -n <ns> get deployment <name> -o jsonpath='{.spec.template.spec.affinity}{"\n"}' | jq
-kubectl -n <ns> get deployment <name> -o jsonpath='{.spec.template.spec.nodeSelector}{"\n"}' | jq
-```
-
-Identify whatever `nodeSelector` or `affinity` is narrowing the pod to nodes that do not include the PV-owning ones.
-
-### Step 3 — update the pod's template to permit the PV-owning nodes
-
-Two shapes, pick the one closer to the intent:
-
-**If the pod's nodeSelector is incidental** (e.g. a label was copied from another workload without thought), remove it. The scheduler will then freely place the pod wherever both the node-affinity of the PV and normal constraints allow:
-
-```yaml
-# Before
-spec:
-  template:
-    spec:
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
-
-# After (nodeSelector removed)
-spec:
-  template:
-    spec:
-      # Let the PVC's PV-level nodeAffinity drive placement.
-      # The scheduler will place this pod on whichever node has the local PV.
-```
-
-**If the pod's nodeSelector is intentional** (e.g. the pod really should run on a specific subset of nodes), **provision local PVs on those nodes instead**. Either extend the Local Storage Operator's `LocalVolumeSet` / equivalent CR to include the intended-placement nodes, or schedule the workload such that the PV-owning nodes are included in the selector:
-
-```yaml
-# LocalVolumeSet with a broader nodeSelector.
-apiVersion: local.storage.alauda.io/v1alpha1
-kind: LocalVolumeSet
-metadata:
-  name: local-block-osds
-spec:
-  nodeSelector:
-    nodeSelectorTerms:
-      - matchExpressions:
-          - key: node-role.kubernetes.io/infra
-            operator: Exists
-  # ... filters ...
-```
-
-Then wait for new PVs to provision on the `infra` nodes before re-deploying the pod.
-
-### Step 4 — watch the pod schedule
-
-After aligning the constraints, trigger a new pod attempt (rollout restart, or simply delete the pending pod so the controller recreates it):
-
-```bash
-kubectl -n <ns> rollout restart deployment/<name>
-# or
-kubectl -n <ns> delete pod -l <selector>
-```
-
-Monitor:
-
-```bash
-kubectl -n <ns> get pod -l <selector> -w
-```
-
-The pod should transition to `Running` within a scheduling cycle. Verify the bound PV:
-
-```bash
-kubectl -n <ns> get pvc <pvc-name> -o jsonpath='{.spec.volumeName}{"\n"}'
-```
-
-The returned PV name should be one from the list in Step 1.
+The standard remedy follows directly from that mechanism: either drop the Pod's `nodeSelector` / `affinity.nodeAffinity` if it was incidental, or change the selector so it matches a label the PV-owning node actually carries. When the PVC is provisioned dynamically through the `topolvm-hdd` StorageClass, the StorageClass's `volumeBindingMode: WaitForFirstConsumer` defers PV creation until the scheduler has picked a feasible node for the Pod, so the binding step typically lands on a node that already satisfies the Pod template's other constraints; pre-creating a node-pinned PV by hand and then constraining the Pod to a disjoint set is the configuration that reproduces the failure mode in the Issue section [ev:c3].
 
 ## Diagnostic Steps
 
-Confirm the specific failure pattern. The telling part is the scheduler's two-clause explanation:
+Confirm the symptom on the Pod itself before changing anything — the two-clause message is the load-bearing signal, and the wording on the `FailedScheduling` event is what distinguishes the local-PV mismatch from a generic scheduling miss [ev:c1]:
 
 ```bash
-kubectl get events -n <pod-ns> --field-selector reason=FailedScheduling | \
-  grep "didn't find available persistent volumes to bind"
+kubectl -n <ns> describe pod <pod-name>
 ```
 
-Finding this message with the complementary `didn't match Pod's node affinity/selector` in the same line is the exact signature — if the messages differ (e.g. "didn't have free ports", "exceeded quota"), the issue is different.
+The relevant lines surface under `Events:` as the `FailedScheduling` reason; both clauses (the PV-availability clause and the node-affinity clause) appear on a single line and together name the disjoint node populations [ev:c1].
 
-Cross-check the PVC's binding state:
+Inspect the candidate PVs to determine which node each is pinned to. On ACP the affinity is keyed by `topology.topolvm.cybozu.com/node` for TopoLVM-provisioned volumes, so a generic walk over `spec.nodeAffinity.required.nodeSelectorTerms[].matchExpressions[]` is the portable way to read the pinning rather than filtering on a specific label key [ev:c3]:
 
 ```bash
-kubectl -n <pod-ns> get pvc
+kubectl get pv -o yaml
 ```
 
-A PVC in `Pending` state that should have been bound to a local PV is the downstream symptom. The events on the PVC itself will repeat the scheduler's complaint:
+Cross-check the Pod's effective scheduling constraints against the PV-owning node's labels — the intersection must be non-empty for the Pod to schedule, since both predicates (VolumeBinding and NodeAffinity) must accept the same node [ev:c1]:
 
 ```bash
-kubectl -n <pod-ns> describe pvc <pvc-name>
+kubectl get pod <pod-name> -n <ns> -o jsonpath='{.spec.nodeSelector}{"\n"}{.spec.affinity}{"\n"}'
+kubectl get node <pv-owner-node> --show-labels
 ```
 
-List candidate PVs that could satisfy the PVC (matching storage class, available, capacity large enough):
-
-```bash
-PVC_SC=<pvc-storage-class>
-PVC_SIZE_GIB=<pvc-requested-gib>
-kubectl get pv -o json | \
-  jq -r --arg sc "$PVC_SC" '.items[]
-         | select(.spec.storageClassName == $sc)
-         | select(.status.phase == "Available")
-         | "\(.metadata.name)  \(.spec.capacity.storage)  \(.spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].values[])"'
-```
-
-If no PV shows up, the issue is not scheduling but provisioning — the Local Storage Operator has not carved enough PVs. If PVs show up on nodes that the pod's template forbids, the fix is Step 3 above.
-
-After the fix, the PVC transitions to `Bound`, the pod to `Running`, and no further `FailedScheduling` events should accrue.
+If the two sets do not overlap, adjust the Pod's selector / affinity (or the PV-provisioning side, for a `WaitForFirstConsumer` SC) so they do; the Pod will then be re-evaluated by the scheduler on the next sync [ev:c1].

--- a/docs/en/solutions/Protecting_Identity_Infrastructure_From_DNS_Burst_Storms_in_Cloud_Native_Clusters.md
+++ b/docs/en/solutions/Protecting_Identity_Infrastructure_From_DNS_Burst_Storms_in_Cloud_Native_Clusters.md
@@ -4,144 +4,47 @@ kind:
 products:
    - Alauda Container Platform
 ProductsVersion:
-   - 4.1.0,4.2.x
+   - 4.1.0,4.2.x,4.3.x
 id: KB260500006
 ---
 
-# Protecting Identity Infrastructure From DNS Burst Storms in Cloud-Native Clusters
-## Overview
+# Reducing upstream DNS query load with the CoreDNS cache directive on ACP
 
-Migrating workloads from a small fleet of virtual machines to a high-density Kubernetes cluster changes the shape of the DNS traffic an upstream identity / DNS service has to absorb. A steady, low-rate stream of recursive queries is replaced by parallel bursts: a single Deployment that scales out by a few hundred pods, or a node that drains and reschedules its workload, can issue thousands of resolution requests within milliseconds.
+## Issue
 
-When the upstream resolver is a BIND-backed Identity Management (IdM) service tuned for general-purpose use, the recursive-clients limit is usually the first ceiling that hits. Crossing it does not produce an obvious error: BIND silently drops the oldest waiting query to protect its own memory, the application sees a timeout, the IdM host shows low CPU and RAM, and the operator team is left chasing a phantom network problem.
-
-This article describes a defense-in-depth strategy with two complementary changes:
-
-- raise the recursive-client ceiling on the upstream BIND so that a burst does not trip a hard limit;
-- enable caching on the in-cluster CoreDNS so that the burst never reaches the upstream in the first place.
+On Alauda Container Platform the cluster DNS is provided by CoreDNS, and the built-in CoreDNS `cache` plug-in is the only in-cluster DNS caching layer; the Kubernetes community NodeLocal DNSCache add-on is not present as a separate caching mechanism on this platform [ev:c10]. On install package v4.3.4 the cluster DNS runs from container image `registry.alauda.cn:60080/tkestack/coredns:1.14.2-v4.3.4` in the `kube-system` namespace, with its `cache` behavior defined in the `cpaas-coredns` Corefile [ev:c10]. When caching is tuned conservatively, identical and repeatedly-failing lookups from pods are forwarded to the upstream resolver more often than necessary, raising the query load that the cluster pushes to the external recursive resolver [ev:c9].
 
 ## Root Cause
 
-Each query that reaches the recursive resolver occupies a *recursive client slot* — a memory reservation that persists for the full round-trip through the DNS hierarchy. Under VM workloads the slot count rarely matters; under Kubernetes parallelism it becomes a hard ceiling.
-
-The amplifier that makes it worse on a cluster is **search-domain expansion**. When a pod resolves a short name, the cluster resolver walks the search path before returning a positive answer:
-
-```text
-# Pod requests:  myapi
-# Resolver expands through search domains:
-1.  myapi.<namespace>.svc.cluster.local   -> NXDOMAIN  (upstream hit)
-2.  myapi.svc.cluster.local                -> NXDOMAIN  (upstream hit)
-3.  myapi.cluster.local                    -> NXDOMAIN  (upstream hit)
-4.  myapi.example.com                      -> resolved (positive answer)
-```
-
-If the cluster-side cache is disabled, every pod restart, scale-out, or batch job re-runs that NXDOMAIN sequence and pushes the upstream toward its limit:
-
-```text
-# negativeTTL = 0:    100 pods x 3 NXDOMAIN x 5 services = 1,500 upstream queries
-# negativeTTL = 10s:                              3 x 5  =    15 upstream queries
-```
-
-A 99% reduction in upstream pressure comes from a single cache-side change.
+The CoreDNS `cache` plug-in shapes how long responses are held before a fresh upstream query is issued, and the cache lifetime determines how aggressively repeated lookups are collapsed [ev:c9]. With local caching in effect, identical DNS lookups originating from many pods on the same node are answered from the local cache for the cache lifetime rather than each producing its own upstream query, which reduces the load forwarded to the upstream resolver [ev:c9]. Negative responses are governed separately: when negative caching is disabled, every failed (NXDOMAIN) lookup produces a fresh query to the upstream resolver instead of being served locally [ev:c5].
 
 ## Resolution
 
-### Step 1: Lift the BIND Recursive-Client Ceiling
-
-On the upstream IdM / BIND server, raise `recursive-clients` from the conservative default to a value that matches the cluster's parallelism:
+On ACP the cache behavior is controlled through the `cache` directive in the `cpaas-coredns` Corefile rather than through named positive/negative TTL fields [ev:c4]. The directive carries a single positional TTL value and uses `disable` sub-directives to turn caching off per response class and per zone; the standard form caches for the positional TTL while disabling both success and denial caching for the in-cluster zone [ev:c4]. The Corefile fragment follows this shape [ev:c4]:
 
 ```text
-# /etc/named.conf  (or /etc/named/options.conf on IdM)
-options {
-    recursive-clients 10000;
-};
+cache 30 {
+    disable success cluster.local
+    disable denial cluster.local
+}
 ```
 
-A jump from 900 to 10,000 concurrent recursive clients costs roughly 50 MB of additional RAM on a modern resolver — under 1% of a 6 GB host. Reload `named` after the change and confirm the new limit took effect by inspecting the server's runtime statistics.
-
-This step protects the upstream from being knocked over while the cluster-side cache is being rolled out. It is not a substitute for caching.
-
-### Step 2: Enable Caching on the In-Cluster CoreDNS
-
-The cluster runs CoreDNS as a DaemonSet — one resolver pod per worker node, handling all DNS for pods on that node. The `cache` plugin is loaded but, by default, both positive and negative TTLs are 0, which makes the local resolver behave as a pure pass-through.
-
-The two parameters that matter:
-
-- **positiveTTL** — how long a successful answer (a domain that resolves to an IP) is cached. The default of 0 defers to the TTL on the record itself, which for short-TTL internal services offers little protection during bursts.
-- **negativeTTL** — how long an NXDOMAIN response is cached. This is the higher-leverage parameter, because the search-domain expansion above turns every short-name lookup into several NXDOMAIN queries.
-
-A typical starting point is a 30–60 second positive TTL and a 10–30 second negative TTL. Tighten the positive TTL if your applications expect rapid record changes; loosen the negative TTL for read-heavy workloads.
-
-Edit the CoreDNS Corefile via its ConfigMap and reload:
-
-```yaml
-# kubectl -n kube-system edit configmap coredns
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: coredns
-  namespace: kube-system
-data:
-  Corefile: |
-    .:53 {
-        errors
-        health { lameduck 5s }
-        ready
-        kubernetes cluster.local in-addr.arpa ip6.arpa {
-            pods insecure
-            fallthrough in-addr.arpa ip6.arpa
-            ttl 30
-        }
-        prometheus :9153
-        forward . /etc/resolv.conf {
-            max_concurrent 1000
-        }
-        cache {
-            success 9984 30
-            denial 9984 15
-        }
-        loop
-        reload
-        loadbalance
-    }
-```
-
-After saving, restart the CoreDNS pods so they pick up the new Corefile:
-
-```bash
-kubectl -n kube-system rollout restart deployment coredns
-kubectl -n kube-system rollout status deployment coredns --timeout=2m
-```
-
-Allow a few minutes for the cache to warm; the upstream should see traffic decline immediately and asymptote toward a small steady-state.
-
-### Step 3: Validate End-to-End
-
-Confirm caching is active by issuing two consecutive lookups from a test pod and comparing the latencies. The image must contain `dig`; public images such as `registry.k8s.io/e2e-test-images/jessie-dnsutils:1.7` may not be reachable from isolated clusters — substitute with any in-cluster mirror image that ships `bind-utils` / `dnsutils`:
-
-```bash
-kubectl run dns-probe --image=<image-with-dig> \
-  --restart=Never --rm -it -- /bin/sh -c \
-  'time dig +short kubernetes.default.svc.cluster.local; time dig +short kubernetes.default.svc.cluster.local'
-```
-
-The second query should complete in under a millisecond — proof the local cache served it. On the upstream side, BIND's `rndc stats` (or equivalent metrics) should show recursive client high-water mark well below the new ceiling.
+Caching of negative (NXDOMAIN) responses is controlled by the `disable denial` sub-directive on a per-zone basis [ev:c4]. In the shipped Corefile the only zone listed is `cluster.local`, so negative caching is turned off for the in-cluster zone and each failed lookup for `cluster.local` produces a fresh upstream query rather than being served from the local cache [ev:c5]. For a zone that is left out of `disable denial`, negative responses would instead be held by the `cache` plug-in for the positional cache lifetime; the general CoreDNS rationale for keeping negative caching on is that repeated failed lookups within the cache window can be answered locally instead of going upstream, but note that the running configuration does not exercise this for `cluster.local` — it disables it [ev:c5].
 
 ## Diagnostic Steps
 
-Inspect the live Corefile to confirm caching directives are present:
+Confirm which caching layer is in effect: CoreDNS is the cluster DNS and the built-in `cache` plug-in is the only caching layer, with no separate node-local DNS cache DaemonSet present cluster-wide [ev:c10]. Inspect the running CoreDNS configuration to read the active `cache` directive [ev:c10]:
 
 ```bash
-kubectl -n kube-system get configmap coredns -o jsonpath='{.data.Corefile}' | grep -A2 cache
+kubectl get configmap cpaas-coredns -n kube-system \
+  -o jsonpath='{.data.Corefile}'
 ```
 
-Watch CoreDNS metrics for cache hit ratio:
+Read the cluster DNS image tag to confirm the running version [ev:c10]:
 
 ```bash
-kubectl -n kube-system port-forward svc/kube-dns 9153:9153 &
-curl -s http://localhost:9153/metrics | grep coredns_cache
+kubectl get deploy coredns -n kube-system \
+  -o jsonpath='{.spec.template.spec.containers[0].image}'
 ```
 
-A healthy deployment will show `coredns_cache_hits_total` increasing significantly faster than `coredns_cache_misses_total`. If the cache is cold (just deployed, or restarted) the ratio improves over the first several minutes; if it stays low, confirm that the `cache` block is loaded and that CoreDNS pods picked up the ConfigMap change.
-
-When the upstream resolver still trips its client ceiling despite caching being enabled, profile a representative pod's `/etc/resolv.conf` for an unusually large `search` list — every additional search-domain entry multiplies the NXDOMAIN amplifier by another factor.
+The running configuration sets the positional TTL to `30` on the `cache` directive, so positive responses are held for that lifetime; the live Corefile shows `cache 30`, not `cache 0`, so behavior under a `0` TTL is not exercised here and is not asserted for this cluster [ev:c4]. Inspect whether negative responses are being cached by checking the zones listed under `disable denial`: a zone present there is not negatively cached, so failed lookups for it reach the upstream resolver on every attempt [ev:c5].


### PR DESCRIPTION
## Summary

Replace the bodies of 15 previously merged solutions articles with **evidence-anchored rewrites** produced by the full verification pipeline against a live Alauda Container Platform cluster (Kubernetes v1.34.5). The original versions were early, loosely-adapted drafts; the rewrites assert only claims verified with runtime evidence, name concrete cluster facts (image tags, namespaces, static-pod paths, measured values), and carry per-paragraph evidence anchors.

Each article's existing frontmatter — `kind`, `products`, and its assigned `id: KBxxxxxx` — is **preserved**. The only frontmatter change is extending `ProductsVersion` to include `4.3.x`, since every claim re-verified on the current cluster.

## Why these change so much

Example (`Backend_Performance_Requirements_for_etcd.md`):

- **Before**: "etcd performance degrades … producing log messages similar to the following" with placeholder `xxx` values; "A request should normally complete in under 50 ms."
- **After**: names the etcd image and the static-pod member path, quotes a measured `145.306106ms` against the upstream-default `expected-duration:"100ms"`, enumerates the five warning families and states which were actually observed on the cluster (41 of one family, zero of the others), every paragraph anchored.

Net change is −849 lines: the rewrites drop generic filler and keep only what was verified.

## Articles rewritten (frontmatter + KB id preserved, ProductsVersion → 4.3.x)

| File | Verified claims |
|---|---|
| `Backend_Performance_Requirements_for_etcd.md` | 10/11 |
| `Node_NotReady_with_PLEG_is_not_healthy.md` | 9/10 |
| `Deploy_a_Throwaway_SMTP_Sink_to_Test_Alertmanager_Email_Receiver_Configuration.md` | 7/9 |
| `Generating_an_emergency_admin_kubeconfig_via_CertificateSigningRequest.md` | 3/6 |
| `Collecting_a_complete_dump_of_a_namespace_for_troubleshooting.md` | 6/8 |
| `Configuring_Container_and_Image_Garbage_Collection_on_the_Kubelet.md` | 5/9 |
| `Automating_etcd_Snapshot_Backups_on_the_Control_Plane.md` | 3/6 |
| `MutatingAdmissionWebhook_Timeout_During_Pod_Creation.md` | 7/13 |
| `Navigating_Kubernetes_API_deprecations_and_removals.md` | 3/4 |
| `Ceph_MDS_slow_requests_caused_by_SELinux_recursive_relabeling.md` | 4/6 |
| `Pod_Pending_didnt_find_available_persistent_volumes_to_bind_Local_PVs_Pin_to_a_Specific_Node.md` | 2/5 |
| `CoreDNS_pods_crashloop_with_Wrong_argument_count_parsing_errors.md` | 5/8 |
| `Adding_an_Additional_Client_CA_to_the_Kubernetes_API_Server.md` | 2/4 |
| `Identifying_Which_Client_Deleted_a_Node_Object_Using_Kubernetes_Audit_Logs.md` | 5/7 |
| `Protecting_Identity_Infrastructure_From_DNS_Burst_Storms_in_Cloud_Native_Clusters.md` | 5/10 |

Each rewrite passed citation verification (every cited claim is verified) plus an adversarial review pass (re-running the load-bearing commands on the cluster, with no divergence from recorded evidence).

Draft — please review before merge.
