### PR TITLE
docs(ecosystem/nacos): drop id: TBD so CI auto-generates a KB id

### DIFF
--- a/docs/en/solutions/ecosystem/nacos/Nacos_Installation_Guide.md
+++ b/docs/en/solutions/ecosystem/nacos/Nacos_Installation_Guide.md
@@ -5,7 +5,6 @@ kind:
   - Solution
 ProductsVersion:
   - '4.1,4.2,4.3'
-id: TBD
 ---
 
 <!--


### PR DESCRIPTION
`add_id.sh` treats any `id:` line (including `TBD`) as already-set and skips generation — which is why the ecosystem guides stay `id: TBD`. Removing the field lets the push-to-main `generate id` step create a real KB id from the doc title and commit it back.

Follow-up to #812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)