### PR TITLE
docs(ecosystem): drop id: TBD on Knative & Authorino guides

### DIFF
--- a/docs/en/solutions/ecosystem/authorino/Authorino_Installation_Guide.md
+++ b/docs/en/solutions/ecosystem/authorino/Authorino_Installation_Guide.md
@@ -5,7 +5,6 @@ kind:
   - Solution
 ProductsVersion:
   - '4.1,4.2,4.3'
-id: TBD
 ---
 
 # Authorino Installation Guide

--- a/docs/en/solutions/ecosystem/knative/Knative_Installation_Guide.md
+++ b/docs/en/solutions/ecosystem/knative/Knative_Installation_Guide.md
@@ -5,7 +5,6 @@ kind:
   - Solution
 ProductsVersion:
   - '4.1,4.2,4.3'
-id: TBD
 ---
 
 <!--


### PR DESCRIPTION
Same fix as #813 (nacos): `add_id.sh` treats any `id:` line (including `TBD`) as already-set and skips generation, so these two ecosystem guides never got real KB ids. Removing the field lets the push-to-main `generate id` step create one from each doc title and commit it back.

Completes the ecosystem install-guide id cleanup (nacos was #813).

🤖 Generated with [Claude Code](https://claude.com/claude-code)