### PR TITLE
update Nexus Operator version requirement to >=v3.76.11 in disaster recovery solution

### DIFF
--- a/docs/en/solutions/How_to_perform_disaster_recovery_for_nexus.md
+++ b/docs/en/solutions/How_to_perform_disaster_recovery_for_nexus.md
@@ -16,7 +16,7 @@ This solution describes how to build a Nexus disaster recovery solution based on
 
 ## Environment
 
-Nexus Operator: >=v3.81.1
+Nexus Operator: >=v3.76.11
 
 ## Terminology
 

--- a/docs/zh/solutions/How_to_perform_disaster_recovery_for_nexus.md
+++ b/docs/zh/solutions/How_to_perform_disaster_recovery_for_nexus.md
@@ -17,7 +17,7 @@ sourceSHA: 3470ad902e70f1155c7256fa71c7b6f8ea7f401295fc82a6c58a5fcf69bcd3a6
 
 ## 环境
 
-Nexus Operator: >=v3.81.1
+Nexus Operator: >=v3.76.11
 
 ## 术语
 


### PR DESCRIPTION
## Summary
- Update the required Nexus Operator version in the Nexus disaster recovery solution from `>=v3.81.1` to `>=v3.76.11`
- Applied to both the English (`docs/en/...`) and Chinese (`docs/zh/...`) versions of the document

## Test plan
- [ ] Confirm the version requirement `>=v3.76.11` is correct for the disaster recovery solution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum supported Nexus Operator version requirement in disaster recovery documentation from v3.81.1 to v3.76.11 (English and Chinese guides).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/knowledge/pull/777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->