### PR TITLE
docs: Mattermost edit_post 403 troubleshooting for Hyperflux Gateway guide

### DIFF
--- a/docs/en/solutions/How_to_Deploy_Hyperflux_Gateway_for_Mattermost.md
+++ b/docs/en/solutions/How_to_Deploy_Hyperflux_Gateway_for_Mattermost.md
@@ -307,7 +307,7 @@ System Console -> User Management -> Permissions -> System Scheme
 
 2. Under the **Posts / Manage Posts** group, enable:
 
-- **Edit Posts (`edit_post`)** — required so the worker can edit its own placeholder post.
+- **Edit Posts** (`edit_post`, the "edit your own posts" permission) — required so the worker can edit its own placeholder post.
 - **Edit Others' Posts (`edit_others_posts`)** if the placeholder author differs from the editor.
 - Confirm the permission is enabled for the role the bot belongs to (All Members, Channel Admin, and so on).
 

--- a/docs/en/solutions/How_to_Deploy_Hyperflux_Gateway_for_Mattermost.md
+++ b/docs/en/solutions/How_to_Deploy_Hyperflux_Gateway_for_Mattermost.md
@@ -19,6 +19,7 @@ Prepare the following before deployment:
 - A reachable Mattermost service URL.
 - A Mattermost administrator account with permission to access **System Console**.
 - A running Hyperflux environment.
+- The bot role must have the **Edit Own Posts (`edit_post`)** permission. Otherwise the streaming reply (which edits a placeholder post) fails and the answer stays on "Thinking, please wait…". See *Troubleshoot common issues*.
 - A Kubernetes cluster where Hyperflux Gateway can be installed.
 - The Hyperflux Gateway release bundle that contains `install-k8s.sh`, `uninstall-k8s.sh`, `install.env`, and `image-metadata.json`.
 
@@ -279,6 +280,40 @@ Verify that the following Mattermost setting is enabled:
 ```text
 System Console -> Integrations -> Integration Management -> Enable Bot Account Creation
 ```
+
+**The bot stays on "Thinking, please wait…" and the answer never appears**
+
+Symptom: after a user sends a message, the bot posts a placeholder ("Thinking, please wait…"), but the placeholder is never replaced with the real answer.
+
+Worker log signature:
+
+```text
+POST /api/v4/posts             -> 201 Created    # placeholder created
+PUT  /api/v4/posts/{post_id}   -> 403 Forbidden  # editing the placeholder is rejected
+error id: api.context.permissions.app_error
+```
+
+Root cause: the gateway streams answers by first creating a placeholder post and then editing that post once the answer is ready. In Mattermost, `create_post` and `edit_post` are independent permissions, so the placeholder can be created successfully while the edit returns 403. The bot role is missing the **Edit Own Posts (`edit_post`)** permission.
+
+> Note: recent Mattermost versions moved "Allow users to edit their messages" out of `System Console -> Site Configuration -> Posts` into the permission scheme, so it is no longer found under Posts.
+
+Resolution: grant the edit permission to the bot role in the Mattermost permission scheme.
+
+1. Open the permission scheme (use the corresponding Team Override Scheme if one is in effect):
+
+```text
+System Console -> User Management -> Permissions -> System Scheme
+```
+
+2. Under the **Posts / Manage Posts** group, enable:
+
+- **Edit Posts (`edit_post`)** — required so the worker can edit its own placeholder post.
+- **Edit Others' Posts (`edit_others_posts`)** if the placeholder author differs from the editor.
+- Confirm the permission is enabled for the role the bot belongs to (All Members, Channel Admin, and so on).
+
+3. Do not set **Edit Time Limit** too low: a long model response can exceed the limit and also cause a 403 on edit.
+
+Verification: manually edit one of the bot account's own recent messages, then send a new message to the bot and confirm the placeholder is replaced by the final answer. Menu locations vary slightly between Mattermost versions; rely on "permission scheme / System Scheme -> Posts". Reference: [Mattermost Advanced permissions](https://docs.mattermost.com/administration-guide/onboard/advanced-permissions.html).
 
 **The bot replies multiple times**
 


### PR DESCRIPTION
## Summary
- 根因:bot 角色缺 **Edit Own Posts (`edit_post`)** 权限时,worker 的 `update_post`(编辑占位帖回写答案)返回 403 `api.context.permissions.app_error`,回复一直卡在 "Thinking, please wait…"。原 bug 已由用户改 Mattermost 权限解决,本次只补文档沉淀。
- 改了 `docs/en/solutions/How_to_Deploy_Hyperflux_Gateway_for_Mattermost.md`:
  - Environment 加一条前提:bot 角色需 `edit_post` 权限;
  - Troubleshoot common issues 加一条 "stays on Thinking…" 排障项(现象 / 日志特征 / 根因 / System Scheme → Posts 修复步骤 / 验证)。

## Tests
- 文档改动,无代码。本地校验:code fence 平衡(56 个 ``` 偶数);Markdown 列表/链接渲染正常。
- 未覆盖部分的安全论证:纯 `.md` 单文件新增段落,未触碰任何代码路径与其它文档;新增内容与既有 Troubleshoot 条目同结构,无破坏面。

## Auto-resolve metadata
- Triggered from: support-triage auto-resolve daily run 2026-06-04
- Source issue: aml/smart-doc#4 (GitLab hub) — 项目 owner 在 issue 上明确要求"修改文档即可,文档修改也要提 PR 到 alauda/knowledge"
- Sibling MR(gateway 内部文档同款改动): https://gitlab-ce.alauda.cn/aml/hyperflux/hyperflux-gateway/-/merge_requests/7
- **Resume this session**: `claude --resume c8c0f016`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added environment prerequisite: Mattermost bot role must have Edit Own Posts permission so streaming replies can edit a placeholder post.
  * Expanded troubleshooting with a new "Thinking, please wait…" section showing example request/response flow, diagnosing missing edit permission as a common cause, and step-by-step guidance to grant and verify post-edit permissions (including edit time-limit advice).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->